### PR TITLE
fix(roast-me): real Codex/Gemini transcript adapters

### DIFF
--- a/skills/roast-me/tools/adapters/base.py
+++ b/skills/roast-me/tools/adapters/base.py
@@ -17,9 +17,21 @@ An adapter MUST:
 
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
+
+#: Shared correction detector — a user message matching this right after a prompt
+#: signals the previous turn went wrong. Single source of truth for every adapter
+#: (and re-used by extract_prompts.py) so the heuristic never drifts between runtimes.
+CORRECTION_RE = re.compile(
+    r"\b(no[,.]?\s|wrong|instead|actually|don'?t|shouldn'?t|stop|not that|"
+    r"I said|I meant|I asked|that'?s not|please don'?t|why did you|"
+    r"you should have|that was wrong|incorrect|try again|redo|"
+    r"that broke|you broke|revert|undo)\b",
+    re.IGNORECASE,
+)
 
 
 class BaseAdapter(ABC):

--- a/skills/roast-me/tools/adapters/codex.py
+++ b/skills/roast-me/tools/adapters/codex.py
@@ -1,36 +1,71 @@
 """Codex CLI adapter (@openai/codex).
 
 Session files: ~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>.jsonl
-Format: JSON Lines. Each line is an event object.
+Format: JSON Lines. Each line is {"timestamp", "type", "payload"}.
 
-CONFIRMED (2026-06, via official CLI reference and community tooling):
-  - Base path: ~/.codex/sessions/
-  - Subdirectory layout: year/month/day
-  - File naming: rollout-<ISO-timestamp>.jsonl
-  - Format: JSONL, one event per line
+CONFIRMED (2026-06, against live ~/.codex/sessions on macOS):
+  - Base path / layout / naming: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+  - Line envelope: {"timestamp": ISO8601, "type": str, "payload": {...}}
+  - The genuine user prompt is an `event_msg` line whose payload.type is
+    "user_message", carrying the typed text in payload.message. (Injected
+    AGENTS.md / developer preambles appear only as response_item/message lines,
+    so keying on user_message excludes them.)
+  - Assistant turns: event_msg/agent_message (payload.message) and
+    response_item/message role=assistant.
+  - Tool calls: response_item/function_call (payload.name).
+  - Tool results: response_item/function_call_output (payload.output) — shell
+    execs include a "Process exited with code N" line; N != 0 (or common error
+    markers) means the command failed.
+  - Model: turn_context.model / session_meta payload.
 
-STUBBED (format details):
-  The internal schema of each JSONL line has not been verified against a live
-  Codex installation. Based on community-authored session viewers, events appear
-  to carry {"role": "user"|"assistant", "content": "...", ...}. If the role
-  field is absent or the schema differs, parse() returns [] gracefully.
-
-Degradation: if ~/.codex/ does not exist, discover() returns [].
+Degradation: if ~/.codex/ does not exist, discover() returns []; any unexpected
+line shape is skipped, so parse() never raises.
 """
 
 from __future__ import annotations
 
+import datetime
 import json
+import re
 from pathlib import Path
 from typing import Any
 
