### PR TITLE
feat: install a 'developer' subagent (balanced/Sonnet) for every agent-capable target

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -4,6 +4,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { planInstall } from './install-plan.js';
 import { targetPaths, writeSkill, wireHook, unwireHook, baseDir, TARGET_IDS } from '../targets/index.js';
+import { targetHasAgents, writeDeveloperAgent, removeDeveloperAgent, developerAgentPath } from '../targets/agents.js';
 import { readState, writeState } from './lib/state.js';
 import { createBackup } from './lib/backups.js';
 
@@ -62,6 +63,7 @@ function managedPathsForInstall({ skillIds, target, home, cwd }) {
   const paths = targetPaths(target, home, cwd);
   const plan = planInstall({ skillIds, target, home, cwd });
   const out = [paths.stateFile, versionFile(cwd), baseVersionsFile(cwd)];
+  if (targetHasAgents(target)) out.push(developerAgentPath(target, cwd), join(cwd, '.rsc', 'developer.json'));
   for (const step of plan) {
     if (step.kind === 'skill') {
       out.push(step.to, baseDir(step.id, cwd));
@@ -94,6 +96,11 @@ export async function applyInstall({ skillIds, target, home, cwd = process.cwd()
     }
   }
   writeBaseVersions(cwd, baseVersions);
+  // Install the `developer` subagent for targets that support file-based agents (Claude
+  // Code, Cursor, OpenCode, Gemini, Copilot, Junie, Kiro, Codex). It runs at the balanced
+  // tier by default (never light/Haiku); the tier lives in .rsc/developer.json, set by
+  // `init` at onboarding and honored on every (re)install/sync.
+  if (targetHasAgents(target)) state.agents = writeDeveloperAgent(target, cwd).length ? ['developer'] : [];
   state.version = CLI_VERSION;
   writeState(paths.stateFile, state);
   mkdirSync(dirname(versionFile(cwd)), { recursive: true });
@@ -174,6 +181,9 @@ export async function purge({ home, cwd = process.cwd(), withDocs = false, dryRu
     }
     // unwireHook mutates files, so only run it for real (dry runs skip it).
     if (!dryRun) removed.push(...unwireHook(target, paths));
+    // Remove the installed developer subagent (agent-capable targets only).
+    const agentFile = developerAgentPath(target, cwd);
+    if (agentFile) drop(agentFile);
   }
   drop(join(cwd, '.rsc'), true);
   if (withDocs) drop(join(cwd, '02-DOCS'), true);

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -158,6 +158,12 @@ test output. You merge the branches, then run the *combined* test suite before t
 green-in-isolation is not green-together. Hand the orchestration to `parallel`; keep the TDD
 discipline inside each branch.
 
+**Dispatch implementation work to the `developer` subagent.** rsc installs a `developer` agent
+pinned to the balanced tier (Sonnet by default, chosen at onboarding, never `light`). When you
+delegate a task or fan out via `parallel`, dispatch it to that agent (e.g. Claude Code
+`subagent_type: developer`) so the bulk of TDD execution runs on the cheaper-but-capable model
+while you stay on the session model to orchestrate. Full rationale: `../sdd/references/model-routing.md`.
+
 ## Model tier — `balanced` (opt-in routing)
 
 This phase's default model tier is **`balanced`** — it is the bulk of TDD execution: cost-sensitive, with quality balanced handles well. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model (this is where routing pays off most — fan-out runs on `balanced` while a hard sub-problem can be escalated to `heavy`). Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -55,6 +55,14 @@ Before discovery, before any recommendation, write the profile to `02-DOCS` and 
 
 If `02-DOCS/` does not yet exist (greenfield), create `02-DOCS/wiki/harness/` now — just enough to hold these two files. That, plus the `CLAUDE.md` Knowledge-map link, is everything `init` writes; ALL other `01-TOOLS/` + `02-DOCS/` scaffolding is the `harness` skill's job.
 
+### Step 4 — Propose the developer model (the implementation subagent)
+
+rsc installs a **`developer`** subagent (the fan-out / implementation worker) for every assistant that supports file-based agents (Claude Code, Cursor, OpenCode, Gemini, Copilot, Junie, Kiro, Codex). It runs at the **balanced** tier by default — **Sonnet** on Anthropic tools (the provider's mid model elsewhere) — and **never** the cheapest `light` model, which is too weak to build with. Offer the choice once, calibrated to the dial:
+
+- *"La implementación la hará un sub-agente `developer`. ¿Qué modelo? **balanced / Sonnet** (rápido y económico — recomendado) o **heavy / Opus** (máxima calidad, más caro)."* Never offer `light`/Haiku.
+
+Record it to `.rsc/developer.json` (`{ "tier": "balanced" }` or `"heavy"`) and re-run the install/sync so the agent files adopt it. If you skip the question (e.g. L0), default to `balanced`. The default is also written at install time, so the developer agent is always set even when onboarding never asks — "propose at onboarding, and also when it isn't set."
+
 ### Opt-out marker — `.rsc/.no-harness`
 
 A freshly-installed session auto-starts `init` while `02-DOCS/wiki/harness/user-profile.md` is absent (the `suggest` Onboarding gate + claude's SessionStart hook). If the user does not want a harness in this repo (e.g. they installed only code skills), write an empty `.rsc/.no-harness` — this permanently silences the auto-start here even before a profile exists. Completing first contact (which writes `user-profile.md`) also silences it. The marker is project-local; commit it so the "no harness here" decision is shared by the team.

--- a/skills/parallel/SKILL.md
+++ b/skills/parallel/SKILL.md
@@ -75,6 +75,8 @@ Each subagent still owns its own discipline inside its scope — TDD via `implem
 
 **Per-unit model tier (when routing is enabled).** `parallel` has *no fixed tier* — this is the most concrete place per-phase model routing pays off. When `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`, give each unit the tier of the *kind of work it does*, not one tier for the whole fan-out: an implement-type unit → `balanced`, a scan/research/boilerplate unit → `light`, a unit doing genuine design or root-cause reasoning → `heavy`. Resolve the tier to a concrete model via `models.tiers` and **dispatch that subagent on that model** (e.g. Claude Code's `model` field on the Task/subagent) — real routing, independent of the session model. If routing is off or no profile exists, dispatch on the session model and say nothing. Full protocol: `../sdd/references/model-routing.md`.
 
+**The `developer` agent is the default worker.** rsc installs a `developer` subagent pinned to the **balanced** tier (Sonnet by default; the user's onboarding choice in `.rsc/developer.json`, never `light`). For implement-type units, **dispatch to the `developer` agent** (e.g. Claude Code `subagent_type: developer`) — that's the deliberate cost cap the user asked for. Only escalate a genuinely heavy unit (real design / root-cause) to a heavy model, and only when routing is enabled; otherwise the `developer` agent's balanced model is the floor and the ceiling.
+
 ### Skill resolution feedback
 
 Every subagent result must report:

--- a/skills/sdd/references/model-routing.md
+++ b/skills/sdd/references/model-routing.md
@@ -155,6 +155,24 @@ To target another provider, change `models.provider` and set `models.tiers` to t
 These are starting points — set them to whatever your account actually has. The tiers are the
 contract; the concrete names are yours to edit.
 
+## The `developer` subagent (the installed implementation worker)
+
+rsc installs a **`developer`** subagent into every assistant that supports file-based agents
+(Claude Code `.claude/agents/`, Cursor, OpenCode, Gemini, Copilot, Junie, Kiro, Codex) when the
+harness is installed. It is the concrete embodiment of "run the fan-out on a smaller model":
+
+- It is pinned to the **balanced** tier — **Sonnet** for Anthropic-backed tools, the provider's
+  mid model elsewhere (Gemini Flash, GPT-mini). It is **never** `light`/Haiku — that tier is too
+  weak to build with. The floor for implementation is balanced.
+- The tier is chosen at **onboarding** (`init`, Step 4): balanced (default) or heavy. It is stored
+  in `.rsc/developer.json` and the installer writes the per-target agent file with the resolved
+  model on every (re)install/sync. If onboarding never asks, the install-time default is balanced.
+- `implement` and `parallel` **dispatch implementation/fan-out work to this agent**, so the
+  session model orchestrates while the cheaper-but-capable model does the bulk of the typing.
+- On assistants without file-based agents (Amp, Zed, Windsurf, Cline, Roo, Continue, Aider, Jules,
+  Antigravity), there is no agent file — the developer tier is advisory there, like the rest of
+  routing. The per-target model id is an editable default (see the provider table above).
+
 ## Result-envelope `model` field
 
 Every phase's result envelope carries the model it ran on, so the chain is auditable:

--- a/targets/agents.js
+++ b/targets/agents.js
@@ -1,0 +1,98 @@
+// rsc developer agent — installed with the harness for every target that supports
+// file-based subagents with a per-agent model. The agent runs at the `balanced` tier
+// (never `light`/Haiku): Sonnet for Anthropic-backed tools, the provider's mid model
+// elsewhere. The chosen tier (balanced default, or heavy) lives in `.rsc/developer.json`,
+// written by `init` at onboarding and read here so re-syncs honor it.
+import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+// Concrete model per provider per tier. June 2026 defaults — EDIT to your account's
+// models; the TIER is the contract, the id is yours to change. `light` is deliberately
+// absent: the developer floor is `balanced`.
+const TIER_MODEL = {
+  anthropic: { balanced: 'claude-sonnet-4-6', heavy: 'claude-opus-4-8' },
+  google: { balanced: 'gemini-2.5-flash', heavy: 'gemini-2.5-pro' },
+  openai: { balanced: 'gpt-5.1-mini', heavy: 'gpt-5.1' },
+};
+
+// Per-target agent capability: where the file goes, its format, and how the model value
+// is written for that tool. Targets absent here have no installable file-based agents
+// (Amp/Zed/Windsurf/Cline/Roo/Continue/Aider/Jules/Antigravity) — there the developer
+// model is advisory (model-routing), not a file.
+const AGENT_TARGETS = {
+  claude: { dir: '.claude/agents', ext: '.md', format: 'md', model: (t) => (t === 'heavy' ? 'opus' : 'sonnet') },
+  junie: { dir: '.junie/agents', ext: '.md', format: 'md', model: (t) => (t === 'heavy' ? 'opus' : 'sonnet') },
+  cursor: { dir: '.cursor/agents', ext: '.md', format: 'md', model: (t) => TIER_MODEL.anthropic[t] },
+  opencode: { dir: '.opencode/agents', ext: '.md', format: 'md', mode: 'subagent', model: (t) => `anthropic/${TIER_MODEL.anthropic[t]}` },
+  gemini: { dir: '.gemini/agents', ext: '.md', format: 'md', model: (t) => TIER_MODEL.google[t] },
+  copilot: { dir: '.github/agents', ext: '.agent.md', format: 'md', model: (t) => TIER_MODEL.anthropic[t] },
+  kiro: { dir: '.kiro/agents', ext: '.json', format: 'json', model: (t) => (t === 'heavy' ? 'claude-opus-4' : 'claude-sonnet-4') },
+  codex: { dir: '.codex/agents', ext: '.toml', format: 'toml', model: (t) => TIER_MODEL.openai[t] },
+};
+
+export const AGENT_TARGET_IDS = Object.keys(AGENT_TARGETS);
+export function targetHasAgents(target) { return Boolean(AGENT_TARGETS[target]); }
+
+const NAME = 'developer';
+const DESC = 'Implementation worker: turns an approved spec+plan into working, tested code under strict TDD (red->green->refactor), one task at a time. The rsc SDD fan-out/implementation hand.';
+const BODY = `You are the **developer** subagent for this project — the hands of the rsc SDD chain. You execute a planned, approved task into working, tested code. You do NOT design features.
+
+- Work **test-first**: smallest failing test (RED), least code to pass it (GREEN), then refactor on green. A test that never failed proves nothing.
+- One task at a time; keep the diff to that task's scope — no "while I'm here".
+- Follow the project's spec, plan and constitution under \`02-DOCS/wiki/sdd/\`, and borrow test mechanics from the stack skill (fastapi/go/nextjs/flutter/...).
+- If there is no approved spec + plan for non-trivial feature work, STOP and route to \`specify\` — do not write feature code.
+- Log non-obvious decisions to \`02-DOCS/wiki/sdd/decisions.md\`. Report your diff + test output at the end.
+
+Full discipline lives in the \`implement\` skill.`;
+
+// `.rsc/developer.json` — the chosen tier (balanced default; never light). `init` writes
+// it on the onboarding answer; the installer reads it so every (re)install/sync matches.
+const tierFile = (cwd) => join(cwd, '.rsc', 'developer.json');
+export function readDeveloperTier(cwd) {
+  try {
+    return JSON.parse(readFileSync(tierFile(cwd), 'utf8')).tier === 'heavy' ? 'heavy' : 'balanced';
+  } catch { return 'balanced'; }
+}
+export function writeDeveloperTier(cwd, tier) {
+  const t = tier === 'heavy' ? 'heavy' : 'balanced';
+  mkdirSync(dirname(tierFile(cwd)), { recursive: true });
+  writeFileSync(tierFile(cwd), `${JSON.stringify({ tier: t }, null, 2)}\n`);
+  return t;
+}
+
+function renderMd(spec, model) {
+  const fm = ['---', `name: ${NAME}`, `description: "${DESC}"`, `model: ${model}`];
+  if (spec.mode) fm.push(`mode: ${spec.mode}`);
+  fm.push('---', '');
+  return `${fm.join('\n')}${BODY}\n`;
+}
+const renderJson = (model) => `${JSON.stringify({ name: NAME, description: DESC, model, prompt: BODY }, null, 2)}\n`;
+function renderToml(model) {
+  const esc = (s) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  // body as a TOML multiline LITERAL string ('''…''') — no escape processing.
+  return `name = "${NAME}"\ndescription = "${esc(DESC)}"\nmodel = "${model}"\ndeveloper_instructions = '''\n${BODY}\n'''\n`;
+}
+
+export function developerAgentPath(target, cwd) {
+  const spec = AGENT_TARGETS[target];
+  return spec ? join(cwd, ...spec.dir.split('/'), `${NAME}${spec.ext}`) : null;
+}
+
+export function writeDeveloperAgent(target, cwd, tier = readDeveloperTier(cwd)) {
+  const spec = AGENT_TARGETS[target];
+  if (!spec) return [];
+  const model = spec.model(tier);
+  const content = spec.format === 'json' ? renderJson(model)
+    : spec.format === 'toml' ? renderToml(model)
+      : renderMd(spec, model);
+  const path = developerAgentPath(target, cwd);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+  return [path];
+}
+
+export function removeDeveloperAgent(target, cwd) {
+  const path = developerAgentPath(target, cwd);
+  if (path && existsSync(path)) { rmSync(path, { force: true }); return [path]; }
+  return [];
+}

--- a/tests/agents.test.js
+++ b/tests/agents.test.js
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AGENT_TARGET_IDS, targetHasAgents, writeDeveloperAgent, developerAgentPath,
+  readDeveloperTier, writeDeveloperTier,
+} from '../targets/agents.js';
+
+test('the 8 agent-capable targets each render a developer agent with a model (valid per format)', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-ag-'));
+  assert.deepEqual([...AGENT_TARGET_IDS].sort(),
+    ['claude', 'codex', 'copilot', 'cursor', 'gemini', 'junie', 'kiro', 'opencode']);
+  for (const t of AGENT_TARGET_IDS) {
+    writeDeveloperAgent(t, cwd);
+    const p = developerAgentPath(t, cwd);
+    assert.ok(existsSync(p), `${t} agent written`);
+    const c = readFileSync(p, 'utf8');
+    assert.ok(/model/.test(c), `${t} carries a model`);
+    if (p.endsWith('.json')) assert.doesNotThrow(() => JSON.parse(c), `${t} json parses`);
+  }
+});
+
+test('developer tier: balanced by default, heavy honored, light coerced to balanced (never light)', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-ag-'));
+  assert.equal(readDeveloperTier(cwd), 'balanced');
+  writeDeveloperTier(cwd, 'heavy');
+  assert.equal(readDeveloperTier(cwd), 'heavy');
+  writeDeveloperTier(cwd, 'light');
+  assert.equal(readDeveloperTier(cwd), 'balanced');
+});
+
+test('balanced→Sonnet / heavy→Opus on Claude; the agent is never Haiku', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-ag-'));
+  writeDeveloperAgent('claude', cwd, 'balanced');
+  let c = readFileSync(developerAgentPath('claude', cwd), 'utf8');
+  assert.match(c, /model: sonnet/);
+  assert.doesNotMatch(c, /haiku/i);
+  writeDeveloperAgent('claude', cwd, 'heavy');
+  c = readFileSync(developerAgentPath('claude', cwd), 'utf8');
+  assert.match(c, /model: opus/);
+});
+
+test('targets without file-based agents get no developer agent', () => {
+  assert.equal(targetHasAgents('codex'), true);
+  assert.equal(targetHasAgents('aider'), false);
+  assert.equal(targetHasAgents('cline'), false);
+  assert.equal(developerAgentPath('aider', process.cwd()), null);
+});

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
-import { applyInstall, listInstalled, uninstall, syncInstalled } from '../scripts/install-apply.js';
+import { applyInstall, listInstalled, uninstall, syncInstalled, purge } from '../scripts/install-apply.js';
 import { listBackups, restoreBackup } from '../scripts/lib/backups.js';
 import { doctor } from '../scripts/doctor.js';
 import { targetPaths } from '../targets/index.js';
@@ -184,6 +184,16 @@ test('multi-target sync refreshes bases for the second target\'s exclusive skill
   // Regression: with the old single global marker, claude's pass bumped it to current so
   // codex's pass saw "unchanged" and skipped refreshing nextjs's base, leaving it stale.
   assert.ok(!existsSync(join(cwd, '.rsc/skills/nextjs/STALE.txt')), 'second-target exclusive base refreshed');
+});
+
+test('claude: install writes the developer subagent (Sonnet); purge removes it', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-devagent-'));
+  await applyInstall({ skillIds: ['suggest'], target: 'claude', cwd });
+  const agent = join(cwd, '.claude/agents/developer.md');
+  assert.ok(existsSync(agent), 'developer agent installed');
+  assert.match(readFileSync(agent, 'utf8'), /model: sonnet/, 'balanced tier → Sonnet by default');
+  await purge({ cwd });
+  assert.ok(!existsSync(agent), 'developer agent removed on purge');
 });
 
 test('claude: install migrates away the legacy nested .claude/skills/rsc/ layout', async () => {


### PR DESCRIPTION
## What

Force fan-out/implementation onto a smaller-but-capable model. rsc now installs a **`developer`** subagent with the harness, for the **8** assistants that support file-based agents:

| Format | Targets |
|---|---|
| MD+YAML | Claude Code, Cursor, OpenCode, Gemini, Copilot, Junie |
| JSON | Kiro |
| TOML | Codex |

It is pinned to the **balanced** tier — **Sonnet** on Anthropic tools, the provider's mid model elsewhere (Gemini Flash, GPT-mini). **Never `light`/Haiku** (too weak to build with).

## How

- **`targets/agents.js`** — per-target path/format/model writer (MD/JSON/TOML); `.rsc/developer.json` holds the tier (balanced default · heavy optional · light coerced to balanced).
- **Installer** — writes the developer agent on install/sync for agent-capable targets; `purge` removes it; managed-paths/backup aware.
- **Onboarding (`init` Step 4)** — proposes the model (balanced default / heavy; never Haiku). The default is also written at install time, so it's set even when onboarding never asks.
- **`implement` + `parallel`** — dispatch implementation/fan-out to the developer agent (e.g. `subagent_type: developer`), so the session model orchestrates while the cheaper model types.
- **`model-routing.md`** — documents the agent + the editable per-provider id table.

## Verification

- Rendering across all 8 formats (valid MD frontmatter / JSON parses / TOML), tier coercion (light→balanced), install/purge round-trip. **147/147.** Manifest unchanged.

Note: Kiro (JSON) and Codex (TOML) agent schemas are best-effort per June-2026 docs; the model ids are editable defaults (the **tier** is the contract).