### PR TITLE
fix(automation): quality-review fixes across the automation suite

### DIFF
--- a/skills/automation-strategy/SKILL.md
+++ b/skills/automation-strategy/SKILL.md
@@ -78,9 +78,9 @@ Pick on **billing unit first** — it's the axis that dictates cost at scale, an
 | **Billing unit** | per **execution** (whole run = 1, any # of steps); self-host = $0 | per **credit** (each module action = 1; was "operations", renamed 2025-08-27) | per **task** (every action counts) | per **user** or per **flow** (premium); bundled with many M365 plans |
 | **Best cost shape** | few long/complex flows, high volume | moderate multi-step flows | many short simple flows | teams already paying for M365 |
 | **Self-host / data residency** | **yes** — your infra, your data | no (EU/US regions only) | no | Microsoft cloud / Dataverse regions |
-| **Ecosystem fit** | technical teams, raw HTTP, code nodes | mid-market, deep per-app modules | widest app catalog (~8,000+) | **native to Microsoft 365** — Teams, SharePoint, Outlook, Dataverse |
+| **Ecosystem fit** | technical teams, raw HTTP, code nodes | mid-market, deep per-app modules | widest app catalog (~9,000+) | **native to Microsoft 365** — Teams, SharePoint, Outlook, Dataverse |
 | **Programmatic + MCP maturity** | public REST API to CRUD workflows; community MCP; strongest for code-driven ops | management API + MCP support maturing | rich API for actions + Zapier MCP to expose actions to agents — **but no public API to create Zaps** | Flow management APIs + solutions/ARM — **but no clean public API to create end-user "My flows"** |
-| **Portability** | high — export/import JSON | low — no portable export | low — no portable export | low — tied to MS solutions |
+| **Portability** | high — export/import JSON + self-hostable runtime | medium — blueprint export/import, but runs only on Make | low — no portable export | low — tied to MS solutions |
 
 **Routing shortcuts:** already living in Microsoft 365 → **Power Automate** (`../power-automate/SKILL.md`). Data must stay on your own infra, or high volume where execution-billing wins → **n8n** (`../n8n/SKILL.md`). Obscure app, non-technical owner → **Zapier** (`../zapier/SKILL.md`). Deep per-app modules, mid volume → **Make** (`../make/SKILL.md`).
 

--- a/skills/automation-strategy/references/platform-selection-matrix.md
+++ b/skills/automation-strategy/references/platform-selection-matrix.md
@@ -33,10 +33,10 @@ because it rides existing M365 licenses.
 | Axis | n8n | Make | Zapier | Power Automate |
 | --- | --- | --- | --- | --- |
 | Free / entry | self-host free; cloud Starter ≈ €20/mo | ≈ 1,000 credits free; Core ≈ $9/mo | 100 tasks/mo free; Pro ≈ $19.99/mo | bundled in many M365 plans; premium add-ons |
-| App breadth | ~1,000 nodes + generic HTTP + code | ~1,500, often deep per app | ~8,000+ — widest catalog | strong on MS + growing 3rd-party connectors |
+| App breadth | ~1,000 nodes + generic HTTP + code | ~1,500, often deep per app | ~9,000+ apps — widest catalog | strong on MS + growing 3rd-party connectors |
 | Self-host / data residency | **yes — your infra** | no (EU/US regions) | no | Microsoft cloud / Dataverse regions |
 | Who runs/maintains it | technical; you run the box | mid; visual but rich | non-technical-friendly | IT/business in a Microsoft shop |
-| Portability | high (export/import JSON) | low (no portable export) | low (no portable export) | low (tied to MS solutions) |
+| Portability | high (export/import JSON + self-hostable runtime) | medium (blueprint export/import, runs only on Make) | low (no portable export) | low (tied to MS solutions) |
 | Complex logic / code | code nodes, sandboxed by default (n8n 2.0) | functions + routers | limited (Code by Zapier) | expressions + Azure Functions escape hatch |
 
 ## Programmatic + MCP maturity (honest)

--- a/skills/harness/references/providers.yaml
+++ b/skills/harness/references/providers.yaml
@@ -3406,8 +3406,9 @@ providers:
         set -a; source "$SCRIPT_DIR/.env"; set +a
         : "${MAKE_ZONE:?MAKE_ZONE not set (e.g. eu1.make.com)}"
         : "${MAKE_API_TOKEN:?MAKE_API_TOKEN not set}"
-        NAME=$(curl -fsS "https://${MAKE_ZONE%/}/api/v2/users/me" -H "Authorization: Token $MAKE_API_TOKEN" | python3 -c 'import json,sys; print(json.load(sys.stdin)["authUser"]["name"])')
-        echo "OK — Make API reachable on $MAKE_ZONE (user: $NAME)."
+        # envelope-agnostic smoke test: -f fails on 4xx/5xx (wrong zone/token); no response-shape parsing
+        curl -fsS "https://${MAKE_ZONE%/}/api/v2/users/me" -H "Authorization: Token $MAKE_API_TOKEN" > /dev/null
+        echo "OK — Make API reachable on $MAKE_ZONE (token accepted)."
       README.md: |
         # MAKE
         Make.com (formerly Integromat). Scenarios via /api/v2; blueprint is a stringified JSON

--- a/skills/n8n/SKILL.md
+++ b/skills/n8n/SKILL.md
@@ -99,7 +99,7 @@ n8n_create_workflow     { "name": "...", "nodes": [ … ], "connections": { … 
 
 ```bash
 curl -sS -X POST "$N8N_API_URL/api/v1/workflows/$ID/execute" -H "X-N8N-API-KEY: $N8N_API_KEY"
-curl -sS -X POST "$N8N_HOST/webhook-test/my-path" -H "Content-Type: application/json" -d '{"foo":"bar"}'
+curl -sS -X POST "$N8N_API_URL/webhook-test/my-path" -H "Content-Type: application/json" -d '{"foo":"bar"}'
 ```
 ```
 n8n_test_workflow       { "id": "$ID" }


### PR DESCRIPTION
Adversarial quality review of the 5 automation skills (PR #20 follow-up). 4 findings, all fixed:

1. **automation-strategy** claimed Make has "no portable export" — contradicting the `make` skill whose core lesson is the blueprint export→mutate→import round-trip. Now: *medium — blueprint export/import, runs only on Make*.
2. **automation-strategy** said Zapier ~8,000+ apps; the `zapier` skill live-verified ~9,000+. Aligned.
3. **n8n** webhook-test curl used `$N8N_HOST` while the skill's `.env` defines `N8N_API_URL` as primary → empty-var on copy-paste. Fixed.
4. **providers.yaml** MAKE `test_connection` parsed an undocumented response envelope (`.authUser.name`) — could FAIL with valid credentials. Now envelope-agnostic (HTTP success check).

Everything else passed review: frontmatter 5/5, 0 broken links, 0 placeholders, evals over minimums with valid routes, Zapier/PA honesty prominent, irreversibility rule present in all 5.

Gates: validate ✓ · manifest:check 249 ✓ · npm test 160/160 ✓