### PR TITLE
feat(sdd): per-phase model routing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3666,7 +3666,7 @@
     },
     {
       "id": "sdd",
-      "description": "Use when you want a disciplined, spec-driven path from a feature idea to shipped, verified software — the rsc-sdd dispatcher / front door. It states the SDD method, reads the accompaniment dial from 02-DOCS, and routes to the right phase skill: constitution -> specify -> clarify -> plan -> tasks -> analyze -> implement -> verify -> review -> ship, with debug / worktrees / parallel callable on demand. Use it to START a feature, when unsure which SDD phase you are in, or to govern the whole flow. Triggers: 'spec-driven development', 'sdd', 'build this feature properly', 'start a new feature', 'I have an idea, take it to production', 'which phase am I in', 'run the sdd flow', 'desarrollo dirigido por especificación', 'monta esta feature bien', 'de la idea a producción'. NOT itself a single phase (it dispatches), NOT the workspace harness (harness), NOT a stack build skill.",
+      "description": "Use when you want a disciplined, spec-driven path from a feature idea to shipped, verified software — the rsc-sdd dispatcher / front door. It states the SDD method, reads the accompaniment dial from 02-DOCS, and routes to the right phase skill: constitution -> specify -> clarify -> plan -> tasks -> analyze -> implement -> verify -> review -> ship, with debug / worktrees / parallel callable on demand. Use it to START a feature, when unsure which SDD phase you are in, or to govern the whole flow. Triggers: 'spec-driven development', 'sdd', 'build this feature properly', 'start a new feature', 'I have an idea, take it to production', 'which phase am I in', 'run the sdd flow', 'desarrollo dirigido por especificación', 'monta esta feature bien', 'de la idea a producción', 'per-phase model routing', 'use a cheaper model for implementation', 'qué modelo por fase'. NOT itself a single phase (it dispatches), NOT the workspace harness (harness), NOT a stack build skill.",
       "tags": [
         "sdd",
         "spec",
@@ -3685,7 +3685,7 @@
     },
     {
       "id": "sdd-init",
-      "description": "Use when calibrating an existing repo before running the rsc SDD flow: detecting stack, package manager, test runners, lint/type/build commands, monorepo signals, artifact store, execution mode, review budget, strict TDD capability, and project skill registry. Triggers: 'calibrate this repo for SDD', 'run sdd init', 'detect my test runner before implementing', 'set up SDD config', 'prepare this repo for spec-driven development'. NOT first-contact user/workspace bootstrap (init), NOT 01-TOOLS/02-DOCS scaffolding (harness), NOT writing a feature spec (specify).",
+      "description": "Use when calibrating an existing repo before running the rsc SDD flow: detecting stack, package manager, test runners, lint/type/build commands, monorepo signals, artifact store, execution mode, review budget, strict TDD capability, and project skill registry. Triggers: 'calibrate this repo for SDD', 'run sdd init', 'detect my test runner before implementing', 'set up SDD config', 'prepare this repo for spec-driven development', 'configure per-phase model routing', 'assign models per SDD phase', 'set up cheaper model for implementation'. NOT first-contact user/workspace bootstrap (init), NOT 01-TOOLS/02-DOCS scaffolding (harness), NOT writing a feature spec (specify).",
       "tags": [
         "sdd",
         "init",

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -36,6 +36,10 @@ Do NOT use when (route elsewhere):
 - A test is failing or behavior is wrong → `debug`.
 - You intend to fix what you find right now → that is `implement`/`clarify`/`plan`/`tasks` work, not analyze. Analyze only reports.
 
+## Model tier — `heavy` (opt-in routing)
+
+This phase's default model tier is **`heavy`** — it is the adversarial consistency gate across constitution ↔ spec ↔ plan ↔ tasks. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## Read the accompaniment dial first
 
 Before reporting, read `02-DOCS/wiki/harness/user-profile.md` for the technical + accompaniment level (the harness dial, L0..L3). It shapes how the report reads — not what gets checked. The six analyses always run in full; verbosity flexes:

--- a/skills/clarify/SKILL.md
+++ b/skills/clarify/SKILL.md
@@ -88,6 +88,10 @@ How you ask determines whether you get a usable answer.
 - **One batch, ranked, then stop.** Don't drip questions one at a time over many turns unless the dial is L3. Don't dump thirty at once. Ask the few that matter, together.
 - **Quote the spec.** Anchor each question to the exact line or section it came from, so the user sees *why* it's open.
 
+## Model tier — `balanced` (opt-in routing)
+
+This phase's default model tier is **`balanced`** — it ranks and asks the few high-leverage questions, not architecture. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## The accompaniment dial
 
 Read the level from `02-DOCS/wiki/harness/user-profile.md` and adapt **how many questions and how you frame them** — clarify is question-heavy, so the dial matters here more than almost anywhere:

--- a/skills/constitution/SKILL.md
+++ b/skills/constitution/SKILL.md
@@ -15,6 +15,10 @@ A constitution is small, durable, and enforceable. It is **not** a wiki of every
 
 This skill produces `02-DOCS/wiki/sdd/constitution.md` and one Knowledge-map row in the root `CLAUDE.md`. It reconciles with — never duplicates — the stack conventions the harness keeps under `02-DOCS/wiki/stack/*`.
 
+## Model tier — `heavy` (opt-in routing)
+
+This phase's default model tier is **`heavy`** — it sets the project's non-negotiables, the highest-leverage decisions in the repo. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## Honor the accompaniment dial first
 
 Before asking anything, read `02-DOCS/wiki/harness/user-profile.md` and match its `technical_level` and `accompaniment_level`. The constitution interview adapts:

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -46,6 +46,10 @@ Do NOT use when:
 - The "bug" is actually an unclear requirement or contradictory spec — that's `clarify`/`analyze`,
   not a code defect.
 
+## Model tier — `heavy` (opt-in routing)
+
+This phase's default model tier is **`heavy`** — root-cause diagnosis is deep reasoning. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## Read the room first (accompaniment dial)
 
 Before diagnosing, read `02-DOCS/wiki/harness/user-profile.md` for the technical + accompaniment

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -158,6 +158,10 @@ test output. You merge the branches, then run the *combined* test suite before t
 green-in-isolation is not green-together. Hand the orchestration to `parallel`; keep the TDD
 discipline inside each branch.
 
+## Model tier — `balanced` (opt-in routing)
+
+This phase's default model tier is **`balanced`** — it is the bulk of TDD execution: cost-sensitive, with quality balanced handles well. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model (this is where routing pays off most — fan-out runs on `balanced` while a hard sub-problem can be escalated to `heavy`). Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## The accompaniment dial — how loud at each checkpoint
 
 Read the level from `02-DOCS/wiki/harness/user-profile.md` and match it. Same work, different volume.

--- a/skills/parallel/SKILL.md
+++ b/skills/parallel/SKILL.md
@@ -65,12 +65,15 @@ SUBAGENT BRIEF (one per unit)
 - Compact rules — 4-5 actionable rules digested from those skills for THIS unit
 - Skill fallback — what to do if a referenced skill is unavailable
 - Interface    — any contract it must conform to, FROZEN before dispatch (see the rule below)
+- Model tier   — the tier this unit runs on, by the KIND of work it does (only when routing is enabled — see below)
 - Report-back  — what to return: the diff, the test output, decisions worth logging, skill_resolution
 ```
 
 **Freeze shared contracts before you dispatch, never during.** If two units both touch the same API shape, type, or schema, that interface is a *dependency*, not something to negotiate in flight. Define it in the serial spine first, hand the frozen version to every unit, and only then fan out. Cross-talk between live subagents is the smell that the partition was wrong.
 
 Each subagent still owns its own discipline inside its scope — TDD via `implement`, the stack skill's test mechanics, decision logging. This skill does not relax any of that; it just runs several of them at once.
+
+**Per-unit model tier (when routing is enabled).** `parallel` has *no fixed tier* — this is the most concrete place per-phase model routing pays off. When `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`, give each unit the tier of the *kind of work it does*, not one tier for the whole fan-out: an implement-type unit → `balanced`, a scan/research/boilerplate unit → `light`, a unit doing genuine design or root-cause reasoning → `heavy`. Resolve the tier to a concrete model via `models.tiers` and **dispatch that subagent on that model** (e.g. Claude Code's `model` field on the Task/subagent) — real routing, independent of the session model. If routing is off or no profile exists, dispatch on the session model and say nothing. Full protocol: `../sdd/references/model-routing.md`.
 
 ### Skill resolution feedback
 
@@ -137,6 +140,7 @@ Be honest about this — most task lists are *mostly* serial with a few disjoint
 | "The brief says 'see the other agent's output' — close enough." | That's a dependency, not independence. Serialize, or freeze the output first. |
 | "Combined suite is red, probably the slower unit — I'll tweak it." | Don't guess at the seam. Reproduce and isolate with debug. |
 | "I just want an isolated branch, so I'll use parallel." | That's isolation, not concurrency. Use worktrees. |
+| "Routing's on, so I'll run the whole fan-out on one tier." | `parallel` has no fixed tier — give each unit the tier of its own work (scan→light, build→balanced, design→heavy). |
 
 ## Red flags — stop and re-plan the partition
 
@@ -172,6 +176,7 @@ End with:
   "artifact": "02-DOCS/wiki/sdd/progress/<slug>.md",
   "next_recommended": "implement",
   "risk": "low|medium|high",
+  "model": { "per_unit": [{ "unit": "users-repo", "tier": "balanced", "resolved": "model-id" }], "routing": "on|off" },
   "skill_resolution": {
     "used": ["parallel"],
     "missing": [],

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -150,6 +150,10 @@ mitigation or the spike that would retire it. Separately, log any decision still
 the riskiest plan. Significant design decisions taken during planning also get appended to
 `02-DOCS/wiki/sdd/decisions.md` (the SDD decisions log), so later phases can trace the *why*.
 
+## Model tier — `heavy` (opt-in routing)
+
+This phase's default model tier is **`heavy`** — architecture, interfaces, data flow and risks are the heaviest cognitive load in the chain. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## Adapting to the dial
 
 Read `02-DOCS/wiki/harness/user-profile.md` and match the artifact and your narration to it:

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -184,6 +184,10 @@ When you've processed the review, summarize for the reviewer (and the decisions 
 
 ---
 
+## Model tier — `heavy` (opt-in routing)
+
+This phase's default model tier is **`heavy`** — adversarial diff reading is where the strongest model pays off most. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## Accompaniment dial (L0..L3)
 
 Read the level from `02-DOCS/wiki/harness/user-profile.md`. **It changes the narration, never the rigor** — every level runs the same passes and the same evidence bar.

--- a/skills/sdd-init/SKILL.md
+++ b/skills/sdd-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-init
-description: "Use when calibrating an existing repo before running the rsc SDD flow: detecting stack, package manager, test runners, lint/type/build commands, monorepo signals, artifact store, execution mode, review budget, strict TDD capability, and project skill registry. Triggers: 'calibrate this repo for SDD', 'run sdd init', 'detect my test runner before implementing', 'set up SDD config', 'prepare this repo for spec-driven development'. NOT first-contact user/workspace bootstrap (init), NOT 01-TOOLS/02-DOCS scaffolding (harness), NOT writing a feature spec (specify)."
+description: "Use when calibrating an existing repo before running the rsc SDD flow: detecting stack, package manager, test runners, lint/type/build commands, monorepo signals, artifact store, execution mode, review budget, strict TDD capability, and project skill registry. Triggers: 'calibrate this repo for SDD', 'run sdd init', 'detect my test runner before implementing', 'set up SDD config', 'prepare this repo for spec-driven development', 'configure per-phase model routing', 'assign models per SDD phase', 'set up cheaper model for implementation'. NOT first-contact user/workspace bootstrap (init), NOT 01-TOOLS/02-DOCS scaffolding (harness), NOT writing a feature spec (specify)."
 tags: [sdd, init, config, testing, registry]
 recommends: [sdd, specify, implement, verify]
 profiles: [core, full]
@@ -38,6 +38,8 @@ Ask only when the answer changes behavior. At L0/L1 infer defaults and show them
 | `artifact_store` | `02-DOCS/wiki/sdd` | Keep RSC artifacts in `02-DOCS`; do not create an `openspec/` parallel tree. |
 | `review_budget.line_budget` | `400` | Lower for solo tight review; higher only with explicit approval. |
 | `delivery_strategy.default` | `ask-on-risk` | `ask-on-risk`, `single-pr`, `autochain`, `exception`. |
+| `models.enabled` | `false` | Per-phase model routing is opt-in. Leave off unless the user asks for it; flipping it on is their call. |
+| `models.provider` | `anthropic` | Which provider the tiers resolve to. Set from the detected assistant when obvious, else `anthropic`. See `../sdd/references/model-routing.md` for other providers. |
 
 ## Detection
 
@@ -48,7 +50,8 @@ Use the repo detector exposed by the CLI code (`detectRepoProfile`) or reproduce
 - scripts: `test`, `lint`, `typecheck`, `build`;
 - runners: Vitest, Jest, Playwright, pytest, `go test`, `flutter test`;
 - monorepo signals;
-- recommended apply and verify commands.
+- recommended apply and verify commands;
+- the active assistant/provider when it's obvious from the environment (Claude Code, Codex, Gemini…), to seed `models.provider` — default `anthropic` when unsure. This only sets the *concrete model names*; routing itself stays off until the user opts in.
 
 If any runner is detected, set `testing.strict_tdd: true`. Strict TDD means implement phases must do red -> green -> triangulate edge cases -> refactor, with command evidence. If no runner is detected, set it false and record the gap rather than pretending.
 
@@ -118,9 +121,38 @@ phase_rules:
   implement: requires analyze pass, strict_tdd when testing.strict_tdd is true
   verify: requires spec tasks evidence
   archive: requires verify record and review/ship outcome
+models:
+  enabled: false              # opt-in master switch; false = honor session model, announce nothing
+  provider: anthropic         # which provider the tiers below resolve to
+  tiers:
+    heavy: claude-opus-4-8
+    balanced: claude-sonnet-4-6
+    light: claude-haiku-4-5-20251001
+  phases:
+    constitution: heavy
+    specify: balanced
+    clarify: balanced
+    plan: heavy
+    tasks: balanced
+    analyze: heavy
+    implement: balanced
+    verify: balanced
+    review: heavy
+    ship: light
+    debug: heavy
+    worktrees: light
+    sdd-init: light
+  overrides: {}               # per-phase tier overrides set by the user
 ```
 
-Preserve user edits if the file exists: update detected facts and leave comments/custom policy fields intact when possible. If preservation is risky, write a proposed replacement next to it as `config.proposed.yaml` and ask.
+The `models` block is the **per-phase model routing** profile: each phase declares a tier
+(`heavy`/`balanced`/`light`) and the tiers resolve to concrete models for `provider`. It ships
+**off** (`enabled: false`) — write it so the user can opt in, never switch models behind their
+back. The full protocol (how phases apply it, the per-assistant switch mechanism, the
+provider→model table) lives in `../sdd/references/model-routing.md`. Keep this block byte-for-byte
+in sync with that reference.
+
+Preserve user edits if the file exists: update detected facts and leave comments/custom policy fields intact when possible. **Never flip `models.enabled` or drop `models.overrides` on re-calibration** — those are user choices; preserve them verbatim and only refresh `tiers`/`provider` if the user asks. If preservation is risky, write a proposed replacement next to it as `config.proposed.yaml` and ask.
 
 ## Result Envelope
 
@@ -139,7 +171,8 @@ End with the standard SDD result envelope:
     "fallback": [],
     "compact_rules": [
       "Read config.yaml before choosing commands.",
-      "Use .rsc/skill-registry.json as the cheap skill index."
+      "Use .rsc/skill-registry.json as the cheap skill index.",
+      "Per-phase model routing ships off (models.enabled:false); never switch models unasked."
     ]
   },
   "evidence": ["npx @ericrisco/rsc registry refresh", "detected test commands recorded"]

--- a/skills/sdd/SKILL.md
+++ b/skills/sdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd
-description: "Use when you want a disciplined, spec-driven path from a feature idea to shipped, verified software — the rsc-sdd dispatcher / front door. It states the SDD method, reads the accompaniment dial from 02-DOCS, and routes to the right phase skill: constitution -> specify -> clarify -> plan -> tasks -> analyze -> implement -> verify -> review -> ship, with debug / worktrees / parallel callable on demand. Use it to START a feature, when unsure which SDD phase you are in, or to govern the whole flow. Triggers: 'spec-driven development', 'sdd', 'build this feature properly', 'start a new feature', 'I have an idea, take it to production', 'which phase am I in', 'run the sdd flow', 'desarrollo dirigido por especificación', 'monta esta feature bien', 'de la idea a producción'. NOT itself a single phase (it dispatches), NOT the workspace harness (harness), NOT a stack build skill."
+description: "Use when you want a disciplined, spec-driven path from a feature idea to shipped, verified software — the rsc-sdd dispatcher / front door. It states the SDD method, reads the accompaniment dial from 02-DOCS, and routes to the right phase skill: constitution -> specify -> clarify -> plan -> tasks -> analyze -> implement -> verify -> review -> ship, with debug / worktrees / parallel callable on demand. Use it to START a feature, when unsure which SDD phase you are in, or to govern the whole flow. Triggers: 'spec-driven development', 'sdd', 'build this feature properly', 'start a new feature', 'I have an idea, take it to production', 'which phase am I in', 'run the sdd flow', 'desarrollo dirigido por especificación', 'monta esta feature bien', 'de la idea a producción', 'per-phase model routing', 'use a cheaper model for implementation', 'qué modelo por fase'. NOT itself a single phase (it dispatches), NOT the workspace harness (harness), NOT a stack build skill."
 tags: [sdd, spec, workflow, plan]
 recommends: [sdd-init, constitution, specify]
 profiles: [core, full]
@@ -46,23 +46,27 @@ constitution ─(once per project)─┐
                                           debug · worktrees · parallel
 ```
 
-| Phase | Owns | Writes | Sibling skill |
-| --- | --- | --- | --- |
-| **sdd-init** | Technical runtime calibration: stack, tests, commands, registry, budgets | `02-DOCS/wiki/sdd/config.yaml`, `.rsc/skill-registry.*` | `../sdd-init/SKILL.md` |
-| **proposal** | Optional pre-execution briefing for ambiguous/architectural/risky work | `02-DOCS/wiki/sdd/proposals/<slug>.md` | handled by `../specify/SKILL.md` when needed |
-| **constitution** | Project non-negotiables: stack canon, quality bars, conventions | `02-DOCS/wiki/sdd/constitution.md` | `../constitution/SKILL.md` |
-| **specify** | Turn a fuzzy intent into a spec — what & why, no how | `02-DOCS/wiki/sdd/specs/<slug>.md` | `../specify/SKILL.md` |
-| **clarify** | Surface ambiguities / edge cases, ask, bake answers back in | updates the spec | `../clarify/SKILL.md` |
-| **plan** | Technical plan: architecture, interfaces, data flow, tests, risks | `02-DOCS/wiki/sdd/plans/<slug>.md` | `../plan/SKILL.md` |
-| **tasks** | Break the plan into ordered, independently-verifiable tasks | task list in the plan artifact | `../tasks/SKILL.md` |
-| **analyze** | Consistency gate: constitution ↔ spec ↔ plan ↔ tasks (report only) | a gap report | `../analyze/SKILL.md` |
-| **implement** | Execute tasks with checkpoints; TDD discipline embedded | logs to `02-DOCS/wiki/sdd/decisions.md` | `../implement/SKILL.md` |
-| **verify** | Post-build gate: run the stack's checks + done-checks + acceptance | evidence | `../verify/SKILL.md` |
-| **review** | Adversarial code review — give and receive with rigor | review notes | `../review/SKILL.md` |
-| **ship** | Close the branch: PR / merge / cleanup. **Git authorship = Eric** | the merge/PR and archive bundle | `../ship/SKILL.md` |
-| **debug** | Root-cause diagnosis: reproduce → isolate → fix → verify | a diagnosis | `../debug/SKILL.md` |
-| **worktrees** | Isolate feature work in a branch/worktree before executing a plan | an isolated workspace | `../worktrees/SKILL.md` |
-| **parallel** | Fan out independent tasks across subagents, gather results | merged results | `../parallel/SKILL.md` |
+| Phase | Owns | Writes | Tier | Sibling skill |
+| --- | --- | --- | --- | --- |
+| **sdd-init** | Technical runtime calibration: stack, tests, commands, registry, budgets | `02-DOCS/wiki/sdd/config.yaml`, `.rsc/skill-registry.*` | light | `../sdd-init/SKILL.md` |
+| **proposal** | Optional pre-execution briefing for ambiguous/architectural/risky work | `02-DOCS/wiki/sdd/proposals/<slug>.md` | — | handled by `../specify/SKILL.md` when needed |
+| **constitution** | Project non-negotiables: stack canon, quality bars, conventions | `02-DOCS/wiki/sdd/constitution.md` | heavy | `../constitution/SKILL.md` |
+| **specify** | Turn a fuzzy intent into a spec — what & why, no how | `02-DOCS/wiki/sdd/specs/<slug>.md` | balanced | `../specify/SKILL.md` |
+| **clarify** | Surface ambiguities / edge cases, ask, bake answers back in | updates the spec | balanced | `../clarify/SKILL.md` |
+| **plan** | Technical plan: architecture, interfaces, data flow, tests, risks | `02-DOCS/wiki/sdd/plans/<slug>.md` | heavy | `../plan/SKILL.md` |
+| **tasks** | Break the plan into ordered, independently-verifiable tasks | task list in the plan artifact | balanced | `../tasks/SKILL.md` |
+| **analyze** | Consistency gate: constitution ↔ spec ↔ plan ↔ tasks (report only) | a gap report | heavy | `../analyze/SKILL.md` |
+| **implement** | Execute tasks with checkpoints; TDD discipline embedded | logs to `02-DOCS/wiki/sdd/decisions.md` | balanced | `../implement/SKILL.md` |
+| **verify** | Post-build gate: run the stack's checks + done-checks + acceptance | evidence | balanced | `../verify/SKILL.md` |
+| **review** | Adversarial code review — give and receive with rigor | review notes | heavy | `../review/SKILL.md` |
+| **ship** | Close the branch: PR / merge / cleanup. **Git authorship = Eric** | the merge/PR and archive bundle | light | `../ship/SKILL.md` |
+| **debug** | Root-cause diagnosis: reproduce → isolate → fix → verify | a diagnosis | heavy | `../debug/SKILL.md` |
+| **worktrees** | Isolate feature work in a branch/worktree before executing a plan | an isolated workspace | light | `../worktrees/SKILL.md` |
+| **parallel** | Fan out independent tasks across subagents, gather results | merged results | per-unit | `../parallel/SKILL.md` |
+
+> The **Tier** column is the *default* model tier each phase routes to when **per-phase model
+> routing** is enabled — see "Per-phase model routing" below. It is off by default and changes
+> nothing about the chain or the gates; it only decides which model does the work.
 
 > If a phase skill above does not yet exist in this repo, the chain still holds — do that phase's work inline following the method here, and skip the broken handoff. Never invent a sibling that is not installed.
 
@@ -104,6 +108,24 @@ Before dispatching, read `02-DOCS/wiki/harness/user-profile.md` and adapt — ex
 | **L3** "acompañamiento total" | Explain the phase, why it matters, what it produces. | Ask broadly, teach the SDD reasoning, narrate every decision. |
 
 If there is no profile yet, default to **non-technical + ask the two harness gauging questions** (technical level, accompaniment level) before dispatching, and persist them — that is the harness's job and `sdd` honors it.
+
+## Per-phase model routing (opt-in)
+
+Different phases reward different models: architecture and adversarial review want the strongest
+one; scaffolding and git plumbing don't. SDD can route each phase to a **tier** — `heavy`
+(deep reasoning), `balanced` (execution), `light` (mechanical) — that resolves to a concrete
+model in `02-DOCS/wiki/sdd/config.yaml` under `models`. The default mapping is the **Tier**
+column above (quality-biased: heavy on constitution/plan/analyze/review/debug, balanced on
+execution, light on ship/worktrees/sdd-init).
+
+It is **off by default** (`models.enabled: false`). When the user opts in, each phase applies it
+two ways: **programmatically** — dispatching `Task`/`parallel` subagents on the tier's model
+(real routing, e.g. Claude Code) — and **advisorily** — announcing the recommended switch at the
+phase boundary, gated by the accompaniment dial, for inline work and assistants that can't switch
+programmatically. Never switch unasked, never claim a switch a tool can't make, and skip routing
+on trivial one-line changes. The `sdd` dispatcher itself never routes (staying on the session
+model); `parallel` has no fixed tier (each unit inherits the tier of its work). Full protocol,
+per-assistant mechanism, and the provider→model table: `references/model-routing.md`.
 
 ## Where the artifacts live (and why it matters)
 
@@ -158,6 +180,7 @@ Every SDD phase ends with the same parseable block so the dispatcher can chain p
   "artifact": "path/to/artifact-or-none",
   "next_recommended": "sdd-init|specify|clarify|plan|tasks|analyze|implement|verify|review|ship",
   "risk": "low|medium|high",
+  "model": { "tier": "heavy|balanced|light", "resolved": "model-id", "routing": "on|off" },
   "skill_resolution": {
     "used": [],
     "missing": [],
@@ -195,6 +218,8 @@ Include current phase, active artifacts, last verdict, completed tasks, next ste
 | "Run constitution again for this feature." | Constitution is once per project. If it exists, read it as guardrails and move on. |
 | "Ship now, I'll add Co-Authored-By: Claude." | `ship` enforces Eric-only authorship. No Claude co-author, no generated-with footer. |
 | "Invoke the `release` phase." | There is no such phase. Never invent a sibling — the chain is the chain. |
+| "Routing sounds useful, I'll switch to the heavy model on my own." | Routing is opt-in (`models.enabled:false`). Don't switch models unless the user turned it on. |
+| "I'll tell them I switched to Opus." (on an assistant with no per-subagent model) | Announce the recommended tier; never claim a switch the tool can't make. Honesty over magic. |
 
 ## Start here
 

--- a/skills/sdd/evals/cases.yaml
+++ b/skills/sdd/evals/cases.yaml
@@ -32,6 +32,9 @@ should_trigger:
   - prompt: "We have an existing repo and no SDD config yet. Start the SDD flow properly before we write a spec."
     why: "The dispatcher should notice the missing runtime calibration and route to sdd-init before specify on non-trivial work."
 
+  - prompt: "I want planning and review to run on the strongest model but implementation on a cheaper one. Set that up for our SDD flow."
+    why: "Per-phase model routing is an SDD concern the dispatcher owns: it should name the tier system (heavy/balanced/light), point at the models block in 02-DOCS/wiki/sdd/config.yaml written by sdd-init, and note it is opt-in — not start coding."
+
 should_not_trigger:
   - prompt: "Write the spec for the new export-to-CSV feature."
     route_to: "specify"
@@ -76,3 +79,12 @@ capability:
       - "Still requires a verification step after the change (the method serves shipping, not ceremony, but evidence before claiming done remains)"
       - "Does not abandon the method for genuinely risky work — distinguishes trivial from non-trivial and is honest about which this is"
       - "If git authorship comes up, notes ship enforces Eric-only authorship (no Co-Authored-By Claude, no generated-with footer)"
+
+  - scenario: "A user asks: 'Can SDD use a cheaper model for the boring phases and the strong one for the hard ones? How do I turn that on?' Show how the dispatcher explains per-phase model routing."
+    must_include:
+      - "Names the three tiers — heavy (deep reasoning), balanced (execution), light (mechanical) — and that each phase has a default tier"
+      - "States the default quality-biased mapping: heavy on constitution/plan/analyze/review/debug, balanced on specify/clarify/tasks/implement/verify, light on ship/worktrees/sdd-init"
+      - "Says routing is OFF by default (models.enabled:false) and lives in the models block of 02-DOCS/wiki/sdd/config.yaml, written by sdd-init; turning it on is the user's choice"
+      - "Explains the two application layers: programmatic (dispatching Task/parallel subagents on the tier's model, e.g. Claude Code) and advisory (announcing the recommended switch at the phase boundary, gated by the accompaniment dial)"
+      - "Is honest about limits: never switches unasked, never claims a model switch an assistant cannot make, and skips routing on trivial one-line changes"
+      - "Points to references/model-routing.md for the full protocol, per-assistant mechanism, and provider→model table rather than inventing model names inline"

--- a/skills/sdd/references/model-routing.md
+++ b/skills/sdd/references/model-routing.md
@@ -1,0 +1,183 @@
+# Per-phase model routing — the protocol
+
+*Different SDD phases ask for different kinds of thinking. Architecture and adversarial
+review reward the strongest model; scaffolding and git plumbing don't. This is the protocol
+that lets each phase run on the model its work deserves — cheaper where it's safe, strong
+where it matters — without surprising anyone and without faking a switch a tool can't make.*
+
+This file is the **single source of truth** for the behavior. `sdd-init` writes the profile,
+`sdd` summarizes it, and every phase skill points here for the procedure. If the three ever
+disagree, this file wins.
+
+## Why this exists
+
+By default every SDD phase runs on whatever model the session happens to be on. That's either
+wasteful (running `ship`'s `git push` on the most expensive model) or risky (running an
+architecture `plan` on the cheapest one). Routing assigns each phase a **tier** and lets the
+phase put its work on the right model. It is **opt-in**: until the user turns it on, nothing
+changes and nothing is announced.
+
+## The three tiers (provider-neutral)
+
+Tiers are abstract so the profile survives a provider switch. A phase only ever names a tier;
+the concrete model is resolved from config.
+
+| Tier | For | Typical work |
+| --- | --- | --- |
+| **heavy** | deep reasoning | architecture, consistency gates, adversarial review, root-cause diagnosis |
+| **balanced** | execution | writing specs, code, tests, breaking work into tasks, interpreting check output |
+| **light** | mechanical / high-volume / exploration | scaffolding, file sweeps, scans, git plumbing, repo detection |
+
+## The profile (lives in `02-DOCS/wiki/sdd/config.yaml`)
+
+`sdd-init` writes this block. It is the canonical shape — keep it byte-for-byte in sync with
+the Config Shape in `../../sdd-init/SKILL.md` and the table in `../SKILL.md`.
+
+```yaml
+models:
+  enabled: false              # opt-in master switch; false = honor the session model, announce nothing
+  provider: anthropic         # which provider the tiers below resolve to
+  tiers:
+    heavy: claude-opus-4-8
+    balanced: claude-sonnet-4-6
+    light: claude-haiku-4-5-20251001
+  phases:
+    constitution: heavy
+    specify: balanced
+    clarify: balanced
+    plan: heavy
+    tasks: balanced
+    analyze: heavy
+    implement: balanced
+    verify: balanced
+    review: heavy
+    ship: light
+    debug: heavy
+    worktrees: light
+    sdd-init: light
+  overrides: {}               # per-phase tier overrides set by the user; preserved across re-calibration
+```
+
+**Master switch.** `enabled: false` (the default) means routing does nothing: honor the
+session model, never announce a switch, never nag. Everything below applies only when
+`enabled: true`.
+
+**Two phases are deliberately absent from `phases`:**
+
+- `sdd` (the dispatcher) — routing decisions are cheap; it stays on the session model.
+- `parallel` — it has no fixed tier. Each fanned-out subagent inherits the tier of the *kind
+  of work* its unit does (an implement-type unit → `balanced`; a scan/research unit → `light`;
+  a deep-reasoning unit → `heavy`).
+
+## Default phase → tier mapping (quality-biased) and why
+
+| Phase | Tier | Why |
+| --- | --- | --- |
+| constitution | heavy | Sets the project's non-negotiables — highest leverage, worth the best reasoning. |
+| specify | balanced | Drafts the what/why spec through dialogue; not architecture. |
+| clarify | balanced | Ranks and asks the few high-leverage questions; not architecture. |
+| plan | heavy | Architecture, interfaces, data flow, risks — the heaviest cognitive load. |
+| tasks | balanced | Decomposes the plan into verifiable tasks; structured but mechanical. |
+| analyze | heavy | Adversarial consistency gate across constitution ↔ spec ↔ plan ↔ tasks. |
+| implement | balanced | The bulk of TDD execution — cost-sensitive, quality sufficient. |
+| verify | balanced | Runs the checks and interprets failures with judgment. |
+| review | heavy | Adversarial diff reading — where the strongest model pays off most. |
+| ship | light | Close the branch: PR / merge / cleanup — mechanical. |
+| debug | heavy | Root-cause diagnosis — deep reasoning. |
+| worktrees | light | Isolate the workspace (git) — mechanical. |
+| sdd-init | light | Repo detection and calibration — mechanical. |
+
+The user owns this. They change a phase by adding it to `models.overrides` (e.g.
+`overrides: { implement: heavy }`), which wins over `phases`.
+
+## How a phase applies the profile (the procedure)
+
+Run this at the start of any SDD phase, after reading the accompaniment dial:
+
+1. **Read** `models` from `02-DOCS/wiki/sdd/config.yaml`. If the block is absent or
+   `enabled: false` → **do nothing**: honor the session model, say nothing about models.
+2. **Resolve the tier** for this phase: `models.overrides[phase]` if present, else
+   `models.phases[phase]`. (`parallel` resolves a tier per unit instead — see below.)
+3. **Resolve the model**: `models.tiers[tier]` for the active `models.provider`.
+4. **Apply, in two layers:**
+   - **Programmatic (real routing, where the assistant supports delegation).** When the phase
+     delegates work to a subagent (the `Task`/Agent tool) or fans out via `parallel`, set that
+     subagent's `model` to the resolved model. This is real routing regardless of the session
+     model and is the most reliable application — prefer it.
+   - **Advisory (all assistants, inline work).** If the resolved model differs from the current
+     session model and the work isn't being delegated, **announce** it at the phase boundary,
+     gated by the accompaniment dial (below), and give the switch command for the active
+     assistant (mechanism table below). Never block — the human may decline and continue.
+5. **Skip routing entirely** for a one-line / trivial change, exactly as the SDD skip rule says
+   for the rest of the chain. Ceremony serves shipping, not the other way around.
+6. **Record** the model actually used in the phase's result envelope (`model` field, below).
+   Log it to `02-DOCS/wiki/sdd/decisions.md` only when the choice actually mattered (e.g. you
+   overrode a tier for a hard plan) — not on every phase.
+
+### Announcement volume by accompaniment dial
+
+The dial controls how loudly you announce a switch; it never changes whether routing happens.
+
+| Level | On a model switch you… |
+| --- | --- |
+| **L0** "cavernícola" | Switch/dispatch silently. One short line only if the user must act (e.g. "para esta fase conviene opus: `/model opus`"). |
+| **L1** "breve" | One line: which tier/model and the one-word why. |
+| **L2** "explica decisiones" | Name the tier, the model, and why this phase warrants it; give the switch command. |
+| **L3** "acompañamiento total" | Explain the tier system as it applies here, the cost/quality trade-off, and how to override in config. |
+
+## Per-assistant switch mechanism
+
+We route programmatically only where the assistant exposes a per-subagent model. Everywhere
+else routing is advisory — announce the tier, the user switches in their tool.
+
+| Assistant | Programmatic (delegation) | Advisory (inline) |
+| --- | --- | --- |
+| **Claude Code** | `model` on the `Task`/Agent tool and on `parallel` subagents (`opus`/`sonnet`/`haiku`) | `/model <name>` for the session |
+| **Codex CLI** | — (solo-agent) | model flag / `model` in config |
+| **Cursor** | native subagent model where exposed | model picker in the UI |
+| **Gemini CLI** | — (experimental) | model flag |
+| **Copilot / Windsurf / Cline / others** | — | announce the tier; user switches in the tool's model selector |
+
+When the active assistant has **no** way to switch, still announce the recommended tier so the
+human can decide — but **never claim a switch happened**. Honesty over magic.
+
+## Provider → concrete models (repoint the tiers here)
+
+To target another provider, change `models.provider` and set `models.tiers` to that row.
+
+| provider | heavy | balanced | light |
+| --- | --- | --- | --- |
+| `anthropic` | `claude-opus-4-8` | `claude-sonnet-4-6` | `claude-haiku-4-5-20251001` |
+| `openai` | `gpt-5.1` (or current flagship) | `gpt-5.1-mini` | `gpt-5.1-nano` |
+| `google` | `gemini-2.5-pro` | `gemini-2.5-flash` | `gemini-2.5-flash-lite` |
+| `openrouter` | a strong model slug | a mid model slug | a cheap/free model slug |
+
+These are starting points — set them to whatever your account actually has. The tiers are the
+contract; the concrete names are yours to edit.
+
+## Result-envelope `model` field
+
+Every phase's result envelope carries the model it ran on, so the chain is auditable:
+
+```json
+{
+  "status": "complete",
+  "model": { "tier": "heavy", "resolved": "claude-opus-4-8", "routing": "on|off" },
+  "...": "rest of the standard envelope"
+}
+```
+
+When routing is off, emit `"model": { "routing": "off" }` (no tier/resolved) — don't invent a
+tier you didn't use.
+
+## Honesty rules / anti-patterns → STOP
+
+| Rationalization | Reality |
+| --- | --- |
+| "Routing sounds good, I'll switch models even though the user never enabled it." | It's opt-in. `enabled: false` (and a missing block) means honor the session model and say nothing. |
+| "I'll tell the user I switched to Opus." (on an assistant with no programmatic switch) | You can't switch there. Announce the tier and the command; never claim a switch you didn't make. |
+| "L0 means terse, so I'll skip routing." | L0 changes words, not behavior. Route the same; just announce silently (or only when the user must act). |
+| "It's a one-line typo fix but the phase is `review`, so → heavy." | Skip routing on trivial changes, like the rest of the chain. Don't spin up the expensive model for a copy tweak. |
+| "I'll log the model on every phase." | Log to `decisions.md` only when the model choice mattered. The envelope `model` field already records the routine case. |
+| "config has no `models` block, I'll assume the defaults are active." | A missing block means routing is **off**. Defaults describe what `sdd-init` *writes*, not an implicit on-state. |
+| "Two parallel units, I'll run both on the phase's tier." | `parallel` has no fixed tier. Give each unit the tier of its own work. |

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -186,6 +186,10 @@ The commit is the durable record. Make it describe the change and tie it to the 
 - **Body:** *why*, not a restatement of the diff. Reference the spec slug and any decision logged in `decisions.md`.
 - **Footer:** issue/PR refs only. **No `Co-Authored-By` for any AI. No "generated with" line.** This is where the violation usually sneaks in — leave the footer clean.
 
+## Model tier — `light` (opt-in routing)
+
+This phase's default model tier is **`light`** — closing the branch (PR / merge / cleanup) is mechanical. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change. The Eric-only authorship rule is independent of the model and never relaxes.
+
 ## Accompaniment dial (L0..L3)
 
 Read the level from `02-DOCS/wiki/harness/user-profile.md`. It changes the narration, **never** the safety checklist or the authorship rule.

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -28,6 +28,10 @@ You are not slowing them down; you make the intent reviewable *before* code exis
 
 If you cannot describe a requirement without naming the technology, you have found a real question — record it as a point to clarify, do not guess the answer.
 
+## Model tier — `balanced` (opt-in routing)
+
+This phase's default model tier is **`balanced`** — it drafts the what/why spec through dialogue, not architecture. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## Read the room first (accompaniment dial)
 
 Before asking anything, read `02-DOCS/wiki/harness/user-profile.md` for the technical level and accompaniment level, and adapt:

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -25,6 +25,10 @@ further questions.
 This is a process skill. It writes no runtime code. It produces one artifact: an
 ordered, checkable task list appended to the plan it was built from.
 
+## Model tier — `balanced` (opt-in routing)
+
+This phase's default model tier is **`balanced`** — it decomposes an approved plan into verifiable tasks: structured work, not architecture. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## Read the harness profile first
 
 Before producing anything, read `02-DOCS/wiki/harness/user-profile.md` for the

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -31,6 +31,10 @@ Do NOT use when:
 - You're reading the diff adversarially for design/correctness smells a test can't catch → that's `review`.
 - There is no spec or task list to verify against → you're earlier in the chain; go to `specify`/`plan`/`tasks` first.
 
+## Model tier — `balanced` (opt-in routing)
+
+This phase's default model tier is **`balanced`** — it runs the checks and interprets failures with judgment. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## Read the room first (accompaniment dial)
 
 Before running anything, read `02-DOCS/wiki/harness/user-profile.md` for the technical + accompaniment level and adapt:

--- a/skills/worktrees/SKILL.md
+++ b/skills/worktrees/SKILL.md
@@ -125,6 +125,10 @@ level) before handing to `implement`.
 The native tool is preferred because it owns the session-switch and the exit lifecycle for you. The
 git path is the universal fallback and is exactly what the native tool does under the hood.
 
+## Model tier — `light` (opt-in routing)
+
+This phase's default model tier is **`light`** — isolating the workspace is mechanical git work. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
+
 ## Adapting to the dial
 
 Read `02-DOCS/wiki/harness/user-profile.md` and match your volume — the isolation is identical at


### PR DESCRIPTION
## What

Adds **per-phase model routing** to the SDD flow — assign each phase a model tier
(`heavy` / `balanced` / `light`) so the cheap phases run cheap and the hard phases
run on the strongest model. Built in the `rsc` idiom (skills as markdown), not in
the CLI: the routing lives in the skills, where `rsc` actually acts.

## Design

- **Declarative** — a `models:` profile in `02-DOCS/wiki/sdd/config.yaml` (written by
  `sdd-init`): `tier → model` and `phase → tier`, user-editable, **`enabled: false` by
  default** (opt-in, no surprises, no unasked cost).
- **Applied (hybrid)** — each phase reads the profile and:
  - *programmatic* — dispatches `Task` / `parallel` subagents on the tier's model
    (real routing, e.g. Claude Code's subagent `model` field), independent of the
    session model;
  - *advisory* — announces the recommended switch at the phase boundary, gated by the
    accompaniment dial, for inline work and assistants that can't switch programmatically.
- **Default mapping (quality-biased):** heavy on constitution/plan/analyze/review/debug ·
  balanced on specify/clarify/tasks/implement/verify · light on ship/worktrees/sdd-init.
  `sdd` (dispatcher) never routes; `parallel` has no fixed tier (each unit inherits the
  tier of its work).
- **Honesty:** never switch unasked, never claim a switch a tool can't make, skip routing
  on trivial one-line changes.

## Changes (by commit)

1. Protocol reference `skills/sdd/references/model-routing.md` + `models` config block in `sdd-init`.
2. Dispatcher wiring in `sdd` (Tier column, routing section, envelope `model` field, anti-patterns).
3. `Model tier` block in the 12 phase skills.
4. `parallel` per-unit tier dispatch.
5. Eval cases + regenerated manifest.

## Verification

- `npm run validate` → frontmatter OK
- `npm run manifest:check` → manifest current (231 skills, unchanged count)
- `npm test` → 126/126
- `bash scripts/eval-lint.sh` → 0 failures
- Cross-check: the `phases:` mapping matches byte-for-byte across `sdd-init`, the reference, and the `sdd` Tier column.

Single source of truth: `skills/sdd/references/model-routing.md`.