### PR TITLE
refactor(analyze): cut the description 940→434 chars and drop redundant rule banks

### DIFF
--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze
-description: "Use when the spec, plan and task list are written and you want a last consistency check BEFORE any code is touched — the pre-implementation GATE of the rsc-sdd chain. It cross-reads constitution vs spec vs plan vs tasks and reports gaps, contradictions, duplication, ambiguity and scope drift, mapping every artifact to the requirements it claims to satisfy. Report-only: it never edits artifacts and never writes code; the user decides each resolution. Triggers: 'analyze', 'analiza la spec antes de implementar', 'cross-check constitution spec plan tasks', 'consistency gate', 'are spec and plan aligned', 'did we miss any requirement', 'scope drift check', 'gap analysis before coding', 'is the plan complete', 'sanity-check before implement', 'coverage of requirements'. NOT clarifying a single spec (that is `clarify`), NOT writing the plan or tasks, NOT running tests/lint (that is `verify`), NOT root-causing a bug (that is `debug`)."
+description: "Use when constitution, spec, plan and tasks all exist and you want them cross-read against each other before any code is written — the rsc-sdd pre-implementation gate. Reports coverage gaps, contradictions, duplication, ambiguity and scope drift; edits nothing. NOT the task breakdown (that is `tasks`), NOT the coding (that is `implement`), NOT the post-code test gate (that is `verify`), NOT resolving ambiguity (that is `clarify`)."
 tags: [sdd, analyze, consistency]
 recommends: [implement]
 profiles: [core, full]
@@ -9,51 +9,26 @@ origin: risco
 
 # Analyze — the pre-implementation consistency gate
 
-You have a **constitution**, a **spec**, a **plan** and a **task list**. Four artifacts written at four different moments, by a mind that drifted a little each time. `analyze` is the last checkpoint before the first line of code: it reads all four *against each other* and surfaces where they disagree. It is the cheapest place in the whole chain to catch a problem — a contradiction found here costs a sentence; the same contradiction found mid-implement costs a rewrite.
+You have a **constitution**, a **spec**, a **plan** and a **task list**. Four artifacts written at four different moments, by a mind that drifted a little each time. `analyze` reads all four *against each other* and surfaces where they disagree. It is the cheapest place in the whole chain to catch a problem — a contradiction found here costs a sentence; the same contradiction found mid-implement costs a rewrite.
 
-This is the **sixth phase** of the rsc-sdd chain (`constitution → specify → clarify → plan → tasks → analyze → implement`). It is a **gate, not a worker**: it produces a report and stops. It does not patch the spec, does not reorder tasks, does not touch code. The user reads the findings and decides what to fix, and which phase to send each fix back to.
+Sixth phase of the rsc-sdd chain (`constitution → specify → clarify → plan → tasks → analyze → implement`); the method itself lives in `../sdd/SKILL.md`. It is a **gate, not a worker**: it produces a report and stops. The user reads the findings and decides what to fix, and which phase to send each fix back to.
 
-## The one rule that defines this skill
+**Report only. Resolve nothing.** Never edit the constitution, spec, plan or tasks; never open a code file to "just fix it"; never silently reconcile a contradiction by picking a side. This one is absolute because a gate that quietly fixes things stops being a gate: the user never learns the spec was wrong, the plan built on the old assumption stays stale, and the "consistency check" has manufactured a new inconsistency. Name the conflict, show both sides with locations, propose where it should be resolved, hand the decision back.
 
