### PR TITLE
feat(cli): transactional installer — backups, restore, sync, upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ rsc consult "I want to launch a SaaS"  # recommend only, no install
 rsc registry refresh                 # write .rsc/skill-registry.{json,md}
 rsc list                             # what rsc has installed
 rsc doctor                           # health check (state, hook, counts)
+rsc sync --target claude,codex       # refresh managed skills/hooks from the current package version
+rsc backups                          # list project-local snapshots
+rsc restore latest --dry-run         # preview restoring the newest snapshot
+rsc restore <snapshot-id>            # restore a project-local snapshot
+rsc upgrade --dry-run                # show npm upgrade + sync commands
 rsc uninstall postgresdb --dry-run   # preview a removal
 ```
 

--- a/docs/superpowers/plans/2026-06-06-rsc-transactional-installer.md
+++ b/docs/superpowers/plans/2026-06-06-rsc-transactional-installer.md
@@ -1,0 +1,703 @@
+# RSC Transactional Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add project-local backup, restore, sync, safer uninstall, and upgrade command support to `rsc`.
+
+**Architecture:** Add a focused backup/restore module under `scripts/lib/backups.js`, keep install state in the existing per-target `.rsc-state.json`, and extend `install-apply.js` as the operation coordinator. CLI commands in `scripts/rsc.js` call those units; `doctor` reports backup readiness.
+
+**Tech Stack:** Node ESM, built-in `node:test`, filesystem APIs, existing `targets/*` adapters, existing `rsc` CLI.
+
+---
+
+### Task 1: Project-Local Backup And Restore Primitives
+
+**Files:**
+- Create: `scripts/lib/backups.js`
+- Create: `tests/backups.test.js`
+
+- [ ] **Step 1: Write failing backup/restore tests**
+
+Add `tests/backups.test.js`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync, mkdirSync, lstatSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createBackup, listBackups, restoreBackup } from '../scripts/lib/backups.js';
+
+function tmp() {
+  return mkdtempSync(join(tmpdir(), 'rsc-backup-'));
+}
+
+test('createBackup snapshots existing files and restoreBackup restores them', () => {
+  const cwd = tmp();
+  const file = join(cwd, 'AGENTS.md');
+  writeFileSync(file, 'before\n');
+
+  const snap = createBackup({ cwd, operation: 'install', target: 'codex', paths: [file], cliVersion: '0.0.0-test' });
+  writeFileSync(file, 'after\n');
+
+  const restored = restoreBackup({ cwd, id: snap.id });
+
+  assert.equal(readFileSync(file, 'utf8'), 'before\n');
+  assert.ok(restored.changed.some((p) => p.endsWith('AGENTS.md')));
+});
+
+test('restoreBackup removes managed files that were missing before the snapshot', () => {
+  const cwd = tmp();
+  const file = join(cwd, '.codex', 'rsc', 'fastapi');
+
+  const snap = createBackup({ cwd, operation: 'install', target: 'codex', paths: [file], cliVersion: '0.0.0-test' });
+  mkdirSync(file, { recursive: true });
+  writeFileSync(join(file, 'SKILL.md'), 'created\n');
+
+  restoreBackup({ cwd, id: snap.id });
+
+  assert.equal(existsSync(file), false);
+});
+
+test('restoreBackup supports dry-run without mutating files', () => {
+  const cwd = tmp();
+  const file = join(cwd, 'AGENTS.md');
+  writeFileSync(file, 'before\n');
+  const snap = createBackup({ cwd, operation: 'install', target: 'codex', paths: [file], cliVersion: '0.0.0-test' });
+  writeFileSync(file, 'after\n');
+
+  const preview = restoreBackup({ cwd, id: snap.id, dryRun: true });
+
+  assert.equal(readFileSync(file, 'utf8'), 'after\n');
+  assert.ok(preview.changed.some((p) => p.endsWith('AGENTS.md')));
+});
+
+test('listBackups returns newest snapshots first and latest restores newest', () => {
+  const cwd = tmp();
+  const first = createBackup({ cwd, operation: 'install', target: 'codex', paths: [], cliVersion: '0.0.0-test', now: new Date('2026-06-06T10:00:00Z') });
+  const second = createBackup({ cwd, operation: 'sync', target: 'codex', paths: [], cliVersion: '0.0.0-test', now: new Date('2026-06-06T11:00:00Z') });
+
+  const listed = listBackups({ cwd });
+  const latest = restoreBackup({ cwd, id: 'latest', dryRun: true });
+
+  assert.equal(listed[0].id, second.id);
+  assert.equal(listed[1].id, first.id);
+  assert.equal(latest.snapshot.id, second.id);
+});
+
+test('createBackup records symlinks as symlinks', () => {
+  const cwd = tmp();
+  const real = join(cwd, '.rsc', 'skills', 'fastapi');
+  const link = join(cwd, '.claude', 'skills', 'fastapi');
+  mkdirSync(real, { recursive: true });
+  writeFileSync(join(real, 'SKILL.md'), 'skill\n');
+  mkdirSync(join(cwd, '.claude', 'skills'), { recursive: true });
+  try {
+    symlinkSync('../../.rsc/skills/fastapi', link, 'dir');
+  } catch {
+    return;
+  }
+
+  const snap = createBackup({ cwd, operation: 'install', target: 'claude', paths: [link], cliVersion: '0.0.0-test' });
+
+  assert.equal(snap.entries[0].kind, 'symlink');
+  assert.equal(lstatSync(link).isSymbolicLink(), true);
+});
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `node --test tests/backups.test.js`
+
+Expected: fail because `scripts/lib/backups.js` does not exist.
+
+- [ ] **Step 3: Implement backup/restore primitives**
+
+Create `scripts/lib/backups.js` with:
+
+```js
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
+
+const SCHEMA_VERSION = 1;
+
+export function backupsDir(cwd = process.cwd()) {
+  return join(cwd, '.rsc', 'backups');
+}
+
+export function createBackup({ cwd = process.cwd(), operation, target, paths, cliVersion, now = new Date() }) {
+  const uniquePaths = [...new Set((paths || []).filter(Boolean))];
+  const id = snapshotId({ now, operation, target });
+  const root = join(backupsDir(cwd), id);
+  const filesRoot = join(root, 'files');
+  mkdirSync(filesRoot, { recursive: true });
+
+  const entries = uniquePaths.map((absPath) => snapshotEntry({ cwd, root, absPath }));
+  const manifest = {
+    schemaVersion: SCHEMA_VERSION,
+    id,
+    createdAt: now.toISOString(),
+    operation,
+    target,
+    cwd,
+    cliVersion,
+    entries,
+  };
+  writeFileSync(join(root, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+  return manifest;
+}
+
+export function listBackups({ cwd = process.cwd() } = {}) {
+  const dir = backupsDir(cwd);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .map((id) => readManifest({ cwd, id }))
+    .filter(Boolean)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export function restoreBackup({ cwd = process.cwd(), id, dryRun = false }) {
+  const snapshot = resolveSnapshot({ cwd, id });
+  const changed = [];
+  for (const entry of snapshot.entries) {
+    const absPath = safeJoin(cwd, entry.path);
+    changed.push(absPath);
+    if (dryRun) continue;
+    restoreEntry({ cwd, snapshot, entry, absPath });
+  }
+  return { snapshot, changed };
+}
+
+function snapshotEntry({ cwd, root, absPath }) {
+  const rel = safeRelative(cwd, absPath);
+  if (!existsSync(absPath)) return { path: rel, existed: false, kind: 'missing' };
+
+  const stat = lstatSync(absPath);
+  if (stat.isSymbolicLink()) {
+    return { path: rel, existed: true, kind: 'symlink', linkTarget: readlinkSync(absPath) };
+  }
+
+  const contentPath = join('files', rel);
+  const contentAbs = join(root, contentPath);
+  mkdirSync(dirname(contentAbs), { recursive: true });
+  if (stat.isDirectory()) {
+    cpSync(absPath, contentAbs, { recursive: true });
+    return { path: rel, existed: true, kind: 'dir', contentPath };
+  }
+  cpSync(absPath, contentAbs);
+  return { path: rel, existed: true, kind: 'file', contentPath };
+}
+
+function restoreEntry({ cwd, snapshot, entry, absPath }) {
+  if (!entry.existed) {
+    rmSync(absPath, { recursive: true, force: true });
+    return;
+  }
+
+  rmSync(absPath, { recursive: true, force: true });
+  mkdirSync(dirname(absPath), { recursive: true });
+  if (entry.kind === 'symlink') {
+    symlinkSync(entry.linkTarget, absPath, process.platform === 'win32' ? 'junction' : undefined);
+    return;
+  }
+  const contentAbs = join(backupsDir(cwd), snapshot.id, entry.contentPath);
+  cpSync(contentAbs, absPath, { recursive: entry.kind === 'dir' });
+}
+
+function resolveSnapshot({ cwd, id }) {
+  if (!id) throw new Error('restore requires a snapshot id or latest');
+  if (id === 'latest') {
+    const latest = listBackups({ cwd })[0];
+    if (!latest) throw new Error('no backups found');
+    return latest;
+  }
+  const manifest = readManifest({ cwd, id });
+  if (!manifest) throw new Error(`backup not found: ${id}`);
+  return manifest;
+}
+
+function readManifest({ cwd, id }) {
+  const path = join(backupsDir(cwd), id, 'manifest.json');
+  if (!existsSync(path)) return undefined;
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function snapshotId({ now, operation, target }) {
+  const stamp = now.toISOString().replace(/[-:]/g, '').replace(/\..*/, '').replace('T', '-');
+  return `${stamp}-${safeId(operation)}-${safeId(target || 'all')}`;
+}
+
+function safeId(value) {
+  return String(value).replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '').toLowerCase();
+}
+
+function safeRelative(cwd, absPath) {
+  const rel = relative(cwd, absPath);
+  if (!rel || rel.startsWith('..') || rel.split(sep).includes('..')) {
+    throw new Error(`path is outside project root: ${absPath}`);
+  }
+  return rel.split(sep).join('/');
+}
+
+function safeJoin(cwd, relPath) {
+  return join(cwd, ...relPath.split('/'));
+}
+```
+
+- [ ] **Step 4: Run backup tests to verify GREEN**
+
+Run: `node --test tests/backups.test.js`
+
+Expected: pass.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add scripts/lib/backups.js tests/backups.test.js
+git commit -m "feat: add rsc backup restore primitives"
+```
+
+### Task 2: Wire Backups Into Install, Uninstall, And Sync
+
+**Files:**
+- Modify: `scripts/install-apply.js`
+- Modify: `tests/apply.test.js`
+
+- [ ] **Step 1: Write failing install/uninstall/sync tests**
+
+Append tests to `tests/apply.test.js`:
+
+```js
+test('install creates a backup before overwriting managed hook files', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-install-backup-'));
+  mkdirSync(join(cwd, '.claude'), { recursive: true });
+  writeFileSync(join(cwd, '.claude/settings.json'), JSON.stringify({ hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'echo mine' }] }] } }, null, 2));
+
+  await applyInstall({ skillIds: ['suggest'], target: 'claude', cwd });
+
+  const backups = listBackups({ cwd });
+  assert.equal(backups[0].operation, 'install');
+  assert.equal(backups[0].target, 'claude');
+  assert.ok(backups[0].entries.some((e) => e.path === '.claude/settings.json' && e.existed));
+});
+
+test('uninstall creates a backup that restoreBackup can use to recover target wiring', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-uninstall-backup-'));
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+
+  await uninstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+  assert.equal(existsSync(join(cwd, '.claude/skills/fastapi')), false);
+
+  restoreBackup({ cwd, id: 'latest' });
+
+  assert.ok(existsSync(join(cwd, '.claude/skills/fastapi/SKILL.md')));
+});
+
+test('syncInstalled dry-run reports managed paths without mutating stale base files', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-sync-dry-'));
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+  writeFileSync(join(cwd, '.rsc/.version'), '0.0.1\n');
+  writeFileSync(join(cwd, '.rsc/skills/fastapi/STALE.txt'), 'old');
+
+  const preview = await syncInstalled({ target: 'claude', cwd, dryRun: true });
+
+  assert.ok(preview.paths.some((p) => p.includes('.claude/skills/fastapi')));
+  assert.ok(existsSync(join(cwd, '.rsc/skills/fastapi/STALE.txt')));
+});
+
+test('syncInstalled refreshes installed skills and creates a sync backup', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-sync-'));
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+  writeFileSync(join(cwd, '.rsc/.version'), '0.0.1\n');
+  writeFileSync(join(cwd, '.rsc/skills/fastapi/STALE.txt'), 'old');
+
+  const result = await syncInstalled({ target: 'claude', cwd });
+
+  assert.deepEqual(result.synced, ['fastapi']);
+  assert.ok(!existsSync(join(cwd, '.rsc/skills/fastapi/STALE.txt')));
+  assert.equal(listBackups({ cwd })[0].operation, 'sync');
+});
+```
+
+Also update the import line:
+
+```js
+import { applyInstall, listInstalled, uninstall, syncInstalled } from '../scripts/install-apply.js';
+import { listBackups, restoreBackup } from '../scripts/lib/backups.js';
+```
+
+- [ ] **Step 2: Run targeted tests to verify RED**
+
+Run: `node --test tests/apply.test.js`
+
+Expected: fail because `syncInstalled` and backup wiring do not exist.
+
+- [ ] **Step 3: Implement managed path collection and sync**
+
+Update `scripts/install-apply.js`:
+
+```js
+import { createBackup } from './lib/backups.js';
+```
+
+Add:
+
+```js
+function managedPathsForInstall({ skillIds, target, home, cwd }) {
+  const paths = targetPaths(target, home, cwd);
+  const plan = planInstall({ skillIds, target, home, cwd });
+  const out = [paths.stateFile, versionFile(cwd)];
+  for (const step of plan) {
+    if (step.kind === 'skill') {
+      out.push(step.to, baseDir(step.id, cwd));
+    } else if (step.kind === 'hook') {
+      out.push(step.to, ...generatedHookFiles({ target, cwd }));
+    }
+  }
+  return [...new Set(out)];
+}
+
+function generatedHookFiles({ target, cwd }) {
+  if (target !== 'claude') return [];
+  return [
+    join(cwd, '.rsc', 'session-start.mjs'),
+    join(cwd, '.rsc', 'worklog-checkpoint.mjs'),
+    join(cwd, '.rsc', 'ship-guard.mjs'),
+    join(cwd, '.rsc', 'danger-guard.mjs'),
+  ];
+}
+```
+
+Change `applyInstall` signature:
+
+```js
+export async function applyInstall({ skillIds, target, home, cwd = process.cwd(), operation = 'install', dryRun = false }) {
+  const managedPaths = managedPathsForInstall({ skillIds, target, home, cwd });
+  if (dryRun) return { dryRun: true, paths: managedPaths, skills: skillIds };
+  const backup = createBackup({ cwd, operation, target, paths: managedPaths, cliVersion: CLI_VERSION });
+  ...
+  return { ...state, backup };
+}
+```
+
+Change `uninstall` so it creates a backup before removals:
+
+```js
+const managedPaths = [];
+for (const id of skillIds) {
+  const entry = state.skills[id];
+  if (!entry) continue;
+  managedPaths.push(...entry.files);
+}
+managedPaths.push(paths.stateFile);
+if (dryRun) return managedPaths;
+const backup = createBackup({ cwd, operation: 'uninstall', target, paths: managedPaths, cliVersion: CLI_VERSION });
+...
+return removed;
+```
+
+Add:
+
+```js
+export async function syncInstalled({ target, home, cwd = process.cwd(), dryRun = false }) {
+  const paths = targetPaths(target, home, cwd);
+  const state = readState(paths.stateFile);
+  const ids = Object.keys(state.skills || {});
+  if (!ids.length) return dryRun ? { dryRun: true, synced: [], paths: [] } : { synced: [], backup: null };
+  if (dryRun) {
+    return {
+      dryRun: true,
+      synced: ids,
+      paths: managedPathsForInstall({ skillIds: ids, target, home, cwd }),
+    };
+  }
+  const nextState = await applyInstall({ skillIds: ids, target, home, cwd, operation: 'sync' });
+  return { synced: ids, backup: nextState.backup };
+}
+```
+
+- [ ] **Step 4: Run targeted tests to verify GREEN**
+
+Run: `node --test tests/backups.test.js tests/apply.test.js`
+
+Expected: pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add scripts/install-apply.js tests/apply.test.js
+git commit -m "feat: make rsc install operations recoverable"
+```
+
+### Task 3: Add CLI Commands For Backups, Restore, Sync, And Upgrade
+
+**Files:**
+- Create: `scripts/lib/upgrade.js`
+- Modify: `scripts/rsc.js`
+- Modify: `tests/rsc-cli.test.js`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Append to `tests/rsc-cli.test.js`:
+
+```js
+test('rsc backups lists project-local snapshots', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-backups-'));
+  const install = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'add', 'fastapi', '--target', 'claude'], { cwd, encoding: 'utf8' });
+  assert.equal(install.status, 0, install.stderr);
+
+  const listed = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'backups'], { cwd, encoding: 'utf8' });
+
+  assert.equal(listed.status, 0, listed.stderr);
+  assert.ok(listed.stdout.includes('install'));
+  assert.ok(listed.stdout.includes('claude'));
+});
+
+test('rsc restore latest --dry-run reports planned restore paths without mutating', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-restore-'));
+  const install = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'add', 'fastapi', '--target', 'claude'], { cwd, encoding: 'utf8' });
+  assert.equal(install.status, 0, install.stderr);
+
+  const preview = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'restore', 'latest', '--dry-run'], { cwd, encoding: 'utf8' });
+
+  assert.equal(preview.status, 0, preview.stderr);
+  assert.ok(preview.stdout.includes('Would restore'));
+  assert.ok(existsSync(join(cwd, '.claude/skills/fastapi/SKILL.md')));
+});
+
+test('rsc sync --dry-run reports installed skills', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-sync-'));
+  const install = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'add', 'fastapi', '--target', 'claude'], { cwd, encoding: 'utf8' });
+  assert.equal(install.status, 0, install.stderr);
+
+  const sync = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'sync', '--target', 'claude', '--dry-run'], { cwd, encoding: 'utf8' });
+
+  assert.equal(sync.status, 0, sync.stderr);
+  assert.ok(sync.stdout.includes('Would sync claude'));
+  assert.ok(sync.stdout.includes('fastapi'));
+});
+
+test('rsc upgrade --dry-run prints npm upgrade command', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-upgrade-'));
+  const result = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'upgrade', '--target', 'claude', '--dry-run'], { cwd, encoding: 'utf8' });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(result.stdout.includes('npm install -g @ericrisco/rsc@latest'));
+  assert.ok(result.stdout.includes('rsc sync --target claude'));
+});
+```
+
+- [ ] **Step 2: Run CLI tests to verify RED**
+
+Run: `node --test tests/rsc-cli.test.js`
+
+Expected: fail on unknown commands.
+
+- [ ] **Step 3: Implement upgrade planning**
+
+Create `scripts/lib/upgrade.js`:
+
+```js
+import { spawnSync } from 'node:child_process';
+
+export function upgradePlan({ targets = [] } = {}) {
+  const targetArg = targets.length ? targets.join(',') : '<target>';
+  return {
+    installCommand: 'npm install -g @ericrisco/rsc@latest',
+    syncCommand: `rsc sync --target ${targetArg}`,
+  };
+}
+
+export function runUpgrade({ targets = [], dryRun = false, global = false } = {}) {
+  const plan = upgradePlan({ targets });
+  if (dryRun || !global) {
+    return { ran: false, plan };
+  }
+  const result = spawnSync('npm', ['install', '-g', '@ericrisco/rsc@latest'], { stdio: 'inherit' });
+  if (result.status !== 0) throw new Error('npm global upgrade failed');
+  return { ran: true, plan };
+}
+```
+
+- [ ] **Step 4: Wire CLI commands**
+
+Update `scripts/rsc.js` imports:
+
+```js
+import { applyInstall, listInstalled, uninstall, syncInstalled } from './install-apply.js';
+import { listBackups, restoreBackup } from './lib/backups.js';
+import { runUpgrade } from './lib/upgrade.js';
+```
+
+Add switch cases before `uninstall`:
+
+```js
+case 'sync': {
+  const dry = argv.includes('--dry-run');
+  for (const t of targets) {
+    const result = await syncInstalled({ target: t, dryRun: dry });
+    if (!result.synced.length) say(`${dry ? 'Would sync' : 'Synced'} ${t}: (nothing to sync)`);
+    else say(`${dry ? 'Would sync' : 'Synced'} ${t}: ${result.synced.join(', ')}`);
+    if (dry && result.paths?.length) for (const p of result.paths) say(`  ${p}`);
+  }
+  return;
+}
+case 'backups': {
+  const backups = listBackups();
+  if (!backups.length) return void say('(no backups)');
+  for (const b of backups) say(`${b.id}\t${b.operation}\t${b.target}\t${b.entries.length} files\t${b.createdAt}`);
+  return;
+}
+case 'restore': {
+  const dry = argv.includes('--dry-run');
+  const id = argv.slice(1).find((a) => !a.startsWith('--'));
+  const result = restoreBackup({ id, dryRun: dry });
+  say(`${dry ? 'Would restore' : 'Restored'} ${result.snapshot.id}`);
+  for (const p of result.changed) say(`  ${p}`);
+  return;
+}
+case 'upgrade': {
+  const dry = argv.includes('--dry-run');
+  const global = argv.includes('--global');
+  const result = runUpgrade({ targets, dryRun: dry, global });
+  if (result.ran) say('Upgraded global @ericrisco/rsc. Restart your shell if needed.');
+  else say(`${dry ? 'Would run' : 'Upgrade guide'}: ${result.plan.installCommand}`);
+  say(`After upgrade: ${result.plan.syncCommand}`);
+  return;
+}
+```
+
+Update default help to mention `sync | backups | restore <id|latest> | upgrade`.
+
+- [ ] **Step 5: Run CLI tests to verify GREEN**
+
+Run: `node --test tests/rsc-cli.test.js`
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add scripts/lib/upgrade.js scripts/rsc.js tests/rsc-cli.test.js
+git commit -m "feat: add rsc lifecycle cli commands"
+```
+
+### Task 4: Improve Doctor Backup Readiness
+
+**Files:**
+- Modify: `scripts/doctor.js`
+- Modify: `tests/apply.test.js`
+
+- [ ] **Step 1: Write failing doctor test**
+
+Append to `tests/apply.test.js`:
+
+```js
+test('doctor reports backup readiness and latest snapshot', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-doctor-backups-'));
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+
+  const health = doctor({ target: 'claude', cwd });
+
+  assert.equal(health.backups.exists, true);
+  assert.equal(health.backups.count, 1);
+  assert.ok(health.backups.latest.includes('install-claude'));
+});
+```
+
+- [ ] **Step 2: Run targeted tests to verify RED**
+
+Run: `node --test tests/apply.test.js`
+
+Expected: fail because `health.backups` is missing.
+
+- [ ] **Step 3: Add backup readiness to doctor**
+
+Update `scripts/doctor.js`:
+
+```js
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { listBackups } from './lib/backups.js';
+```
+
+Inside `doctor`:
+
+```js
+const backups = listBackups({ cwd });
+...
+backups: {
+  exists: existsSync(join(cwd || process.cwd(), '.rsc', 'backups')),
+  count: backups.length,
+  latest: backups[0]?.id || null,
+},
+```
+
+- [ ] **Step 4: Run targeted tests to verify GREEN**
+
+Run: `node --test tests/apply.test.js`
+
+Expected: pass.
+
+- [ ] **Step 5: Commit Task 4**
+
+Run:
+
+```bash
+git add scripts/doctor.js tests/apply.test.js
+git commit -m "feat: report rsc backup readiness"
+```
+
+### Task 5: Documentation And Full Verification
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README command list**
+
+Edit `README.md` CLI section to include:
+
+```md
+rsc sync --target claude,codex        # refresh managed skills/hooks from current package version
+rsc backups                           # list project-local snapshots
+rsc restore latest --dry-run          # preview restoring the newest snapshot
+rsc restore <snapshot-id>             # restore a project-local snapshot
+rsc upgrade --dry-run                 # show npm upgrade + sync commands
+```
+
+- [ ] **Step 2: Run manifest and tests**
+
+Run:
+
+```bash
+npm run manifest:check
+npm test
+```
+
+Expected: both pass.
+
+- [ ] **Step 3: Commit Task 5**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: document rsc lifecycle commands"
+```

--- a/docs/superpowers/specs/2026-06-06-rsc-transactional-installer-design.md
+++ b/docs/superpowers/specs/2026-06-06-rsc-transactional-installer-design.md
@@ -1,0 +1,195 @@
+# RSC Transactional Installer Design
+
+## Goal
+
+Make `rsc` feel like a mature installer without changing its core product shape: a project-local, granular skill catalog. The V1 adds project-local backups, restore, sync, safer uninstall, and an upgrade command surface.
+
+## Chosen Approach
+
+Use a project-local transactional layer under `.rsc/`:
+
+- `.rsc/backups/<snapshot-id>/manifest.json`
+- `.rsc/backups/<snapshot-id>/files/...`
+- existing per-target `.rsc-state.json` files stay the source of truth for installed skills
+- `.rsc/.version` remains the materialized catalog version marker
+
+This keeps the product aligned with the current README promise that everything stays in the project. A global `~/.rsc` state is explicitly out of scope for this V1 because it would change the product from project manager to machine manager.
+
+## Alternatives Considered
+
+1. Project-local V1.
+   Best fit for current architecture. Easy to test with temporary directories, minimal blast radius, and works for all current targets.
+
+2. Global state V1.
+   Closer to `gentle-ai`, but it would require redefining ownership across projects, global target roots, and machine-level sync. Too large for this step.
+
+3. Full pipeline/rollback engine.
+   Strongest long-term model, but premature. V1 can expose the right user behavior with smaller primitives: snapshot, apply, restore.
+
+## Commands
+
+### `rsc sync`
+
+Refresh managed skills for one or more targets using the current installed state.
+
+Behavior:
+
+- Reads the target state file.
+- Reinstalls every skill recorded in that state.
+- Includes `suggest` if installed, so hooks are refreshed.
+- Creates a backup before modifying managed files.
+- Updates `.rsc/.version`.
+- Supports `--target a,b`.
+- Supports `--dry-run`, printing the files that would be refreshed.
+
+If no installed skills exist for the selected target, it prints `(nothing to sync)`.
+
+### `rsc backups`
+
+List project-local backup snapshots newest first.
+
+Output includes:
+
+- snapshot id
+- operation
+- target
+- number of files captured
+- timestamp
+
+### `rsc restore <snapshot-id|latest>`
+
+Restore files captured in a project-local snapshot.
+
+Behavior:
+
+- Restores regular files from the snapshot.
+- Restores missing files that existed at snapshot time.
+- Removes files that were created by the operation after the snapshot, when they are tracked in the snapshot manifest as managed files that did not exist before.
+- Does not touch anything outside the current project root.
+- Requires an argument. `latest` resolves to the newest snapshot.
+- Supports `--dry-run`.
+
+### `rsc uninstall`
+
+Keep current skill-level uninstall behavior but make it safer.
+
+Behavior:
+
+- Creates a backup before removing managed files.
+- Supports existing `--dry-run`.
+- Removes only files recorded in the target state.
+- Leaves shared `.rsc/skills/<id>` bases intact in V1, preserving the existing expectation that uninstall removes target wiring, not the catalog cache.
+
+### `rsc upgrade`
+
+Provide an npm-native upgrade surface.
+
+Behavior:
+
+- Default mode is guided: print exact commands to upgrade and sync:
+  - `npm install -g @ericrisco/rsc@latest`
+  - `npx @ericrisco/rsc sync --target <targets>`
+- `--global` executes `npm install -g @ericrisco/rsc@latest`.
+- `--dry-run` prints the planned command.
+- Never runs `sync` automatically after upgrading, because the current process is still the old binary. It tells the user to run `rsc sync` after the new version is installed.
+
+## Backup Model
+
+Every mutating operation creates a snapshot before it writes or removes files:
+
+- `install`
+- `sync`
+- `uninstall`
+
+Snapshot ids use UTC-ish sortable timestamps plus operation, for example:
+
+`20260606-143012-install-claude`
+
+Each snapshot manifest records:
+
+- schema version
+- id
+- createdAt ISO timestamp
+- operation
+- target
+- cwd
+- CLI version
+- entries
+
+Each entry records:
+
+- relative path from project root
+- existed before the operation
+- kind: `file`, `dir`, `symlink`, or `missing`
+- content path in the snapshot for files and symlinks
+
+For V1, directories are recorded so restore can remove newly-created managed directories when they were absent before, but directory permissions are not preserved.
+
+## Managed Path Collection
+
+Before a mutation, `rsc` computes the paths it may touch:
+
+- paths from the install plan
+- existing tracked files for skills being uninstalled
+- target state file
+- `.rsc/.version`
+- generated hook scripts returned by target adapters when known
+
+For install and sync, the install plan already knows the target skill paths and hook target. For Claude, hook materialization writes `.rsc/session-start.mjs`, `.rsc/worklog-checkpoint.mjs`, `.rsc/ship-guard.mjs`, and `.rsc/danger-guard.mjs`; these are included in the backup path set.
+
+## Restore Semantics
+
+Restore is conservative:
+
+- If an entry existed and was a file, restore the exact file content.
+- If an entry existed and was a symlink, restore the symlink target when the platform supports symlinks; otherwise restore as a copied directory only when the snapshot contains the copied files.
+- If an entry was missing before the operation and exists now, remove it.
+- If a path is outside the current project root, restore refuses to act.
+
+The restore command reports every path it would change in dry-run mode.
+
+## Doctor Improvements
+
+`rsc doctor` should include backup readiness:
+
+- whether `.rsc/backups` exists
+- snapshot count
+- latest snapshot id
+- installed skill count
+- missing managed files
+- hook presence
+
+No network checks in V1.
+
+## Testing Strategy
+
+Use Node's built-in test runner with temporary project directories.
+
+Required tests:
+
+- backup snapshots capture existing hook files before install overwrites them
+- uninstall creates a snapshot and can be restored
+- restore `latest` restores modified files and removes newly-created managed files
+- sync dry-run reports installed skills without mutating files
+- sync refreshes stale `.rsc/skills/<id>` content when `.rsc/.version` is old
+- `rsc backups` lists snapshots
+- `rsc restore latest --dry-run` prints planned paths and does not mutate
+- `rsc upgrade --dry-run` prints the npm command
+- doctor reports snapshot count and latest snapshot
+
+## Non-Goals
+
+- No global `~/.rsc` ownership layer.
+- No automatic post-upgrade sync from the old process.
+- No compressed archives in V1.
+- No pruning policy in V1.
+- No cross-project restore.
+- No attempt to restore arbitrary user files not in the managed path set.
+
+## Success Criteria
+
+- Existing tests still pass.
+- New backup/restore/sync/upgrade tests pass.
+- Mutating commands create a recoverable project-local snapshot.
+- `restore latest` can undo a simple install or uninstall in tests.
+- The CLI help/error text clearly names the new commands.

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -1,18 +1,27 @@
 import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { targetPaths } from '../targets/index.js';
 import { readState } from './lib/state.js';
 import { loadManifest } from './lib/manifest.js';
+import { listBackups } from './lib/backups.js';
 
 export function doctor({ target, home, cwd }) {
+  const root = cwd || process.cwd();
   const paths = targetPaths(target, home, cwd);
   const state = readState(paths.stateFile);
   const manifest = loadManifest();
+  const backups = listBackups({ cwd: root });
   const report = {
     target,
     installed: Object.keys(state.skills),
     missing: [],
     hookWired: existsSync(paths.hookTarget),
     manifestSkills: manifest.counts.skills,
+    backups: {
+      exists: existsSync(join(root, '.rsc', 'backups')),
+      count: backups.length,
+      latest: backups[0]?.id || null,
+    },
   };
   for (const [id, e] of Object.entries(state.skills)) {
     for (const f of e.files) if (!existsSync(f)) report.missing.push(`${id}:${f}`);

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -101,6 +101,7 @@ export async function uninstall({ skillIds, target, home, cwd = process.cwd(), d
       removed.push(f);
     }
   }
+  if (!removed.length) return removed;
   if (dryRun) return removed;
   createBackup({ cwd, operation: 'uninstall', target, paths: managedPaths, cliVersion: CLI_VERSION });
   for (const id of skillIds) {

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { planInstall } from './install-plan.js';
 import { targetPaths, writeSkill, wireHook, baseDir } from '../targets/index.js';
 import { readState, writeState } from './lib/state.js';
+import { createBackup } from './lib/backups.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const CLI_VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).version;
@@ -32,10 +33,37 @@ function ensureBase(id, cwd, refresh) {
   return dest;
 }
 
-export async function applyInstall({ skillIds, target, home, cwd = process.cwd() }) {
+function generatedHookFiles({ target, cwd }) {
+  if (target !== 'claude') return [];
+  return [
+    join(cwd, '.rsc', 'session-start.mjs'),
+    join(cwd, '.rsc', 'worklog-checkpoint.mjs'),
+    join(cwd, '.rsc', 'ship-guard.mjs'),
+    join(cwd, '.rsc', 'danger-guard.mjs'),
+  ];
+}
+
+function managedPathsForInstall({ skillIds, target, home, cwd }) {
   const paths = targetPaths(target, home, cwd);
   const plan = planInstall({ skillIds, target, home, cwd });
+  const out = [paths.stateFile, versionFile(cwd)];
+  for (const step of plan) {
+    if (step.kind === 'skill') {
+      out.push(step.to, baseDir(step.id, cwd));
+    } else if (step.kind === 'hook') {
+      out.push(step.to, ...generatedHookFiles({ target, cwd }));
+    }
+  }
+  return [...new Set(out)];
+}
+
+export async function applyInstall({ skillIds, target, home, cwd = process.cwd(), operation = 'install', dryRun = false }) {
+  const paths = targetPaths(target, home, cwd);
+  const plan = planInstall({ skillIds, target, home, cwd });
+  const managedPaths = managedPathsForInstall({ skillIds, target, home, cwd });
+  if (dryRun) return { dryRun: true, skills: skillIds, paths: managedPaths };
   const state = readState(paths.stateFile);
+  const backup = createBackup({ cwd, operation, target, paths: managedPaths, cliVersion: CLI_VERSION });
   // Refresh bases when installing a different version than they were materialized at
   // (or a pre-versioning install where the marker is absent). Same version → no-op.
   const refresh = readBaseVersion(cwd) !== CLI_VERSION;
@@ -52,7 +80,7 @@ export async function applyInstall({ skillIds, target, home, cwd = process.cwd()
   writeState(paths.stateFile, state);
   mkdirSync(dirname(versionFile(cwd)), { recursive: true });
   writeFileSync(versionFile(cwd), CLI_VERSION + '\n');
-  return state;
+  return { ...state, backup };
 }
 
 export function listInstalled({ target, home, cwd = process.cwd() }) {
@@ -64,17 +92,43 @@ export async function uninstall({ skillIds, target, home, cwd = process.cwd(), d
   const paths = targetPaths(target, home, cwd);
   const state = readState(paths.stateFile);
   const removed = [];
+  const managedPaths = [paths.stateFile];
   for (const id of skillIds) {
     const entry = state.skills[id];
     if (!entry) continue;
     for (const f of entry.files) {
+      managedPaths.push(f);
       removed.push(f);
-      if (!dryRun && existsSync(f)) rmSync(f, { recursive: true, force: true });
     }
-    if (!dryRun) delete state.skills[id];
   }
-  if (!dryRun) writeState(paths.stateFile, state);
+  if (dryRun) return removed;
+  createBackup({ cwd, operation: 'uninstall', target, paths: managedPaths, cliVersion: CLI_VERSION });
+  for (const id of skillIds) {
+    const entry = state.skills[id];
+    if (!entry) continue;
+    for (const f of entry.files) {
+      if (existsSync(f)) rmSync(f, { recursive: true, force: true });
+    }
+    delete state.skills[id];
+  }
+  writeState(paths.stateFile, state);
   return removed;
+}
+
+export async function syncInstalled({ target, home, cwd = process.cwd(), dryRun = false }) {
+  const paths = targetPaths(target, home, cwd);
+  const state = readState(paths.stateFile);
+  const ids = Object.keys(state.skills || {});
+  if (!ids.length) return dryRun ? { dryRun: true, synced: [], paths: [] } : { synced: [], backup: null };
+  if (dryRun) {
+    return {
+      dryRun: true,
+      synced: ids,
+      paths: managedPathsForInstall({ skillIds: ids, target, home, cwd }),
+    };
+  }
+  const nextState = await applyInstall({ skillIds: ids, target, home, cwd, operation: 'sync' });
+  return { synced: ids, backup: nextState.backup };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/lib/backups.js
+++ b/scripts/lib/backups.js
@@ -1,0 +1,151 @@
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
+
+const SCHEMA_VERSION = 1;
+
+export function backupsDir(cwd = process.cwd()) {
+  return join(cwd, '.rsc', 'backups');
+}
+
+export function createBackup({ cwd = process.cwd(), operation, target, paths, cliVersion, now = new Date() }) {
+  const uniquePaths = [...new Set((paths || []).filter(Boolean))];
+  const id = uniqueSnapshotId({ cwd, now, operation, target });
+  const root = join(backupsDir(cwd), id);
+  const filesRoot = join(root, 'files');
+  mkdirSync(filesRoot, { recursive: true });
+
+  const entries = uniquePaths.map((absPath) => snapshotEntry({ cwd, root, absPath }));
+  const manifest = {
+    schemaVersion: SCHEMA_VERSION,
+    id,
+    createdAt: now.toISOString(),
+    operation,
+    target,
+    cwd,
+    cliVersion,
+    entries,
+  };
+  writeFileSync(join(root, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+  return manifest;
+}
+
+export function listBackups({ cwd = process.cwd() } = {}) {
+  const dir = backupsDir(cwd);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .map((id) => readManifest({ cwd, id }))
+    .filter(Boolean)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id));
+}
+
+export function restoreBackup({ cwd = process.cwd(), id, dryRun = false }) {
+  const snapshot = resolveSnapshot({ cwd, id });
+  const changed = [];
+  for (const entry of snapshot.entries) {
+    const absPath = safeJoin(cwd, entry.path);
+    changed.push(absPath);
+    if (dryRun) continue;
+    restoreEntry({ cwd, snapshot, entry, absPath });
+  }
+  return { snapshot, changed };
+}
+
+function snapshotEntry({ cwd, root, absPath }) {
+  const rel = safeRelative(cwd, absPath);
+  if (!existsSync(absPath)) return { path: rel, existed: false, kind: 'missing' };
+
+  const stat = lstatSync(absPath);
+  if (stat.isSymbolicLink()) {
+    return { path: rel, existed: true, kind: 'symlink', linkTarget: readlinkSync(absPath) };
+  }
+
+  const contentPath = join('files', rel);
+  const contentAbs = join(root, contentPath);
+  mkdirSync(dirname(contentAbs), { recursive: true });
+  if (stat.isDirectory()) {
+    cpSync(absPath, contentAbs, { recursive: true });
+    return { path: rel, existed: true, kind: 'dir', contentPath };
+  }
+
+  cpSync(absPath, contentAbs);
+  return { path: rel, existed: true, kind: 'file', contentPath };
+}
+
+function restoreEntry({ cwd, snapshot, entry, absPath }) {
+  if (!entry.existed) {
+    rmSync(absPath, { recursive: true, force: true });
+    return;
+  }
+
+  rmSync(absPath, { recursive: true, force: true });
+  mkdirSync(dirname(absPath), { recursive: true });
+  if (entry.kind === 'symlink') {
+    symlinkSync(entry.linkTarget, absPath, process.platform === 'win32' ? 'junction' : undefined);
+    return;
+  }
+
+  const contentAbs = join(backupsDir(cwd), snapshot.id, entry.contentPath);
+  cpSync(contentAbs, absPath, { recursive: entry.kind === 'dir' });
+}
+
+function resolveSnapshot({ cwd, id }) {
+  if (!id) throw new Error('restore requires a snapshot id or latest');
+  if (id === 'latest') {
+    const latest = listBackups({ cwd })[0];
+    if (!latest) throw new Error('no backups found');
+    return latest;
+  }
+
+  const manifest = readManifest({ cwd, id });
+  if (!manifest) throw new Error(`backup not found: ${id}`);
+  return manifest;
+}
+
+function readManifest({ cwd, id }) {
+  const path = join(backupsDir(cwd), id, 'manifest.json');
+  if (!existsSync(path)) return undefined;
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function uniqueSnapshotId({ cwd, now, operation, target }) {
+  const base = snapshotId({ now, operation, target });
+  let id = base;
+  let counter = 2;
+  while (existsSync(join(backupsDir(cwd), id))) {
+    id = `${base}-${counter}`;
+    counter += 1;
+  }
+  return id;
+}
+
+function snapshotId({ now, operation, target }) {
+  const stamp = now.toISOString().replace(/[-:]/g, '').replace(/\..*/, '').replace('T', '-');
+  return `${stamp}-${safeId(operation)}-${safeId(target || 'all')}`;
+}
+
+function safeId(value) {
+  return String(value).replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '').toLowerCase();
+}
+
+function safeRelative(cwd, absPath) {
+  const rel = relative(cwd, absPath);
+  if (!rel || rel.startsWith('..') || rel.split(sep).includes('..')) {
+    throw new Error(`path is outside project root: ${absPath}`);
+  }
+  return rel.split(sep).join('/');
+}
+
+function safeJoin(cwd, relPath) {
+  return join(cwd, ...relPath.split('/'));
+}

--- a/scripts/lib/backups.js
+++ b/scripts/lib/backups.js
@@ -10,7 +10,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, join, relative, sep } from 'node:path';
+import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 
 const SCHEMA_VERSION = 1;
 
@@ -147,5 +147,8 @@ function safeRelative(cwd, absPath) {
 }
 
 function safeJoin(cwd, relPath) {
+  if (!relPath || isAbsolute(relPath) || relPath.split('/').includes('..')) {
+    throw new Error(`path is outside project root: ${relPath}`);
+  }
   return join(cwd, ...relPath.split('/'));
 }

--- a/scripts/lib/upgrade.js
+++ b/scripts/lib/upgrade.js
@@ -1,0 +1,18 @@
+import { spawnSync } from 'node:child_process';
+
+export function upgradePlan({ targets = [] } = {}) {
+  const targetArg = targets.length ? targets.join(',') : '<target>';
+  return {
+    installCommand: 'npm install -g @ericrisco/rsc@latest',
+    syncCommand: `rsc sync --target ${targetArg}`,
+  };
+}
+
+export function runUpgrade({ targets = [], dryRun = false, global = false } = {}) {
+  const plan = upgradePlan({ targets });
+  if (dryRun || !global) return { ran: false, plan };
+
+  const result = spawnSync('npm', ['install', '-g', '@ericrisco/rsc@latest'], { stdio: 'inherit' });
+  if (result.status !== 0) throw new Error('npm global upgrade failed');
+  return { ran: true, plan };
+}

--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -4,12 +4,14 @@ import { detectTarget, TARGETS } from '../targets/index.js';
 import { detectRepo } from './detect-repo.js';
 import { rank } from './consult.js';
 import { expandRecommends, toOutcomes, hasOutcome } from './lib/recommend.js';
-import { applyInstall, listInstalled, uninstall } from './install-apply.js';
+import { applyInstall, listInstalled, uninstall, syncInstalled } from './install-apply.js';
 import { doctor } from './doctor.js';
 import { say, select, pickFrom, banner, confirm } from './lib/ui.js';
 import { refreshRegistry, registryStatus } from './lib/registry.js';
 import { audit, writeAuditReport } from './audit.js';
 import { DOMAINS } from './lib/domains.js';
+import { listBackups, restoreBackup } from './lib/backups.js';
+import { runUpgrade } from './lib/upgrade.js';
 
 const argv = process.argv.slice(2);
 const cmd = argv[0];
@@ -191,6 +193,43 @@ async function main() {
       return void say(listInstalled({ target }).join('\n') || '(nothing installed)');
     case 'doctor':
       return void say(JSON.stringify(doctor({ target }), null, 2));
+    case 'sync': {
+      const dry = argv.includes('--dry-run');
+      for (const t of targets) {
+        const result = await syncInstalled({ target: t, dryRun: dry });
+        const verb = dry ? 'Would sync' : 'Synced';
+        say(`${verb} ${t}: ${result.synced.length ? result.synced.join(', ') : '(nothing to sync)'}`);
+        if (dry && result.paths?.length) {
+          for (const p of result.paths) say(`  ${p}`);
+        }
+      }
+      return;
+    }
+    case 'backups': {
+      const backups = listBackups();
+      if (!backups.length) return void say('(no backups)');
+      for (const b of backups) {
+        say(`${b.id}\t${b.operation}\t${b.target}\t${b.entries.length} files\t${b.createdAt}`);
+      }
+      return;
+    }
+    case 'restore': {
+      const dry = argv.includes('--dry-run');
+      const id = argv.slice(1).find((a) => !a.startsWith('--'));
+      const result = restoreBackup({ id, dryRun: dry });
+      say(`${dry ? 'Would restore' : 'Restored'} ${result.snapshot.id}`);
+      for (const p of result.changed) say(`  ${p}`);
+      return;
+    }
+    case 'upgrade': {
+      const dry = argv.includes('--dry-run');
+      const global = argv.includes('--global');
+      const result = runUpgrade({ targets, dryRun: dry, global });
+      if (result.ran) say('Upgraded global @ericrisco/rsc. Restart your shell if needed.');
+      else say(`${dry ? 'Would run' : 'Upgrade guide'}: ${result.plan.installCommand}`);
+      say(`After upgrade: ${result.plan.syncCommand}`);
+      return;
+    }
     case 'registry': {
       const sub = argv[1];
       if (sub === 'refresh') {
@@ -213,7 +252,7 @@ async function main() {
     }
     default:
       say(`rsc: unknown command '${cmd}'.`);
-      say('Use: npx @ericrisco/rsc | add <id...> | install --profile <p> | consult "<text>" | list | audit | registry refresh | doctor | uninstall <id>');
+      say('Use: npx @ericrisco/rsc | add <id...> | install --profile <p> | consult "<text>" | list | audit | registry refresh | doctor | sync | backups | restore <id|latest> | upgrade | uninstall <id>');
   }
 }
 

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -237,6 +237,17 @@ test('syncInstalled refreshes installed skills and creates a sync backup', async
   assert.equal(listBackups({ cwd })[0].operation, 'sync');
 });
 
+test('doctor reports backup readiness and latest snapshot', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-doctor-backups-'));
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+
+  const health = doctor({ target: 'claude', cwd });
+
+  assert.equal(health.backups.exists, true);
+  assert.equal(health.backups.count, 1);
+  assert.ok(health.backups.latest.includes('install-claude'));
+});
+
 test('claude: SessionStart runs session-start.mjs via node (Windows-safe), materialized', async () => {
   const cwd = mkdtempSync(join(tmpdir(), 'rsc-cwd-'));
   await applyInstall({ skillIds: ['suggest'], target: 'claude', cwd });

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -212,6 +212,16 @@ test('uninstall creates a backup that restoreBackup can use to recover target wi
   assert.ok(existsSync(join(cwd, '.claude/skills/fastapi/SKILL.md')));
 });
 
+test('uninstall of a skill that is not installed is a no-op', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-uninstall-missing-'));
+
+  const removed = await uninstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+
+  assert.deepEqual(removed, []);
+  assert.deepEqual(listBackups({ cwd }), []);
+  assert.equal(existsSync(join(cwd, '.claude/skills/.rsc-state.json')), false);
+});
+
 test('syncInstalled dry-run reports managed paths without mutating stale base files', async () => {
   const cwd = mkdtempSync(join(tmpdir(), 'rsc-sync-dry-'));
   await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -5,7 +5,8 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
-import { applyInstall, listInstalled, uninstall } from '../scripts/install-apply.js';
+import { applyInstall, listInstalled, uninstall, syncInstalled } from '../scripts/install-apply.js';
+import { listBackups, restoreBackup } from '../scripts/lib/backups.js';
 import { doctor } from '../scripts/doctor.js';
 import { targetPaths } from '../targets/index.js';
 
@@ -182,6 +183,58 @@ test('claude: project-local install links to .rsc base, wires hook, list/uninsta
   assert.ok(!existsSync(join(cwd, '.claude/skills/fastapi')), 'link removed');
   assert.ok(existsSync(join(cwd, '.rsc/skills/fastapi/SKILL.md')), 'shared base survives uninstall');
   assert.ok(!listInstalled({ target: 'claude', cwd }).includes('fastapi'));
+});
+
+test('install creates a backup before overwriting managed hook files', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-install-backup-'));
+  mkdirSync(join(cwd, '.claude'), { recursive: true });
+  writeFileSync(join(cwd, '.claude/settings.json'), JSON.stringify({
+    hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'echo mine' }] }] },
+  }, null, 2));
+
+  await applyInstall({ skillIds: ['suggest'], target: 'claude', cwd });
+
+  const backups = listBackups({ cwd });
+  assert.equal(backups[0].operation, 'install');
+  assert.equal(backups[0].target, 'claude');
+  assert.ok(backups[0].entries.some((e) => e.path === '.claude/settings.json' && e.existed));
+});
+
+test('uninstall creates a backup that restoreBackup can use to recover target wiring', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-uninstall-backup-'));
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+
+  await uninstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+  assert.equal(existsSync(join(cwd, '.claude/skills/fastapi')), false);
+
+  restoreBackup({ cwd, id: 'latest' });
+
+  assert.ok(existsSync(join(cwd, '.claude/skills/fastapi/SKILL.md')));
+});
+
+test('syncInstalled dry-run reports managed paths without mutating stale base files', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-sync-dry-'));
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+  writeFileSync(join(cwd, '.rsc/.version'), '0.0.1\n');
+  writeFileSync(join(cwd, '.rsc/skills/fastapi/STALE.txt'), 'old');
+
+  const preview = await syncInstalled({ target: 'claude', cwd, dryRun: true });
+
+  assert.ok(preview.paths.some((p) => p.includes('.claude/skills/fastapi')));
+  assert.ok(existsSync(join(cwd, '.rsc/skills/fastapi/STALE.txt')));
+});
+
+test('syncInstalled refreshes installed skills and creates a sync backup', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-sync-'));
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+  writeFileSync(join(cwd, '.rsc/.version'), '0.0.1\n');
+  writeFileSync(join(cwd, '.rsc/skills/fastapi/STALE.txt'), 'old');
+
+  const result = await syncInstalled({ target: 'claude', cwd });
+
+  assert.deepEqual(result.synced, ['fastapi']);
+  assert.ok(!existsSync(join(cwd, '.rsc/skills/fastapi/STALE.txt')));
+  assert.equal(listBackups({ cwd })[0].operation, 'sync');
 });
 
 test('claude: SessionStart runs session-start.mjs via node (Windows-safe), materialized', async () => {

--- a/tests/backups.test.js
+++ b/tests/backups.test.js
@@ -11,7 +11,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createBackup, listBackups, restoreBackup } from '../scripts/lib/backups.js';
+import { backupsDir, createBackup, listBackups, restoreBackup } from '../scripts/lib/backups.js';
 
 function tmp() {
   return mkdtempSync(join(tmpdir(), 'rsc-backup-'));
@@ -101,4 +101,22 @@ test('createBackup records symlinks as symlinks', () => {
 
   assert.equal(snap.entries[0].kind, 'symlink');
   assert.equal(lstatSync(link).isSymbolicLink(), true);
+});
+
+test('restoreBackup rejects manifest paths outside the project root', () => {
+  const cwd = tmp();
+  const root = join(backupsDir(cwd), 'bad-snapshot');
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, 'manifest.json'), JSON.stringify({
+    schemaVersion: 1,
+    id: 'bad-snapshot',
+    createdAt: '2026-06-06T10:00:00.000Z',
+    operation: 'restore',
+    target: 'codex',
+    cwd,
+    cliVersion: '0.0.0-test',
+    entries: [{ path: '../outside.txt', existed: false, kind: 'missing' }],
+  }, null, 2));
+
+  assert.throws(() => restoreBackup({ cwd, id: 'bad-snapshot', dryRun: true }), /outside project root/);
 });

--- a/tests/backups.test.js
+++ b/tests/backups.test.js
@@ -1,0 +1,104 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createBackup, listBackups, restoreBackup } from '../scripts/lib/backups.js';
+
+function tmp() {
+  return mkdtempSync(join(tmpdir(), 'rsc-backup-'));
+}
+
+test('createBackup snapshots existing files and restoreBackup restores them', () => {
+  const cwd = tmp();
+  const file = join(cwd, 'AGENTS.md');
+  writeFileSync(file, 'before\n');
+
+  const snap = createBackup({ cwd, operation: 'install', target: 'codex', paths: [file], cliVersion: '0.0.0-test' });
+  writeFileSync(file, 'after\n');
+
+  const restored = restoreBackup({ cwd, id: snap.id });
+
+  assert.equal(readFileSync(file, 'utf8'), 'before\n');
+  assert.ok(restored.changed.some((p) => p.endsWith('AGENTS.md')));
+});
+
+test('restoreBackup removes managed files that were missing before the snapshot', () => {
+  const cwd = tmp();
+  const file = join(cwd, '.codex', 'rsc', 'fastapi');
+
+  const snap = createBackup({ cwd, operation: 'install', target: 'codex', paths: [file], cliVersion: '0.0.0-test' });
+  mkdirSync(file, { recursive: true });
+  writeFileSync(join(file, 'SKILL.md'), 'created\n');
+
+  restoreBackup({ cwd, id: snap.id });
+
+  assert.equal(existsSync(file), false);
+});
+
+test('restoreBackup supports dry-run without mutating files', () => {
+  const cwd = tmp();
+  const file = join(cwd, 'AGENTS.md');
+  writeFileSync(file, 'before\n');
+  const snap = createBackup({ cwd, operation: 'install', target: 'codex', paths: [file], cliVersion: '0.0.0-test' });
+  writeFileSync(file, 'after\n');
+
+  const preview = restoreBackup({ cwd, id: snap.id, dryRun: true });
+
+  assert.equal(readFileSync(file, 'utf8'), 'after\n');
+  assert.ok(preview.changed.some((p) => p.endsWith('AGENTS.md')));
+});
+
+test('listBackups returns newest snapshots first and latest restores newest', () => {
+  const cwd = tmp();
+  const first = createBackup({
+    cwd,
+    operation: 'install',
+    target: 'codex',
+    paths: [],
+    cliVersion: '0.0.0-test',
+    now: new Date('2026-06-06T10:00:00Z'),
+  });
+  const second = createBackup({
+    cwd,
+    operation: 'sync',
+    target: 'codex',
+    paths: [],
+    cliVersion: '0.0.0-test',
+    now: new Date('2026-06-06T11:00:00Z'),
+  });
+
+  const listed = listBackups({ cwd });
+  const latest = restoreBackup({ cwd, id: 'latest', dryRun: true });
+
+  assert.equal(listed[0].id, second.id);
+  assert.equal(listed[1].id, first.id);
+  assert.equal(latest.snapshot.id, second.id);
+});
+
+test('createBackup records symlinks as symlinks', () => {
+  const cwd = tmp();
+  const real = join(cwd, '.rsc', 'skills', 'fastapi');
+  const link = join(cwd, '.claude', 'skills', 'fastapi');
+  mkdirSync(real, { recursive: true });
+  writeFileSync(join(real, 'SKILL.md'), 'skill\n');
+  mkdirSync(join(cwd, '.claude', 'skills'), { recursive: true });
+  try {
+    symlinkSync('../../.rsc/skills/fastapi', link, 'dir');
+  } catch {
+    return;
+  }
+
+  const snap = createBackup({ cwd, operation: 'install', target: 'claude', paths: [link], cliVersion: '0.0.0-test' });
+
+  assert.equal(snap.entries[0].kind, 'symlink');
+  assert.equal(lstatSync(link).isSymbolicLink(), true);
+});

--- a/tests/rsc-cli.test.js
+++ b/tests/rsc-cli.test.js
@@ -35,3 +35,69 @@ test('rsc consult prioritizes explicit query over repo hints', () => {
   assert.equal(result.status, 0, result.stderr);
   assert.ok(result.stdout.split('\n')[0].startsWith('modal\t'), result.stdout);
 });
+
+test('rsc backups lists project-local snapshots', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-backups-'));
+  const install = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'add', 'fastapi', '--target', 'claude'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  assert.equal(install.status, 0, install.stderr);
+
+  const listed = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'backups'], {
+    cwd,
+    encoding: 'utf8',
+  });
+
+  assert.equal(listed.status, 0, listed.stderr);
+  assert.ok(listed.stdout.includes('install'));
+  assert.ok(listed.stdout.includes('claude'));
+});
+
+test('rsc restore latest --dry-run reports planned restore paths without mutating', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-restore-'));
+  const install = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'add', 'fastapi', '--target', 'claude'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  assert.equal(install.status, 0, install.stderr);
+
+  const preview = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'restore', 'latest', '--dry-run'], {
+    cwd,
+    encoding: 'utf8',
+  });
+
+  assert.equal(preview.status, 0, preview.stderr);
+  assert.ok(preview.stdout.includes('Would restore'));
+  assert.ok(existsSync(join(cwd, '.claude/skills/fastapi/SKILL.md')));
+});
+
+test('rsc sync --dry-run reports installed skills', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-sync-'));
+  const install = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'add', 'fastapi', '--target', 'claude'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  assert.equal(install.status, 0, install.stderr);
+
+  const sync = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'sync', '--target', 'claude', '--dry-run'], {
+    cwd,
+    encoding: 'utf8',
+  });
+
+  assert.equal(sync.status, 0, sync.stderr);
+  assert.ok(sync.stdout.includes('Would sync claude'));
+  assert.ok(sync.stdout.includes('fastapi'));
+});
+
+test('rsc upgrade --dry-run prints npm upgrade command', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-upgrade-'));
+  const result = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'upgrade', '--target', 'claude', '--dry-run'], {
+    cwd,
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(result.stdout.includes('npm install -g @ericrisco/rsc@latest'));
+  assert.ok(result.stdout.includes('rsc sync --target claude'));
+});


### PR DESCRIPTION
## What

Adds the **transactional installer / lifecycle CLI** and reconciles it with the `rsc purge` feature already on `main`.

New capabilities (the installer branch):
- **Backups** — every install/uninstall/sync snapshots the paths it touches under `.rsc/backups/` (`scripts/lib/backups.js`).
- **Recoverable installs** — `applyInstall` takes a backup before mutating and supports `--dry-run` (reports managed paths without writing).
- **`rsc sync`** — re-materialize installed skills for each target (`syncInstalled`).
- **`rsc backups` / `rsc restore <id|latest>`** — list and roll back snapshots.
- **`rsc upgrade`** — upgrade the global CLI and print the post-upgrade sync command (`scripts/lib/upgrade.js`).
- **Hardened `uninstall`** — backs up before removing, no-ops cleanly when nothing matches.

## Reconciliation with `rsc purge`

Both features touch `scripts/rsc.js` and `scripts/install-apply.js`; they are complementary and merged as a **union** (no behavior dropped from either side):

- `install-apply.js` — installer's backup-aware `applyInstall`/`uninstall`/`syncInstalled` kept; main's `purge()` added after them. Imports unioned. **`purge` deliberately takes no backup** — backups live under `.rsc/`, which purge removes, so a pre-purge snapshot would delete itself (documented inline). `purge` stays the deliberate "remove everything" escape hatch.
- `rsc.js` — lifecycle cases (`sync`/`backups`/`restore`/`upgrade`) + the `purge` case and `uninstall --all` alias coexist under one unified help line.

`targets/*` (purge's `unwireHook`) and `lib/backups.js`/`lib/upgrade.js` (installer) don't overlap.

## Verification

- `npm run validate` → frontmatter OK
- `npm run manifest:check` → manifest current (231 skills)
- `npm test` → **131/131** (installer suite + `purge.test.js` run together against the merged code)
- `bash scripts/eval-lint.sh` → 0 failures
- cleanup gate → clean