-from .base import BaseAdapter
+from .base import CORRECTION_RE, BaseAdapter
+
+# A shell tool result failed when it reports a non-zero exit code, or carries a
+# common error marker with no explicit success code. Conservative on purpose —
+# better to miss a soft error than to invent one.
+_EXIT_CODE_RE = re.compile(r"exited with code\s+(\d+)", re.IGNORECASE)
+_ERROR_MARKER_RE = re.compile(
+    r"\b(command not found|no such file|permission denied|traceback \(most recent|"
+    r"fatal:|panic:|segmentation fault|unhandled exception)\b",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_error(output: str) -> bool:
+    if not output:
+        return False
+    m = _EXIT_CODE_RE.search(output)
+    if m:
+        return m.group(1) != "0"
+    return bool(_ERROR_MARKER_RE.search(output))
+
+
+def _ts(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except (ValueError, AttributeError):
+            return None
+    return None
 
 
 class CodexAdapter(BaseAdapter):
     RUNTIME_ID = "codex"
 
-    # CONFIRMED: path layout from official CLI docs and community tools.
     SESSIONS_DIR = Path.home() / ".codex" / "sessions"
 
     def discover(self) -> list[Path]:
@@ -50,17 +85,17 @@ class CodexAdapter(BaseAdapter):
         return sorted(files, key=lambda f: f.stat().st_mtime, reverse=True)
 
     def parse(self, path: Path) -> list[dict[str, Any]]:
-        """Parse one Codex session JSONL file.
-
-        STUBBED schema: assumes {"role": "user", "content": "..."} event lines.
-        Falls back silently if the schema differs.
-        """
-        records: list[dict[str, Any]] = []
+        """Parse one Codex session JSONL file into user-prompt records with
+        session-aware error/correction context."""
         try:
             lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
         except OSError:
             return []
 
+        # 1) Flatten the file into an ordered timeline of turns.
+        timeline: list[dict[str, Any]] = []
+        model = ""
+        pending_tool = ""
         for line in lines:
             line = line.strip()
             if not line:
@@ -69,45 +104,103 @@ class CodexAdapter(BaseAdapter):
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-
-            # STUBBED: expected schema based on community session viewers.
-            role = obj.get("role") or obj.get("type", "")
-            if role != "user":
+            if not isinstance(obj, dict):
                 continue
 
-            content = obj.get("content", "")
-            if isinstance(content, list):
-                # Some formats use a content array like OpenAI chat API.
-                parts = [
-                    c.get("text", "") if isinstance(c, dict) else str(c)
-                    for c in content
-                    if isinstance(c, dict) and c.get("type") == "text"
-                ]
-                text = "\n".join(parts)
-            elif isinstance(content, str):
-                text = content
-            else:
-                text = ""
+            top_type = obj.get("type")
+            payload = obj.get("payload")
+            if not isinstance(payload, dict):
+                payload = {}
+            ts = _ts(obj.get("timestamp"))
 
-            if not text.strip():
+            # Track the active model from session metadata / turn context.
+            if top_type in ("session_meta", "turn_context"):
+                m = payload.get("model")
+                if isinstance(m, str) and m:
+                    model = m
                 continue
 
-            ts = obj.get("timestamp") or obj.get("created_at")
-            if isinstance(ts, str):
-                try:
-                    import datetime
-                    dt = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
-                    ts = dt.timestamp()
-                except (ValueError, AttributeError):
-                    ts = None
-            elif not isinstance(ts, (int, float)):
-                ts = None
+            if top_type == "event_msg":
+                p_type = payload.get("type")
+                if p_type == "user_message":
+                    text = payload.get("message", "")
+                    if isinstance(text, str) and text.strip():
+                        timeline.append({"kind": "user", "text": text, "ts": ts})
+                elif p_type == "agent_message":
+                    text = payload.get("message", "")
+                    if isinstance(text, str) and text.strip():
+                        timeline.append({"kind": "assistant", "text": text, "ts": ts})
+                continue
+
+            if top_type == "response_item":
+                p_type = payload.get("type")
+                if p_type == "function_call":
+                    name = payload.get("name", "")
+                    pending_tool = name if isinstance(name, str) else ""
+                elif p_type == "function_call_output":
+                    output = payload.get("output", "")
+                    output = output if isinstance(output, str) else json.dumps(output)
+                    timeline.append({
+                        "kind": "tool_output",
+                        "tool": pending_tool,
+                        "is_error": _looks_like_error(output),
+                        "text": output,
+                        "ts": ts,
+                    })
+                    pending_tool = ""
+                # response_item/message (assistant/user/developer) is intentionally
+                # ignored: genuine prompts come from event_msg/user_message, and the
+                # assistant context comes from event_msg/agent_message.
+                continue
+
+        # 2) Walk the timeline; enrich each user prompt with what follows it.
+        user_indices = [i for i, t in enumerate(timeline) if t["kind"] == "user"]
+        records: list[dict[str, Any]] = []
+        for n, idx in enumerate(user_indices):
+            turn = timeline[idx]
+            next_user = user_indices[n + 1] if n + 1 < len(user_indices) else len(timeline)
+
+            followed_by_error = False
+            error_tool = ""
+            error_text = ""
+            for j in range(idx + 1, next_user):
+                t = timeline[j]
+                if t["kind"] == "tool_output" and t.get("is_error"):
+                    followed_by_error = True
+                    error_tool = t.get("tool", "")
+                    error_text = t.get("text", "")
+                    break
+
+            followed_by_correction = False
+            correction_text = ""
+            if next_user < len(timeline):
+                nxt = timeline[next_user]["text"]
+                if CORRECTION_RE.search(nxt):
+                    followed_by_correction = True
+                    correction_text = nxt
+
+            # context_before: last assistant text strictly before this prompt.
+            context_before = ""
+            for j in range(idx - 1, -1, -1):
+                if timeline[j]["kind"] == "assistant":
+                    context_before = timeline[j]["text"]
+                    break
+
+            error_was_recovered = followed_by_error and not followed_by_correction
 
             records.append({
                 "runtime": self.RUNTIME_ID,
                 "session_file": str(path),
-                "prompt_text": text,
-                "timestamp": ts,
+                "prompt_text": turn["text"],
+                "timestamp": turn.get("ts"),
+                "model": model,
+                "context_before": context_before,
+                "followed_by_error": followed_by_error,
+                "error_was_recovered": error_was_recovered,
+                "followed_by_correction": followed_by_correction,
+                "correction_text": correction_text,
+                "error_tool": error_tool,
+                "error_text": error_text,
             })
 
         return records

--- a/skills/roast-me/tools/adapters/gemini.py
+++ b/skills/roast-me/tools/adapters/gemini.py
@@ -1,50 +1,58 @@
 """Gemini CLI adapter (@google/gemini-cli).
 
-Session files: ~/.gemini/tmp/<project_hash>/chats/*.jsonl
-Format: JSON Lines. Each line is a MessageRecord.
+Session files: ~/.gemini/tmp/<project_hash>/chats/session-*.json
+Format: a SINGLE JSON object per file (not JSONL).
 
-CONFIRMED (2026-06, via official Gemini CLI docs at google-gemini.github.io
-and github.com/google-gemini/gemini-cli session-management.md):
-  - Base path: ~/.gemini/tmp/
-  - Subdirectory: <project_hash>/chats/
-  - File format: JSONL
-  - MessageRecord fields include: sessionId, projectHash, model, role,
-    content (array of {text: "..."}), and token usage fields.
+CONFIRMED (2026-06, against live ~/.gemini/tmp on macOS):
+  - Base path / layout: ~/.gemini/tmp/<project_hash>/chats/*.json
+  - File shape: {"sessionId", "projectHash", "startTime", "lastUpdated",
+    "messages": [ {"id", "timestamp", "type", "content", ...} ]}
+  - messages[].type is "user" or "gemini"; content is a plain string.
+  - gemini (assistant) messages also carry "model", "thoughts", "tokens".
+  - The format does NOT persist tool calls/errors as messages, so tool-error
+    detection is not possible here — followed_by_error stays False (honest);
+    correction detection (next user message) still works.
 
-STUBBED (exact MessageRecord schema):
-  The exact JSONL schema per line has not been verified against a live Gemini
-  CLI installation. The role/content structure is inferred from the official
-  session-management docs. If the schema differs, parse() returns [] gracefully.
-
-Degradation: if ~/.gemini/ does not exist, discover() returns [].
+Degradation: if ~/.gemini/ does not exist, discover() returns []; a file that
+is not the expected object shape yields no records (parse never raises).
 """
 
 from __future__ import annotations
 
+import datetime
 import json
 from pathlib import Path
 from typing import Any
 
-from .base import BaseAdapter
+from .base import CORRECTION_RE, BaseAdapter
+
+
+def _ts(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except (ValueError, AttributeError):
+            return None
+    return None
 
 
 class GeminiAdapter(BaseAdapter):
     RUNTIME_ID = "gemini"
 
-    # CONFIRMED: path from official gemini-cli session-management docs.
     GEMINI_TMP_DIR = Path.home() / ".gemini" / "tmp"
 
     def discover(self) -> list[Path]:
-        """Find all *.jsonl chat files under ~/.gemini/tmp/<hash>/chats/."""
+        """Find all session *.json chat files under ~/.gemini/tmp/<hash>/chats/."""
         if not self.GEMINI_TMP_DIR.exists():
             return []
         files: list[Path] = []
         try:
-            # Pattern: ~/.gemini/tmp/<project_hash>/chats/*.jsonl
-            for jsonl in self.GEMINI_TMP_DIR.rglob("chats/*.jsonl"):
+            for jf in self.GEMINI_TMP_DIR.rglob("chats/*.json"):
                 try:
-                    if jsonl.is_file():
-                        files.append(jsonl)
+                    if jf.is_file():
+                        files.append(jf)
                 except OSError:
                     continue
         except OSError:
@@ -52,70 +60,83 @@ class GeminiAdapter(BaseAdapter):
         return sorted(files, key=lambda f: f.stat().st_mtime, reverse=True)
 
     def parse(self, path: Path) -> list[dict[str, Any]]:
-        """Parse one Gemini CLI chat JSONL file.
-
-        STUBBED schema: expected MessageRecord with {role, content: [{text}], ...}.
-        Falls back silently if the schema differs.
-        """
-        records: list[dict[str, Any]] = []
+        """Parse one Gemini chat JSON file into user-prompt records with
+        correction context. Tool errors are not represented in this format."""
         try:
-            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
+            obj = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, json.JSONDecodeError):
+            return []
+        if not isinstance(obj, dict):
             return []
 
-        for line in lines:
-            line = line.strip()
-            if not line:
+        messages = obj.get("messages")
+        if not isinstance(messages, list):
+            return []
+
+        # Normalise into an ordered timeline of {kind, text, model, ts}.
+        timeline: list[dict[str, Any]] = []
+        for m in messages:
+            if not isinstance(m, dict):
                 continue
-            try:
-                obj = json.loads(line)
-            except json.JSONDecodeError:
+            mtype = m.get("type")
+            content = m.get("content", "")
+            if not isinstance(content, str) or not content.strip():
                 continue
+            ts = _ts(m.get("timestamp"))
+            if mtype == "user":
+                timeline.append({"kind": "user", "text": content, "ts": ts})
+            elif mtype == "gemini":
+                model = m.get("model")
+                timeline.append({
+                    "kind": "assistant",
+                    "text": content,
+                    "ts": ts,
+                    "model": str(model) if model else "",
+                })
 
-            # STUBBED: inferred from gemini-cli session-management docs.
-            role = obj.get("role", "")
-            if role not in ("user", "USER"):
-                continue
+        user_indices = [i for i, t in enumerate(timeline) if t["kind"] == "user"]
+        records: list[dict[str, Any]] = []
+        for n, idx in enumerate(user_indices):
+            turn = timeline[idx]
+            next_user = user_indices[n + 1] if n + 1 < len(user_indices) else len(timeline)
 
-            content = obj.get("content", [])
-            if isinstance(content, list):
-                parts = []
-                for block in content:
-                    if isinstance(block, dict):
-                        text = block.get("text", "")
-                        if text:
-                            parts.append(text)
-                text = "\n".join(parts)
-            elif isinstance(content, str):
-                text = content
-            else:
-                text = ""
+            # Model that answered this prompt: the first assistant reply after it.
+            model = ""
+            context_after_assistant = ""
+            for j in range(idx + 1, next_user):
+                if timeline[j]["kind"] == "assistant":
+                    model = timeline[j].get("model", "") or model
+                    if not context_after_assistant:
+                        context_after_assistant = timeline[j]["text"]
+            # context_before: last assistant text strictly before this prompt.
+            context_before = ""
+            for j in range(idx - 1, -1, -1):
+                if timeline[j]["kind"] == "assistant":
+                    context_before = timeline[j]["text"]
+                    break
 
-            if not text.strip():
-                continue
+            followed_by_correction = False
+            correction_text = ""
+            if next_user < len(timeline):
+                nxt = timeline[next_user]["text"]
+                if CORRECTION_RE.search(nxt):
+                    followed_by_correction = True
+                    correction_text = nxt
 
-            # Gemini MessageRecord may carry token counts and model name.
-            model = obj.get("model") or obj.get("modelVersion")
-            ts = obj.get("timestamp") or obj.get("createTime")
-            if isinstance(ts, str):
-                try:
-                    import datetime
-                    dt = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
-                    ts = dt.timestamp()
-                except (ValueError, AttributeError):
-                    ts = None
-            elif not isinstance(ts, (int, float)):
-                ts = None
-
-            record: dict[str, Any] = {
+            records.append({
                 "runtime": self.RUNTIME_ID,
                 "session_file": str(path),
-                "prompt_text": text,
-                "timestamp": ts,
-            }
-            if model:
-                record["model"] = str(model)
-
-            records.append(record)
+                "prompt_text": turn["text"],
+                "timestamp": turn.get("ts"),
+                "model": model,
+                "context_before": context_before,
+                # This format does not record tool errors — be honest, not invent.
+                "followed_by_error": False,
+                "error_was_recovered": False,
+                "followed_by_correction": followed_by_correction,
+                "correction_text": correction_text,
+                "error_tool": "",
+                "error_text": "",
+            })
 
         return records

--- a/skills/roast-me/tools/extract_prompts.py
+++ b/skills/roast-me/tools/extract_prompts.py
@@ -33,6 +33,7 @@ from typing import Any
 # ---------------------------------------------------------------------------
 _TOOLS_DIR = Path(__file__).parent
 sys.path.insert(0, str(_TOOLS_DIR))
+from adapters.base import CORRECTION_RE
 from adapters.registry import get_adapters, list_runtime_ids
 
 # ---------------------------------------------------------------------------
@@ -42,15 +43,11 @@ from adapters.registry import get_adapters, list_runtime_ids
 MAX_PROMPTS = 300
 PROMPT_TEXT_LIMIT = 1500
 CORRECTION_TEXT_LIMIT = 500
+ERROR_TEXT_LIMIT = 500
 CONTEXT_BEFORE_LIMIT = 500
 
-CORRECTION_PATTERNS = re.compile(
-    r"\b(no[,.]?\s|wrong|instead|actually|don'?t|shouldn'?t|stop|not that|"
-    r"I said|I meant|I asked|that'?s not|please don'?t|why did you|"
-    r"you should have|that was wrong|incorrect|try again|redo|"
-    r"that broke|you broke|revert|undo)\b",
-    re.IGNORECASE,
-)
+# Single source of truth for the correction heuristic — shared with every adapter.
+CORRECTION_PATTERNS = CORRECTION_RE
 
 # Model tier classification (provider-neutral labels).
 # Maps substrings found in model IDs to tier names.
@@ -144,13 +141,15 @@ def normalise_record(raw: dict[str, Any], position: int, total: int) -> dict[str
         "has_xml_tags": has_xml_tags,
         "has_file_paths": has_file_paths,
         "has_code_blocks": has_code_blocks,
-        # These will be populated by post-processing when session context is available.
-        "followed_by_error": False,
-        "error_was_recovered": False,
-        "followed_by_correction": False,
-        "correction_text": "",
-        "error_tool": "",
-        "error_text": "",
+        # Error/correction context: honored from the adapter when it does its own
+        # session-aware detection (codex, gemini); defaults to False for adapters
+        # that only surface raw prompts. Claude uses process_claude_sessions instead.
+        "followed_by_error": bool(raw.get("followed_by_error", False)),
+        "error_was_recovered": bool(raw.get("error_was_recovered", False)),
+        "followed_by_correction": bool(raw.get("followed_by_correction", False)),
+        "correction_text": truncate(raw.get("correction_text", ""), CORRECTION_TEXT_LIMIT),
+        "error_tool": raw.get("error_tool", "") or "",
+        "error_text": truncate(raw.get("error_text", ""), ERROR_TEXT_LIMIT),
         "context_before": truncate(raw.get("context_before", ""), CONTEXT_BEFORE_LIMIT),
         # Compute fields (best-effort from adapter)
         "model": model_id,

--- a/tests/roast-me.test.js
+++ b/tests/roast-me.test.js
@@ -272,3 +272,110 @@ test('extract_prompts.py: accepts bare number for days (positional argument)', (
   const data = JSON.parse(readFileSync(outputPath, 'utf8'));
   assert.equal(data.metadata.days, 3, `expected days=3, got ${data.metadata.days}`);
 });
+
+// ---------------------------------------------------------------------------
+// Codex + Gemini adapters — real on-disk formats (synthetic fixtures, no PII).
+// ---------------------------------------------------------------------------
+
+function readOutput(result) {
+  const line = result.stdout.split('\n').find((l) => l.startsWith('Output: '));
+  assert.ok(line, `no 'Output:' line in stdout:\n${result.stdout}\n${result.stderr}`);
+  const p = line.replace('Output: ', '').trim();
+  assert.ok(existsSync(p), `output file not created at ${p}`);
+  return JSON.parse(readFileSync(p, 'utf8'));
+}
+
+function runExtractorRuntime(fakeHome, runtime) {
+  return spawnSync('python3', [EXTRACTOR, '--runtime', runtime, '--days', '365'], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: fakeHome },
+  });
+}
+
+// Mirrors the real Codex envelope: {timestamp, type, payload}. The genuine prompt
+// is event_msg/user_message; tool failures are response_item/function_call_output
+// carrying "exited with code N".
+function buildCodexRolloutJsonl() {
+  const L = [
+    { timestamp: '2026-06-01T10:00:00Z', type: 'turn_context', payload: { model: 'gpt-5.1', cwd: '/x' } },
+    { timestamp: '2026-06-01T10:00:01Z', type: 'event_msg', payload: { type: 'user_message', message: 'Audit the formatter output for 2015' } },
+    { timestamp: '2026-06-01T10:00:02Z', type: 'response_item', payload: { type: 'function_call', name: 'exec_command', arguments: '{}' } },
+    { timestamp: '2026-06-01T10:00:03Z', type: 'response_item', payload: { type: 'function_call_output', call_id: 'c1', output: 'Process exited with code 1\nbash: foo: command not found' } },
+    { timestamp: '2026-06-01T10:00:30Z', type: 'event_msg', payload: { type: 'user_message', message: "no, that's wrong — revert it" } },
+    { timestamp: '2026-06-01T10:00:40Z', type: 'event_msg', payload: { type: 'agent_message', message: 'Reverted.' } },
+    { timestamp: '2026-06-01T10:01:00Z', type: 'event_msg', payload: { type: 'user_message', message: 'Now add unit tests for the parser module' } },
+  ];
+  return L.map((e) => JSON.stringify(e)).join('\n') + '\n';
+}
+
+function createFakeCodexHome() {
+  const fakeHome = mkdtempSync(join(tmpdir(), 'roast-me-codex-'));
+  const dir = join(fakeHome, '.codex', 'sessions', '2026', '06', '28');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'rollout-2026-06-28T10-00-00-abc.jsonl'), buildCodexRolloutJsonl(), 'utf8');
+  return fakeHome;
+}
+
+// Mirrors the real Gemini chat file: one JSON object with a messages[] array of
+// {id, timestamp, type: "user"|"gemini", content}. No tool errors are persisted.
+function buildGeminiSessionJson() {
+  return JSON.stringify({
+    sessionId: 's1',
+    projectHash: 'deadbeef',
+    startTime: '2026-06-01T10:00:00Z',
+    lastUpdated: '2026-06-01T10:05:00Z',
+    messages: [
+      { id: 'm1', timestamp: '2026-06-01T10:00:00Z', type: 'user', content: 'Write a tagline for the product' },
+      { id: 'm2', timestamp: '2026-06-01T10:00:05Z', type: 'gemini', content: 'Here is one.', model: 'gemini-2.5-pro', tokens: { total: 12 } },
+      { id: 'm3', timestamp: '2026-06-01T10:01:00Z', type: 'user', content: "no, that's not what I asked — try again" },
+      { id: 'm4', timestamp: '2026-06-01T10:01:05Z', type: 'gemini', content: 'Sure.', model: 'gemini-2.5-pro' },
+    ],
+  });
+}
+
+function createFakeGeminiHome() {
+  const fakeHome = mkdtempSync(join(tmpdir(), 'roast-me-gemini-'));
+  const dir = join(fakeHome, '.gemini', 'tmp', 'deadbeefhash', 'chats');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'session-2026-06-01T10-00-s1.json'), buildGeminiSessionJson(), 'utf8');
+  return fakeHome;
+}
+
+test('extract_prompts.py: codex adapter parses real envelope, detects tool error + correction', (t) => {
+  if (!PYTHON_AVAILABLE) { t.skip('python3 not available'); return; }
+
+  const data = readOutput(runExtractorRuntime(createFakeCodexHome(), 'codex'));
+  const prompts = data.prompts;
+
+  // 3 genuine user_message prompts (AGENTS.md/developer injections excluded by design).
+  assert.equal(prompts.length, 3, `expected 3 codex prompts, got ${prompts.length}`);
+
+  const first = prompts.find((p) => p.prompt_text.includes('Audit the formatter'));
+  assert.ok(first, 'first codex prompt not found');
+  assert.equal(first.runtime, 'codex');
+  assert.equal(first.model, 'gpt-5.1', 'model should come from turn_context');
+  assert.equal(first.followed_by_error, true, 'non-zero exit code → followed_by_error');
+  assert.equal(first.error_tool, 'exec_command', 'error_tool from the preceding function_call');
+  // It was corrected by the user, so it is NOT auto-recovered → it counts as impactful.
+  assert.equal(first.followed_by_correction, true, 'next user message is a correction');
+  assert.equal(first.error_was_recovered, false, 'error + correction ⇒ not auto-recovered');
+  assert.ok(data.metadata.effective_error_rate > 0, 'an un-recovered error must raise effective_error_rate');
+});
+
+test('extract_prompts.py: gemini adapter parses messages[], detects correction, no fake errors', (t) => {
+  if (!PYTHON_AVAILABLE) { t.skip('python3 not available'); return; }
+
+  const data = readOutput(runExtractorRuntime(createFakeGeminiHome(), 'gemini'));
+  const prompts = data.prompts;
+
+  assert.equal(prompts.length, 2, `expected 2 gemini prompts, got ${prompts.length}`);
+
+  const first = prompts.find((p) => p.prompt_text.includes('Write a tagline'));
+  assert.ok(first, 'first gemini prompt not found');
+  assert.equal(first.runtime, 'gemini');
+  assert.equal(first.model, 'gemini-2.5-pro', 'model captured from the assistant reply');
+  assert.equal(first.followed_by_correction, true, 'next user message is a correction');
+  // Gemini chat files do not persist tool errors — must never be invented.
+  assert.equal(first.followed_by_error, false, 'gemini format has no tool-error signal');
+  assert.equal(data.metadata.effective_error_rate, 0, 'no errors ⇒ effective_error_rate 0');
+});