-**Report only. Resolve nothing.** `analyze` never edits the constitution, spec, plan or tasks, never opens a code file to "just fix it", never silently reconciles a contradiction by picking a side. It names the conflict, shows both artifacts with their locations, proposes where it should be resolved, and hands the decision back. The moment you feel the urge to edit an artifact, you have left this skill — stop and route the fix to the phase that owns it.
+**Model tier: `heavy`** (adversarial cross-reading). Resolve and apply it per `../sdd/references/model-routing.md`; routing is off unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`.
 
-Why so strict? Because a gate that quietly fixes things stops being a gate. If `analyze` patches the spec on its own, the user never learns the spec was wrong, the plan built on the old assumption stays stale, and the "consistency check" has manufactured a new inconsistency. The value is the *honest report*, not the patch.
+**Accompaniment dial.** Read `02-DOCS/wiki/harness/user-profile.md` before reporting — default to **L2** and say the harness has not gauged the user yet if there is no profile. The dial flexes how the report reads, never what gets checked; the six analyses always run in full.
 
-## When to use / when NOT to use
-
-Use when:
-
-- The plan and tasks exist and you are about to start implementing — run this first, every time.
-- A spec or plan changed after the others were written and you want to re-check alignment.
-- Implementation stalled because the artifacts seem to contradict each other.
-- You want a requirements-coverage map: which task satisfies which spec requirement, and what is orphaned.
-
-Do NOT use when (route elsewhere):
-
-- A single spec is fuzzy and you need to ask the user questions and bake answers in → `clarify` (analyze reports the ambiguity; clarify resolves it).
-- The plan or tasks don't exist yet → write them first (`plan`, then `tasks`).
-- You want to run lint/types/tests/acceptance after coding → `verify` (post-implementation gate; analyze is pre-implementation).
-- A test is failing or behavior is wrong → `debug`.
-- You intend to fix what you find right now → that is `implement`/`clarify`/`plan`/`tasks` work, not analyze. Analyze only reports.
-
-## Model tier — `heavy` (opt-in routing)
-
-This phase's default model tier is **`heavy`** — it is the adversarial consistency gate across constitution ↔ spec ↔ plan ↔ tasks. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
-
-## Read the accompaniment dial first
-
-Before reporting, read `02-DOCS/wiki/harness/user-profile.md` for the technical + accompaniment level (the harness dial, L0..L3). It shapes how the report reads — not what gets checked. The six analyses always run in full; verbosity flexes:
-
-- **L0** — the finding table only: severity, the two artifacts, the conflict in one line. No prose.
-- **L1** — the table plus a one-line *why it matters* per CRITICAL/HIGH finding.
-- **L2** — the table plus, per finding, the recommended resolution phase and the trade-off of leaving it.
-- **L3** — full walk-through: for each finding, quote both sides, explain the consequence at implement time in plain language, and lay out the options so a non-technical user can choose.
-
-If no profile exists, default to L2 and note that the harness has not gauged the user yet.
+| Dial | The report renders as |
+| --- | --- |
+| L0 | Finding table only: severity, the two artifacts, the conflict in one line. No prose. |
+| L1 | + a one-line *why it matters* per CRITICAL/HIGH finding. |
+| L2 | + per finding, the recommended resolution phase and the trade-off of leaving it. |
+| L3 | + full walk-through: quote both sides, explain the consequence at implement time in plain language, lay out the options so a non-technical user can choose. |
 
 ## Inputs — locate the four artifacts
 
-Read all four before analyzing. The rsc-sdd artifacts live under `02-DOCS/wiki/sdd/` (the harness Karpathy-wiki convention), indexed from `02-DOCS/wiki/index.md` (the Knowledge map; root `CLAUDE.md` keeps only a short pointer to it):
+Read all four before analyzing. The rsc-sdd artifacts live under `02-DOCS/wiki/sdd/`, indexed from `02-DOCS/wiki/index.md` (the Knowledge map; root `CLAUDE.md` keeps only a short pointer to it):
 
 | Artifact | Canonical location | Role in the check |
 | --- | --- | --- |
@@ -110,32 +85,22 @@ Produce a single consistency report:
 1. **Verdict line** — `GATE: PASS` (zero CRITICAL/HIGH) or `GATE: BLOCKED` (one or more CRITICAL/HIGH), with the counts.
 2. **Coverage map** — the table above.
 3. **Findings table** — `# | Severity | Type | Artifact A (loc) | Artifact B (loc) | Conflict | Resolve in (phase)`.
-4. **Recommended routing** — group fixes by the phase that owns them (`clarify` for spec ambiguity, `plan` for missing architecture, `tasks` for a missing done-check, `constitution` if a principle itself is wrong).
+4. **Recommended routing** — group fixes by the phase that owns them (`clarify` for spec ambiguity, `plan` for missing architecture, `tasks` for a missing done-check, `constitution` if a principle itself is wrong). If findings pour in across all six checks, the artifacts diverged badly — recommend re-running `clarify`/`plan` before a line-by-line analyze is even useful.
 
