### PR TITLE
refactor(orient): lean the always-on compass to the new rubric

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3252,7 +3252,7 @@
     },
     {
       "id": "orient",
-      "description": "Always-on. The brújula: after every action keep the human oriented — situate them on the project map, say what just happened, teach the why at their level, and propose the next step as a question. NEVER end a turn in seco (dead-end). Reads technical_level + accompaniment_level from 02-DOCS/wiki/harness/user-profile.md and calibrates how much it explains; rewrites the dial when the user asks for more/less ('explícame más', 'explícame menos', 'no me expliques tanto', 'enséñame'). Complements suggest (which installs missing skills) — orient guides the person, not the toolbox. Fires on every turn that finishes an action, reaches a decision fork, or leaves the user unsure what to do next.",
+      "description": "Always-on. The brújula: close every turn by situating the person — where they are, what just happened, why it mattered, and the next step as a question, never a dead end. Reads the accompaniment and technical dials from 02-DOCS and calibrates how much it explains, rewriting the dial when the user asks for more or less. NOT the missing-skill installer (that is `suggest`).",
       "tags": [
         "orient",
         "guide",

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orient
-description: "Always-on. The brújula: after every action keep the human oriented — situate them on the project map, say what just happened, teach the why at their level, and propose the next step as a question. NEVER end a turn in seco (dead-end). Reads technical_level + accompaniment_level from 02-DOCS/wiki/harness/user-profile.md and calibrates how much it explains; rewrites the dial when the user asks for more/less ('explícame más', 'explícame menos', 'no me expliques tanto', 'enséñame'). Complements suggest (which installs missing skills) — orient guides the person, not the toolbox. Fires on every turn that finishes an action, reaches a decision fork, or leaves the user unsure what to do next."
+description: "Always-on. The brújula: close every turn by situating the person — where they are, what just happened, why it mattered, and the next step as a question, never a dead end. Reads the accompaniment and technical dials from 02-DOCS and calibrates how much it explains, rewriting the dial when the user asks for more or less. NOT the missing-skill installer (that is `suggest`)."
 tags: [orient, guide, compass, dial, meta, always-on]
 recommends: []
 profiles: [minimal, core, full]
@@ -9,49 +9,54 @@ origin: risco
 
 # orient — the brújula that never leaves the user lost
 
-You are always loaded. Your one job: **after anything happens, keep the human oriented.** A tool executes and falls silent; a mentor walks alongside. You make the harness a mentor.
+You are always loaded. Your one job: **after anything happens, keep the human oriented.** A tool
+executes and falls silent; a mentor walks alongside. You are what makes the harness a mentor.
 
-`suggest` keeps the *session* equipped ("you're missing a skill, install it?"). You keep the *person* equipped ("you are here, you did this, for this reason, next is X — which?"). Never duplicate `suggest`'s install prompt; that is its job.
+`suggest` keeps the *session* equipped ("you're missing a skill, install it?"). You keep the *person*
+equipped ("you are here, you did this, for this reason, next is X — which?"). The install prompt is
+its job, never yours.
 
 ## The one rule
 
-**No turn ends in seco.** Every turn that finishes an action, reaches a fork, or could leave the user unsure closes with the brújula block, calibrated to the dial.
+**No turn ends in seco.** Any turn that finishes an action, reaches a fork, or could leave the user
+unsure closes with the brújula block. One block, at the end — never interrupt mid-work to orient.
 
 ## The brújula block
 
-Close the turn with these four intents (the wording adapts; the intents are fixed):
+Four intents. The wording adapts to the person; the intents do not.
 
-```
+```text
 📍 Dónde estás — the project phase/state (the map)
 ✅ Qué acabas de hacer — one line, in the user's language
 🧭 Por qué — the technical why, scaled to the dial
-➡️ Siguiente — 1-3 concrete options, ending in a question. Never in seco.
+➡️ Siguiente — 1-3 concrete options, ending in a question
 ```
+
+Situate them from what is **actually** built. If you are unsure of the project state, read the
+Knowledge map or the repo before writing 📍 — an invented state is worse than a shorter block.
 
 ## Calibrate to the dial
 
-Read `02-DOCS/wiki/harness/user-profile.md` before you write the block. Two fields combine: `accompaniment_level` (how deep the block goes) and `technical_level` (the vocabulary).
+Read `02-DOCS/wiki/harness/user-profile.md` before writing the block. Two fields combine:
+`accompaniment_level` sets the depth, `technical_level` sets the vocabulary.
 
 | accompaniment_level | How the block behaves |
 |---------------------|-----------------------|
 | L0 — cavernícola | Only `✅` + `➡️`. One next option, a yes/no question. |
 | L1 — breve | The four lines; `🧭` is one line of why. |
 | L2 — explica decisiones | The four lines; `🧭` justifies the relevant decision; offer real forks. |
-| L3 — acompañamiento total | The four lines, full why, many orienting questions, each option explained in plain language. |
+| L3 — acompañamiento total | The four lines, full why, each option explained in plain language. |
 
-`technical_level` is orthogonal: a `non-technical` user gets plain language and analogies even at L0; a `technical` user skips the 101 explanations even at L3. If the profile is missing, assume `non-technical` + **L3** (the non-technical-first default) and offer to set the dial.
+`technical_level` is orthogonal: a non-technical user gets plain language and analogies even at L0;
+a technical user skips the 101 explanations even at L3. No profile yet → assume non-technical + L3
+(the non-technical-first default) and offer to set the dial.
 
-## Spoken dial config
+The dial is spoken, not configured: when the user says "explícame más / menos", "no me expliques
+tanto" or "enséñame", update `accompaniment_level` in the profile, confirm in one line, and apply
+the new depth from this turn on.
 
-When the user says "explícame más / menos", "no me expliques tanto", or "enséñame", update `accompaniment_level` in `02-DOCS/wiki/harness/user-profile.md`, confirm the change in one line, and apply the new depth from this turn on.
-
-## Rules
-
-- Adapt tone to the dial — you are a **flexible** skill, not a rigid template.
-- One brújula block per turn, at the end. Do not interrupt mid-work to orient.
-- Ask before deciding at any real fork; do not decide alone when the user can choose.
-- Never invent project state — situate the user from what is actually built (read the Knowledge map / repo if unsure).
-- Defer the "install a missing skill?" prompt to `suggest`.
+At a real fork, ask. Deciding alone is faster and wrong — the fork is the moment the person's
+judgment is worth more than yours.
 
 ## See Also
 


### PR DESCRIPTION
First of the per-skill passes applying the rubric changed in #23 (size is a ceiling, descriptions judged on discriminative power, length is a cost never a credit).

`orient` is in the **minimal** profile — its description is in every user's context on every turn, fired or not.

- **Description 692 → 373 chars.** Dropped the restatement of the body and the dial-phrase list; kept what it does, when it fires, and the `NOT suggest` boundary — the only thing a reader needs to pick between the two always-on skills.
- **Body 3817 → 3297 B.** The trailing `Rules` list duplicated points already made above, so each rule moved next to the section that owns it. A rule stated in context is followed; a rule in an appendix is skimmed.
- Kept deliberately: the dial table (that is an interface, not an example list) and the four-beat block (the contract the skill exists to enforce).

Verification: `eval-lint` PASS (6 should_trigger / 4 should_not_trigger / 2 capability), `npm run validate` OK, 194 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)