### PR TITLE
chore: gitignore .claude/, the wiring rsc generates for the local machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ node_modules/
 .env.local
 *.log
 .rsc/
+# .claude/ is the same kind of thing as .rsc/: wiring rsc GENERATES for this machine —
+# settings.json with absolute paths, symlinked skill dirs, the installed developer agent.
+# Left untracked-but-not-ignored it also makes rsc's own ship-guard treat every rsc-wired
+# repo as having an abandoned diff, which blocks switching branches.
+.claude/
 
 # Per-tool ignores already exist inside each skill's _TEMPLATE/.gitignore.
 


### PR DESCRIPTION
`.claude/` holds the same kind of thing as `.rsc/`, which is already ignored: a `settings.json` full of absolute machine paths, symlinked skill directories, and the installed `developer` agent. Nothing under it has ever been tracked (`git ls-files .claude` is empty).

Beyond the noise, leaving it untracked-but-not-ignored has a concrete cost: rsc's own **ship-guard counts it as uncommitted work**, so any rsc-wired repo looks like it has an abandoned diff and refuses to switch branches until you create `.rsc/.no-ship-guard`. Found the hard way while moving between branches on this repo.

194 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)