### PR TITLE
fix(install): version skill bases per-skill so multi-target sync refreshes every target

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -14,22 +14,37 @@ const CLI_VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
 // materialized at — the single, target-agnostic source of truth for "installed
 // skills version" (read by the SessionStart update check too).
 const versionFile = (cwd) => join(cwd, '.rsc', '.version');
-function readBaseVersion(cwd) {
-  try { return readFileSync(versionFile(cwd), 'utf8').trim(); } catch { return undefined; }
+
+// Per-skill base version. A single global `.rsc/.version` cannot represent a
+// partially-refreshed base set, which broke multi-target sync: the first target's pass
+// bumped `.rsc/.version`, so later targets saw "current" and skipped refreshing their
+// exclusive skills' bases. Tracking the version each base was materialized at makes the
+// refresh decision per skill, independent of target ordering. (Absent file → every base
+// is treated as stale and refreshed once, which self-heals installs from before this.)
+const baseVersionsFile = (cwd) => join(cwd, '.rsc', '.base-versions.json');
+function readBaseVersions(cwd) {
+  try { return JSON.parse(readFileSync(baseVersionsFile(cwd), 'utf8')); } catch { return {}; }
+}
+function writeBaseVersions(cwd, versions) {
+  mkdirSync(dirname(baseVersionsFile(cwd)), { recursive: true });
+  writeFileSync(baseVersionsFile(cwd), JSON.stringify(versions, null, 2) + '\n');
 }
 
-// Materialize the real skill files into the project-local base. Normally copied
-// once and reused; when `refresh` is set (a different CLI version than the base was
-// materialized at) the base is re-copied so a reinstall actually updates content.
-// Skills are read-only catalog (user customization lives in 02-DOCS/CLAUDE.md), so
-// overwriting on a version change is safe.
-function ensureBase(id, cwd, refresh) {
+// Materialize the real skill files into the project-local base. Copied once and reused;
+// when the recorded base version for THIS skill differs from the CLI version, the base is
+// re-copied so a reinstall/sync actually updates content. Tracked per skill (see
+// baseVersionsFile) so a multi-target sync refreshes every target's bases, not just the
+// first target's. Skills are read-only catalog (user customization lives in 02-DOCS), so
+// overwriting on a version change is safe. Mutates `baseVersions` with the new mark.
+function ensureBase(id, cwd, baseVersions) {
   const dest = baseDir(id, cwd);
-  if (refresh && existsSync(dest)) rmSync(dest, { recursive: true, force: true });
+  const stale = baseVersions[id] !== CLI_VERSION;
+  if (stale && existsSync(dest)) rmSync(dest, { recursive: true, force: true });
   if (!existsSync(dest)) {
     mkdirSync(dirname(dest), { recursive: true });
     cpSync(join(ROOT, 'skills', id), dest, { recursive: true });
   }
+  baseVersions[id] = CLI_VERSION;
   return dest;
 }
 
@@ -46,7 +61,7 @@ function generatedHookFiles({ target, cwd }) {
 function managedPathsForInstall({ skillIds, target, home, cwd }) {
   const paths = targetPaths(target, home, cwd);
   const plan = planInstall({ skillIds, target, home, cwd });
-  const out = [paths.stateFile, versionFile(cwd)];
+  const out = [paths.stateFile, versionFile(cwd), baseVersionsFile(cwd)];
   for (const step of plan) {
     if (step.kind === 'skill') {
       out.push(step.to, baseDir(step.id, cwd));
@@ -64,18 +79,21 @@ export async function applyInstall({ skillIds, target, home, cwd = process.cwd()
   if (dryRun) return { dryRun: true, skills: skillIds, paths: managedPaths };
   const state = readState(paths.stateFile);
   const backup = createBackup({ cwd, operation, target, paths: managedPaths, cliVersion: CLI_VERSION });
-  // Refresh bases when installing a different version than they were materialized at
-  // (or a pre-versioning install where the marker is absent). Same version → no-op.
-  const refresh = readBaseVersion(cwd) !== CLI_VERSION;
+  // Decide base refresh per skill (see baseVersionsFile): a base is re-materialized when
+  // its recorded version differs from the CLI version. Robust to multi-target installs/
+  // syncs — a single global marker would be bumped by the first target and make later
+  // targets skip refreshing their exclusive skills' bases.
+  const baseVersions = readBaseVersions(cwd);
   for (const step of plan) {
     if (step.kind === 'skill') {
-      const base = ensureBase(step.id, cwd, refresh);
+      const base = ensureBase(step.id, cwd, baseVersions);
       const files = await writeSkill(target, step.id, base, step.to);
       state.skills[step.id] = { files, base };
     } else if (step.kind === 'hook') {
-      await wireHook(target, paths, join(ensureBase('suggest', cwd, refresh), 'SKILL.md'));
+      await wireHook(target, paths, join(ensureBase('suggest', cwd, baseVersions), 'SKILL.md'));
     }
   }
+  writeBaseVersions(cwd, baseVersions);
   state.version = CLI_VERSION;
   writeState(paths.stateFile, state);
   mkdirSync(dirname(versionFile(cwd)), { recursive: true });

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -131,6 +131,7 @@ test('reinstall after a version change refreshes the base content (reinstall == 
   const cwd = mkdtempSync(join(tmpdir(), 'rsc-ref-'));
   await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
   // simulate an older install whose base drifted from the current bundled version
+  writeFileSync(join(cwd, '.rsc/.base-versions.json'), JSON.stringify({ fastapi: '0.0.1' }) + '\n');
   writeFileSync(join(cwd, '.rsc/.version'), '0.0.1\n');
   writeFileSync(join(cwd, '.rsc/skills/fastapi/STALE.txt'), 'old content');
   await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
@@ -144,6 +145,25 @@ test('same-version reinstall does not refresh the base', async () => {
   writeFileSync(join(cwd, '.rsc/skills/fastapi/KEEP.txt'), 'mine');
   await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd }); // same CLI version
   assert.ok(existsSync(join(cwd, '.rsc/skills/fastapi/KEEP.txt')), 'base untouched when version unchanged');
+});
+
+test('multi-target sync refreshes bases for the second target\'s exclusive skills', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-multi-'));
+  // fastapi via claude, nextjs only via codex — both share one .rsc/skills base.
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+  await applyInstall({ skillIds: ['nextjs'], target: 'codex', cwd });
+  // Simulate the real upgrade: both bases (and the global marker) at an older version.
+  writeFileSync(join(cwd, '.rsc/.version'), '0.0.1\n');
+  writeFileSync(join(cwd, '.rsc/.base-versions.json'), JSON.stringify({ fastapi: '0.0.1', nextjs: '0.0.1' }) + '\n');
+  writeFileSync(join(cwd, '.rsc/skills/fastapi/STALE.txt'), 'x');
+  writeFileSync(join(cwd, '.rsc/skills/nextjs/STALE.txt'), 'x');
+  // Re-apply claude first (its pass bumps .rsc/.version to current), then codex.
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+  await applyInstall({ skillIds: ['nextjs'], target: 'codex', cwd });
+  assert.ok(!existsSync(join(cwd, '.rsc/skills/fastapi/STALE.txt')), 'first-target base refreshed');
+  // Regression: with the old single global marker, claude's pass bumped it to current so
+  // codex's pass saw "unchanged" and skipped refreshing nextjs's base, leaving it stale.
+  assert.ok(!existsSync(join(cwd, '.rsc/skills/nextjs/STALE.txt')), 'second-target exclusive base refreshed');
 });
 
 test('claude: install migrates away the legacy nested .claude/skills/rsc/ layout', async () => {
@@ -261,6 +281,7 @@ test('syncInstalled dry-run reports managed paths without mutating stale base fi
 test('syncInstalled refreshes installed skills and creates a sync backup', async () => {
   const cwd = mkdtempSync(join(tmpdir(), 'rsc-sync-'));
   await applyInstall({ skillIds: ['fastapi'], target: 'claude', cwd });
+  writeFileSync(join(cwd, '.rsc/.base-versions.json'), JSON.stringify({ fastapi: '0.0.1' }) + '\n');
   writeFileSync(join(cwd, '.rsc/.version'), '0.0.1\n');
   writeFileSync(join(cwd, '.rsc/skills/fastapi/STALE.txt'), 'old');
 


### PR DESCRIPTION
## Bug

A multi-target install/sync (`rsc sync --target claude,codex`) left **stale** the shared bases of skills exclusive to a non-first target.

Refresh was gated on the single global `.rsc/.version` marker. The first target's `applyInstall` pass bumps it to the current version, so when the second target's pass runs, `readBaseVersion() === CLI_VERSION` → `refresh = false` → it skips re-materializing that target's exclusive skills' bases. A single global marker can't represent a *partially*-refreshed base set.

Observed live on a real install: after `sync --target claude,codex` from 0.1.24→0.1.26, `suggest`/`specify`/`sdd` (claude set) updated but `nextjs`/`fastapi`/`postgresdb`/`building-agents` (codex-only) stayed at 0.1.24 — so the SDD deference banners never reached them.

## Fix

Track the version each base was materialized at in `.rsc/.base-versions.json` and decide refresh **per skill** inside `ensureBase()`, independent of target ordering. An absent map treats every base as stale and refreshes once — self-healing installs from before this change. `.rsc/.version` is still written (the SessionStart update check reads it).

## Tests

- Updated the drift simulations to the per-base marker (the new freshness source).
- New regression test: a second target's exclusive base refreshes after the first target bumps the global version. 138/138 pass.