### PR TITLE
refactor(accessibility): drop trigger-phrase list from description, cut duplicated reference links

### DIFF
--- a/skills/accessibility/SKILL.md
+++ b/skills/accessibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: accessibility
-description: "Use when making a web UI conform to WCAG 2.2 Level AA — fixing axe-core violations, a low Lighthouse a11y score, adding keyboard support, focus management, ARIA roles/labels, skip links, live regions, accessible names, or checking contrast and tap-target size. Triggers: 'make this accessible', 'fix the contrast', 'keyboard navigation is broken', 'screen reader can't read this', 'axe says button-name / color-contrast', 'the modal doesn't trap focus', 'tab order is wrong', 'our tap targets are smaller than 24px', 'fes-ho accessible', 'el lector de pantalla no lee los errores'. NOT general performance / LCP tuning (that is performance), NOT setting up the Jest/RTL test runner itself (that is testing-web)."
+description: "Use when making a web UI conform to WCAG 2.2 Level AA — axe-core or Lighthouse a11y violations, keyboard operability, focus management, ARIA roles/names/live regions, contrast, tap-target size. NOT palette or visual intent (that is `design`), NOT test-runner setup (that is `testing-web`), NOT LCP/page-speed (that is `performance`)."
 tags: [wcag, accessibility, a11y, aria, axe-core]
 recommends: [testing-web, e2e-testing, design, react, performance]
 origin: risco
@@ -76,7 +76,7 @@ Everything a mouse can do, a keyboard must do.
 2. **Trap focus** inside while open — Tab from the last element wraps to the first.
 3. **Escape closes**, and **focus returns to the trigger** that opened it.
 
-Composite widgets (menus, tabs, grids) use **roving tabindex**: one element is `tabindex="0"`, the rest `-1`, arrow keys move the `0`. Full keyboard tables per pattern → `references/aria-patterns.md`.
+Composite widgets (menus, tabs, grids) use **roving tabindex**: one element is `tabindex="0"`, the rest `-1`, arrow keys move the `0`. Full keyboard tables per pattern — modal, disclosure, tabs, combobox, menu, toast → `references/aria-patterns.md`.
 
 ## Visible focus & the WCAG 2.2 deltas
 
@@ -144,7 +144,7 @@ Mental model: **Name, Role, Value.** Every custom control needs an accessible *n
 
 ## Automate it (versioned, 2026-06-02)
 
-Three layers — each catches what the cheaper one can't. Restate the ceiling: **automation ≈ 57% coverage**, the rest is manual.
+Three layers — each catches what the cheaper one can't.
 
 **Lint (static, JSX only) — `eslint-plugin-jsx-a11y` 6.10.2.** Catches missing `alt`, label-less inputs, positive `tabindex`, invalid roles, at edit time.
 
@@ -190,7 +190,7 @@ Do these by hand before you call it done:
 - [ ] **`prefers-reduced-motion`** honored — no autoplay parallax/animation that ignores it.
 - [ ] **Alt text is meaningful, not decorative-as-content** — informative images describe; decorative images use `alt=""`.
 
-Full AA checklist grouped by POUR, with the per-item auto/manual split → `references/wcag22-checklist.md`.
+Full AA checklist grouped by POUR, with the per-item auto/manual split and the 6 new 2.2 criteria flagged → `references/wcag22-checklist.md`.
 
 ## Anti-patterns
 
@@ -207,10 +207,8 @@ Full AA checklist grouped by POUR, with the per-item auto/manual split → `refe
 | Shipping on a green axe run                    | Covers ~57%; keyboard/SR/cognitive untested              | run the manual checklist                            |
 | Autoplaying motion, no reduced-motion guard    | Triggers vestibular disorders (2.3.3)                    | gate behind `prefers-reduced-motion`                |
 
-## Where to go next
+## Hand off to
 
-- Full WCAG 2.2 AA checklist (POUR, auto/manual tags, the 6 new criteria flagged) → `references/wcag22-checklist.md`
-- Copy-ready accessible patterns with keyboard tables (modal, disclosure, tabs, combobox, menu, toast) → `references/aria-patterns.md`
 - Test harness, render setup, fixtures, CI runner mechanics → `../testing-web/SKILL.md` (this skill supplies the a11y *assertions* that run inside it)
 - Full browser-driven flow orchestration → `../e2e-testing/SKILL.md`
 - Visual intent, color palette, spacing scale → `../design/SKILL.md` (this skill checks the contrast/target-size *outcome*, not the aesthetic)


### PR DESCRIPTION
Context-engineering pass on `skills/accessibility/` against the updated `scripts/skill-rubric.md`. **No technical substance changed** — every WCAG criterion number, contrast ratio, library version, code sample and anti-pattern row is byte-identical.

This skill already largely met the rubric (218 lines against a 400 ceiling, both `references/` files linked inline, an Anti-patterns table present, no "Iron rules"/"Rationalizations" banks to remove). The diff is correspondingly small and honest: 5 insertions, 7 deletions.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 711 | **333** (target ≤350, limit 1024) |
| Body bytes | 14280 | **13653** |
| Body lines | 218 | 216 |
| `eval-lint` | — | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

## Removed

- **The `Triggers: '...'` phrase list** — 10 quoted trigger phrases across English, Spanish and Catalan. The model matches by meaning; the enumeration was pure per-turn context cost with zero discriminative value. This is the bulk of the 711 → 333 reduction.
- **"Restate the ceiling: automation ≈ 57% coverage, the rest is manual"** in the Automate section. The loop at the top of the skill already states the 57%/43% split, and the "never ship on a green axe run alone" decision rule already governs it. A third restatement taught nothing new.
- **The two `references/` bullets in the tail link list**, which duplicated links already present inline at the point of use. The detail they carried (the pattern roster; the "6 new 2.2 criteria flagged" note) was folded into those inline mentions rather than dropped, so nothing about *when to open either file* was lost. Both reference files remain linked from the body.
- Renamed **"Where to go next" → "Hand off to"**, which is what the section now is: sibling delegation only.

## Deliberately kept

- **The Anti-patterns table** — the rubric requires one.
- **The Rule 0 native-vs-ARIA table, the hiding-technique table, and the overlay focus-management trio.** These are decision tables where the flow genuinely branches, not prose restatements.
- **"Decision rule: never ship on a green axe run alone."** It reads like a rule-bank line, but it is the single load-bearing judgment call in the skill, it already sits next to the step it governs, and it justifies itself with the 57% figure rather than shouting NON-NEGOTIABLE.
- **The manual checklist.** It is the ~43% no scanner can cover and is this phase's own artifact, not a duplicate of the automated layers.
- **A third `NOT` boundary (`performance`)** beyond the two the rubric asks for. All three targets — `design`, `testing-web`, `performance` — appear as `should_not_trigger` routes in `evals/cases.yaml`, so each is a real observed confusion rather than padding. All three are verified real skills under `skills/`.

## Verification

- `bash scripts/eval-lint.sh | grep '^accessibility'` → `PASS (should_trigger=7, should_not_trigger=5, capability=1)`
- Description 333 chars, parses as single-line quoted YAML, third person, `Use when` lead.
- Both `references/aria-patterns.md` and `references/wcag22-checklist.md` linked from the body.
- All 5 `../<sibling>/SKILL.md` links (design, e2e-testing, nextjs, react, testing-web) resolve to real skills.
- `manifest.json` deliberately untouched — it is derived and regenerated by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
