### PR TITLE
refactor(implement): trim the description; the body already meets the new rubric

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2280,7 +2280,7 @@
     },
     {
       "id": "implement",
-      "description": "Use when an approved plan and task list exist and it is time to turn them into working, tested code — the SDD phase AFTER analyze and BEFORE verify. Enforces TDD discipline: a test fails before the code that makes it pass. Triggers: 'implement the plan', 'build out the tasks', 'start coding this feature', 'work through the task list', 'execute the implementation', 'write the code for this spec', 'do task 3', 'continue implementing', 'red-green-refactor this', 'implement with tests first'. Delegates concrete test tooling to the stack skill (fastapi/go/nextjs/flutter) and fans independent tasks out via `parallel`. NOT spec writing (that is `specify`), NOT planning (that is `plan`), NOT the final lint/test/audit gate (that is `verify`).",
+      "description": "Use when an approved plan and task list exist and it is time to turn them into working, tested code — the SDD phase after `analyze` and before `verify`. Enforces TDD: a failing test comes before the code that makes it pass, one task at a time, appended to a progress ledger that survives compaction. Delegates test tooling to the stack skill and fans disjoint tasks out via `parallel`. NOT spec writing (that is `specify`), NOT planning (that is `plan`), NOT the final lint/test/audit gate (that is `verify`).",
       "tags": [
         "sdd",
         "implement",

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: "Use when an approved plan and task list exist and it is time to turn them into working, tested code — the SDD phase AFTER analyze and BEFORE verify. Enforces TDD discipline: a test fails before the code that makes it pass. Triggers: 'implement the plan', 'build out the tasks', 'start coding this feature', 'work through the task list', 'execute the implementation', 'write the code for this spec', 'do task 3', 'continue implementing', 'red-green-refactor this', 'implement with tests first'. Delegates concrete test tooling to the stack skill (fastapi/go/nextjs/flutter) and fans independent tasks out via `parallel`. NOT spec writing (that is `specify`), NOT planning (that is `plan`), NOT the final lint/test/audit gate (that is `verify`)."
+description: "Use when an approved plan and task list exist and it is time to turn them into working, tested code — the SDD phase after `analyze` and before `verify`. Enforces TDD: a failing test comes before the code that makes it pass, one task at a time, appended to a progress ledger that survives compaction. Delegates test tooling to the stack skill and fans disjoint tasks out via `parallel`. NOT spec writing (that is `specify`), NOT planning (that is `plan`), NOT the final lint/test/audit gate (that is `verify`)."
 tags: [sdd, implement, code]
 recommends: [verify]
 profiles: [core, full]


### PR DESCRIPTION
Fourth per-skill pass. Reviewed `implement` against the rubric from #23 — **most of the body passes as written**, which is worth recording as much as a big diff would be.

Two things I expected to cut and deliberately did not:

- **`Anti-patterns → STOP` stays.** The rubric *requires* an anti-patterns table (dimension 3). It is a different animal from the rationalization tables removed from `init` and `harness`: those restated rules stated directly above them, this one names concrete failure modes with their fixes.
- **The accompaniment-dial table stays.** Unlike the one removed from `harness`, it is not a re-teaching of the dial — it says what to *show at each implementation checkpoint*, which is specific to this phase and documented nowhere else.

**Description 743 → 509 chars.** Trigger list out; the progress-ledger behaviour in. Surviving compaction is the non-obvious property that distinguishes this phase, and it was missing from a description that had room for ten trigger phrases — a good illustration of what the old rubric was buying us.

Verification: `eval-lint` PASS (6 should_trigger / 5 should_not_trigger / 1 capability), `npm run validate` OK, 194 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)