### PR DESCRIPTION
Follow-up to #15. The Codex/Gemini adapters shipped with **inferred parse schemas** (and Gemini had the wrong file glob), so they extracted nothing on real installs. Rewritten against the **actual on-disk formats**, verified against live `~/.codex` and `~/.gemini` data.

## Codex — `~/.codex/sessions/**/rollout-*.jsonl`
- Real envelope `{timestamp, type, payload}`. Genuine prompts = `event_msg`/`user_message` (excludes injected AGENTS.md/developer preambles).
- Session-aware: tool failures from `function_call_output` (`exited with code N`≠0 / error markers), `error_tool` from the preceding `function_call`, corrections from the next user message.
- Model from `turn_context`/`session_meta`.
- **Smoke vs real data:** 114 sessions → 300 prompts, 145 w/ errors, 129 auto-recovered.

## Gemini — `~/.gemini/tmp/<hash>/chats/session-*.json`
- **Fixed:** files are a single JSON object (not JSONL) and end in `.json` (not `.jsonl`).
- Parses `messages[]` of `{type: user|gemini, content}`; captures the answering model; detects corrections.
- The format does not persist tool errors → `followed_by_error` stays **False** (honest, never invented).

## Plumbing
- `extract_prompts.normalise_record` now honors adapter-provided error/correction fields (was hardcoded `False`); added `ERROR_TEXT_LIMIT`.
- Shared `CORRECTION_RE` in `adapters/base.py` — one source of truth across runtimes.

## Verification
- `npm test` → **160/160** (+2 adapter tests with synthetic real-format fixtures).
- manifest unchanged (no frontmatter touched); `manifest:check` + `validate` pass.