-Write the report to `02-DOCS/wiki/sdd/analysis/<slug>.md` (create the dir if absent) and index it in `02-DOCS/wiki/index.md` (the Knowledge map; root `CLAUDE.md` keeps only a short pointer) under the `sdd/` topic, so the next phase and the harness can find it. It is an OKF v0.1 wiki article: open it with YAML frontmatter carrying a non-empty `type:` (use `type: analysis`), a `timestamp` in ISO 8601, and standard markdown links — never wikilinks. The report is the artifact analyze owns — it is the *only* thing analyze writes. Per-run point-in-time; overwrite on re-run, the wiki keeps history.
+Write the report to `02-DOCS/wiki/sdd/analysis/<slug>.md` (create the dir if absent) and index it in `02-DOCS/wiki/index.md` under the `sdd/` topic, so the next phase and the harness can find it. It is an OKF v0.1 wiki article: open it with YAML frontmatter carrying a non-empty `type:` (use `type: analysis`), a `timestamp` in ISO 8601, and standard markdown links — never wikilinks. The report is the artifact analyze owns — it is the *only* thing analyze writes. Per-run point-in-time; overwrite on re-run, the wiki keeps history.
 
-Adapt the rendered verbosity to the dial (L0 = table only; L3 = full walk-through). Do not log a decision to `decisions.md` — analyze decides nothing; the phase that resolves the finding logs its own decision.
+Render it at the dial's verbosity. Do not log a decision to `decisions.md` — analyze decides nothing; the phase that resolves the finding logs its own decision.
 
-## Anti-patterns → STOP
+## Anti-patterns
 
-| Rationalization | Reality / Fix |
+| Anti-pattern | Why it breaks the gate / do instead |
 | --- | --- |
-| "This contradiction is trivial, I'll just fix the spec myself" | Then you are `clarify`/`plan`, not `analyze`. Report it; the user resolves. A gate that edits stops being a gate. |
-| "No CRITICAL findings, so I'll start coding from here" | Analyze never transitions to code. Pass the verdict to `implement`; that phase starts the work. |
-| "The plan adds caching the spec didn't mention — obviously a good idea, I'll allow it" | That is DRIFT. Flag it. Good ideas still need the spec amended (user's call), or they are silent scope creep. |
-| "I'll only check coverage; contradictions are rare" | Run all six analyses every time. The one you skip is the one that bites at implement time. |
-| "The spec is vague but I can guess what they meant" | Guessing defeats the gate. Mark AMBIGUOUS and route to `clarify`; do not encode your guess. |
-| "I'll fold the findings straight into the task list to save a step" | No. Editing tasks is the `tasks` phase. Report, route, hand back. |
-| "Constitution says Postgres but plan picked Mongo for good reasons — I'll side with the plan" | The constitution wins by definition. Flag CRITICAL. If the principle is wrong, that is a `constitution` change the user makes, not a quiet override here. |
-| "I read the spec and tasks; the constitution is boilerplate, skip it" | The constitution is analysis #1 and the highest severity. Never skip it. |
-
-## Red flags — stop and report instead of analyzing
-
-- An artifact is missing (no plan, no tasks) → say which, name the phase, do not fabricate it.
-- Multiple specs match the slug → ask which feature; don't analyze the wrong one.
-- You catch yourself opening a source file → you have left the gate; close it.
-- Findings are pouring in across all six checks → the artifacts diverged badly; recommend the user re-runs `clarify`/`plan` before a line-by-line analyze is even useful.
+| Fixing a "trivial" contradiction in the spec yourself | Then you are `clarify`/`plan`/`tasks`, not `analyze`. Report it; the user resolves. |
+| Starting to code because nothing CRITICAL turned up | Analyze never transitions to code. Hand the verdict to `implement`; that phase starts the work. |
+| Waving through plan work the spec never asked for because it's obviously a good idea | That is DRIFT. Flag it. Good ideas still need the spec amended (user's call), or they are silent scope creep. |
+| Siding with the plan when it contradicts the constitution | The constitution wins by definition — flag CRITICAL. If the principle itself is wrong, that is a `constitution` change the user makes, not a quiet override here. |
+| Guessing what a vague requirement meant | Guessing defeats the gate. Mark AMBIGUOUS and route to `clarify`; do not encode your guess. |
 
 ## Next in the chain
 
