### PR TITLE
feat(suggest): semantic in-agent skill discovery via `rsc catalog`

### DIFF
--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -187,6 +187,26 @@ async function main() {
       for (const o of toOutcomes(ids)) say(`${o.id}\t${o.label}`);
       return;
     }
+    case 'catalog': {
+      // Full catalog dump for SEMANTIC in-agent discovery: every skill as
+      // `id  <installed|available>  short description`, unranked. `consult` ranks
+      // lexically and returns nothing for natural-language / Catalan intent; `catalog`
+      // hands the agent the whole candidate set so the MODEL picks the best-fit missing
+      // skill by meaning. `--available` drops what's already installed for this target.
+      const m = loadManifest();
+      const installed = new Set(listInstalled({ target }));
+      const onlyAvailable = argv.includes('--available');
+      const short = (d) => {
+        const s = String(d || '').split('. ')[0].replace(/\s+/g, ' ').trim();
+        return s.length > 160 ? `${s.slice(0, 159)}…` : s;
+      };
+      for (const sk of [...m.skills].sort((a, b) => a.id.localeCompare(b.id))) {
+        const state = installed.has(sk.id) ? 'installed' : 'available';
+        if (onlyAvailable && state === 'installed') continue;
+        say(`${sk.id}\t${state}\t${short(sk.description)}`);
+      }
+      return;
+    }
     case 'audit': {
       const report = audit();
       const written = writeAuditReport(report);

--- a/skills/suggest/SKILL.md
+++ b/skills/suggest/SKILL.md
@@ -56,8 +56,8 @@ When the current task would clearly benefit from an rsc skill that is **not inst
 Rules:
 
 - Installing changes the user's environment — always confirm first.
-- To know what exists, run `npx @ericrisco/rsc consult "<the task>"` instead of guessing.
-- For a project-level view, prefer `.rsc/skill-registry.json` when present; if it is missing or stale, suggest `npx @ericrisco/rsc registry refresh`. This is a cheap index, not a reason to load every skill.
+- To know what exists, run `npx @ericrisco/rsc catalog --available` (every NOT-installed skill as `id  available  short description`) and **pick the best fit yourself, by meaning** — see the detector below. Don't guess from memory.
+- `npx @ericrisco/rsc consult "<task>"` is only a cheap **lexical** hint: it keyword-matches and silently returns nothing for natural-language or non-English/Catalan intent (e.g. it finds no email skill for "mandar emails"). Never let it be the decider; if it's empty, scan `catalog` and judge semantically.
 - Never recommend something already installed (`npx @ericrisco/rsc list`).
 - One suggestion at a time. Don't interrupt the flow for nice-to-haves.
 
@@ -78,24 +78,29 @@ This is broader than "start a project". It includes mid-conversation requests su
 - Knowledge and research: "documenta cómo funciona esto", "crea una wiki", "procesa este inbox", "research competitors", "turn this into SOPs".
 - Other languages: any equivalent phrasing. Match the user's intent, not exact words.
 
-When a capability intent appears:
+When a capability intent appears, **you** make the match semantically — do not delegate the decision to a keyword ranker:
 
-1. Run `npx @ericrisco/rsc list` to know what is already installed.
-2. Run `npx @ericrisco/rsc consult "<the user's exact intent>"`.
-3. Read the ordered result as the install queue, but pick only the **first missing**
-   skill that is useful right now. Skip `suggest` and any installed skill.
+1. Run `npx @ericrisco/rsc catalog --available` to get every NOT-installed skill as
+   `id  available  short description`. (It already excludes what's installed.)
+2. **Read the catalog and pick the single best-fit skill by MEANING** — match the user's
+   intent to a skill's *purpose*, semantically, in any language (CA/ES/EN/…), the way you'd
+   match a request to a teammate's expertise. Judge meaning, not shared keywords:
+   "mandar emails de bienvenida" → `email-connector` even though no words overlap its tags;
+   "login con Google" → an auth/security skill, not `flutter`; "transcripció de veu" → a
+   speech/audio skill *if one exists*.
+3. If nothing in the catalog genuinely fits, **say so and move on** — don't force a weak
+   match, and don't propose a tangential skill just to have an answer. (`npx @ericrisco/rsc
+   consult "<intent>"` is available as a lexical hint, but it misses natural-language and
+   Catalan intent and is silent for many real needs — never read its silence as "no skill
+   exists." The catalog + your judgment is the source of truth.)
 4. Ask before installing: "Para esto instalaría `<id>`, que aún no tienes. ¿La instalo? (sí/no)".
-5. On yes, run `npx @ericrisco/rsc add <id>` and then continue the original request.
+5. On yes, run `npx @ericrisco/rsc add <id>` and continue the original request. One at a time.
 
-Example: if the user says "quiero montar una pagina web para vender cursos online",
-do not just start building. Check the installed list, consult that exact phrase, and
-recommend the first missing skill from the returned queue. In a base install, `init`
-and `harness` may already exist, so the first missing skill is usually `nextjs`. In a
-bare install, `init` may be first. Install one skill at a time.
-
-Example: if the user says "hazme una secuencia de cold emails para vender mi SaaS",
-consult that exact phrase and recommend the first missing email/marketing skill rather
-than writing generic copy with no specialist loaded.
+Example: "quiero montar una pagina web para vender cursos online" → scan the catalog and
+pick the web stack skill (usually `nextjs`) by meaning; don't start building before offering it.
+Example: "hazme una secuencia de cold emails para vender mi SaaS" → pick the email/outreach
+skill (`cold-outreach` / `email-connector`) because it *means* email outreach — not because
+the keywords happen to match (they often won't).
 
 ## Onboarding gate (first contact)
 

--- a/skills/suggest/evals/cases.yaml
+++ b/skills/suggest/evals/cases.yaml
@@ -62,17 +62,17 @@ capability:
   - scenario: "Mid-conversation, after base install, the user says 'quiero montar una pagina web para vender cursos online'. `init`, `harness`, `orient`, and `suggest` are already installed; `nextjs` is not. Show how rsc-suggest behaves."
     must_include:
       - "Treats the message as in-agent capability intent, not as a CLI-only consult task"
-      - "Runs `npx @ericrisco/rsc list` before recommending so installed `init`/`harness` are skipped"
-      - "Runs `npx @ericrisco/rsc consult \"quiero montar una pagina web para vender cursos online\"` or equivalent exact-intent consult"
-      - "Names `nextjs` as the first missing useful skill for the website work"
+      - "Runs `npx @ericrisco/rsc catalog --available` to see the not-installed skills (already excludes installed `init`/`harness`)"
+      - "Picks the best-fit skill by MEANING from the catalog, not by relying on lexical `consult` ranking"
+      - "Names `nextjs` as the missing useful skill for the website work"
       - "Asks one short confirmation before installing and does not auto-install"
       - "On confirmation, runs `npx @ericrisco/rsc add nextjs`, then resumes the original website task"
 
   - scenario: "Mid-conversation, the user says 'Automatiza el flujo de leads desde el formulario hasta mi CRM'. The base skills are installed, but `automation-flows` and CRM/connector skills are not. Show how rsc-suggest behaves."
     must_include:
       - "Treats the message as in-agent capability intent for automation/integration, not only as a coding task"
-      - "Runs `npx @ericrisco/rsc list` before recommending"
-      - "Runs `npx @ericrisco/rsc consult \"Automatiza el flujo de leads desde el formulario hasta mi CRM\"` or equivalent exact-intent consult"
-      - "Names the first missing useful automation/connector skill from the consult results"
+      - "Runs `npx @ericrisco/rsc catalog --available` to see the not-installed skills"
+      - "Picks the best-fit missing automation/connector skill by MEANING (not by lexical `consult` ranking, which may return nothing)"
+      - "Names that one missing automation/connector skill"
       - "Asks one short confirmation before installing and does not auto-install"
       - "On confirmation, runs `npx @ericrisco/rsc add <id>` for that one missing skill, then resumes the automation task"

--- a/tests/rsc-cli.test.js
+++ b/tests/rsc-cli.test.js
@@ -54,6 +54,29 @@ test('rsc consult recommends bootstrap and web skills for a new website intent',
 });
 
 
+test('rsc catalog dumps the full catalog with install state and descriptions', () => {
+  const result = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'catalog'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const lines = result.stdout.trim().split('\n');
+  assert.ok(lines.length >= 200, `expected the full catalog, got ${lines.length} lines`);
+  assert.ok(lines.every((l) => /^\S+\t(installed|available)\t.+/.test(l)), 'each line is id<TAB>state<TAB>description');
+  const nextjs = lines.find((l) => l.startsWith('nextjs\t'));
+  assert.ok(nextjs && /next\.js/i.test(nextjs), `nextjs row carries its description: ${nextjs}`);
+});
+
+test('rsc catalog --available hides skills already installed', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-catalog-'));
+  const install = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'add', 'fastapi', '--target', 'claude'], { cwd, encoding: 'utf8' });
+  assert.equal(install.status, 0, install.stderr);
+  const all = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'catalog', '--target', 'claude'], { cwd, encoding: 'utf8' });
+  const avail = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'catalog', '--available', '--target', 'claude'], { cwd, encoding: 'utf8' });
+  assert.ok(all.stdout.includes('fastapi\tinstalled\t'), 'full catalog marks fastapi installed');
+  assert.ok(!avail.stdout.split('\n').some((l) => l.startsWith('fastapi\t')), '--available drops the installed fastapi');
+});
+
 test('rsc backups lists project-local snapshots', () => {
   const cwd = mkdtempSync(join(tmpdir(), 'rsc-cli-backups-'));
   const install = spawnSync(process.execPath, [join(ROOT, 'scripts/rsc.js'), 'add', 'fastapi', '--target', 'claude'], {


### PR DESCRIPTION
## Problem

In-agent discovery of *not-installed* skills delegated the decision to `rsc consult` — a **lexical** keyword ranker (stopwords + a hardcoded synonym map + FTS5/LIKE over id/desc/tags, gated by a min-score threshold). It works for exact tool/brand names but fails on natural-language / Catalan intent — *which is most of how people describe work*:

| You type | consult proposes |
|---|---|
| "mandar **emails** de bienvenida" | ∅ — yet `email-connector`/`cold-outreach`/`newsletter` exist (plural "emails" misses the `email` tag) |
| "transcripció de veu" (CA) | ∅ |
| "**login** con Google" | `flutter` (because "app") |
| "pagos con **stripe**" | `stripe` ✓ (brand-name match) |

The catalog's *self-recommending* promise broke exactly where it should shine.

## Fix

- **New `rsc catalog [--available]`**: a full, unranked dump — `id  installed|available  short description` for every skill — so the agent has the whole candidate set (the CLI is the only place with the bundled manifest; the registry isn't always present).
- **Rewrite `suggest`'s detector**: the **model** now picks the best-fit missing skill **by meaning**, in any language, reading the catalog — not by delegating to the lexical ranker. `consult` is demoted to an optional lexical hint, and its silence must never be read as "no skill exists."

## Verification

- `rsc catalog` dumps 231 skills; `email-connector`/`cold-outreach` now visible to the agent (the recall `consult` missed).
- New CLI tests (full-dump shape + `--available` hides installed). Evals updated. **140/140 pass.**

`consult` stays as-is for the terminal lexical UX (option b — broadening the ranker — left as a possible follow-up).