-When the verdict is `GATE: PASS` (or the user has consciously accepted the remaining MEDIUM/LOW findings), proceed to **`implement`** — execute the tasks with TDD discipline, delegating concrete test tooling to the relevant stack skill (`fastapi`, `nextjs`, `go`, `flutter`, `postgresdb`). If the verdict is `GATE: BLOCKED`, route each CRITICAL/HIGH finding to its owning phase (`clarify`, `plan`, `tasks`, or `constitution`), let the user resolve, then re-run `analyze`. The gate only opens once.
+On `GATE: PASS` (or once the user consciously accepts the remaining MEDIUM/LOW findings), proceed to **`implement`** — execute the tasks with TDD discipline, delegating concrete test tooling to the relevant stack skill (`fastapi`, `nextjs`, `go`, `flutter`, `postgresdb`). On `GATE: BLOCKED`, route each CRITICAL/HIGH finding to its owning phase (`clarify`, `plan`, `tasks`, or `constitution`), let the user resolve, then re-run `analyze`. The gate only opens once.


### PR DESCRIPTION
Context-engineering pass on `skills/analyze/SKILL.md` against the updated `scripts/skill-rubric.md`. Phase semantics preserved exactly — `analyze` is still the report-only pre-implementation gate, still runs the same six analyses, still writes the same report.

## Numbers

| | Before | After |
|---|---|---|
| `description` | 940 chars | **434 chars** |
| SKILL.md | 13,958 bytes / 141 lines | **10,377 bytes / 106 lines** |
| eval-lint | — | **PASS** (`should_trigger=7, should_not_trigger=6, capability=1`) |

## Description

Deleted the 11-phrase `Triggers: '...'` keyword list — the model matches by meaning, and this is a `core`-profile skill, so that list was paid for in context on every turn it is installed, invoked or not. Rebuilt as what/when plus a four-way discriminative boundary against real siblings: `tasks` (the phase before), `implement` (the phase after), `verify` (the post-code gate people confuse with this pre-code one) and `clarify` (which *resolves* the ambiguity analyze only *reports*).

## Removed

- **"When to use / when NOT to use"** (10 lines) — the description now carries the boundary; the missing-artifact case was already handled in Inputs.
- **"Red flags — stop and report"** (6 lines) — three of four bullets restated Inputs or the report-only rule. The one genuinely new bullet (findings pouring in across all six checks → re-run `clarify`/`plan` first) was folded into Output §4, next to the routing it governs.
- **Model-routing mechanics paragraph** — `sdd` owns that method; replaced by one line naming this phase's tier (`heavy`) and pointing at `../sdd/references/model-routing.md`.
- **Three of eight anti-pattern rows** that duplicated other rows or restated "run all six analyses".
- **The standalone "The one rule that defines this skill" heading** — the rule is kept, compressed into one paragraph next to the chain position, saying *why* it is absolute instead of shouting NON-NEGOTIABLE.

## Deliberately kept

- Report-only discipline; the six analyses including the carrier-completeness / isolated-implementer check; the requirement-coverage map; the severity scale; the report + OKF v0.1 output contract; the next-in-chain hand-off. Wording unchanged where it was already tight — this is a context pass, not a content rewrite.
- **Anti-patterns table** (rubric requires one), reframed from rationalization→reality to anti-pattern→why it breaks the gate.
- **The accompaniment dial**, compressed to a pointer plus an L0..L3 table: that L-level mapping is *this* phase's report-rendering contract (asserted by the capability eval), not a restatement of what `init` owns.

## Verification

- `bash scripts/eval-lint.sh | grep '^analyze'` → `PASS`
- description 434 chars (≤1024 hard limit), parses as single-line quoted YAML
- all four sibling links resolve (`../sdd/SKILL.md`, `../sdd/references/model-routing.md`, `../plan/references/plan-template.md`, `../tasks/SKILL.md`)
- no `references/` dir in this skill, so nothing is left unlinked
- `manifest.json` untouched (derived; orchestrator regenerates)

Note for the orchestrator: `analyze` has **no result-envelope block** — it never had one, unlike `specify`/`tasks`/`implement`/`verify`/`ship`. Adding one would be a content change, so it was left out of this pass; worth a follow-up if the chain expects envelopes from every phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
