### PR TITLE
refactor(automation-strategy): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/automation-strategy/SKILL.md
+++ b/skills/automation-strategy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: automation-strategy
-description: "Use when deciding whether a process is worth automating, choosing an automation platform, sizing ROI / build-vs-buy, designing an automation strategy, or diagnosing why a fleet of automations keeps breaking — the discipline layer that runs BEFORE anyone builds. Triggers: 'should we automate this?', 'is this worth automating', 'n8n vs Make vs Zapier vs Power Automate — which do we pick', 'custom script or no-code platform', \"what's the ROI on automating X\", 'design our automation strategy', 'our automations keep breaking', 'automating this cost more than it saved', '¿merece la pena automatizar esto?', 'qué plataforma de automatización elegimos'. NOT building the flow on a platform (design + importable artifact is automation-flows; driving a live platform API/MCP is the n8n / make / zapier / power-automate skills), NOT a typed API client with auth/pagination/backoff (api-connector-builder), NOT the inbound endpoint that receives webhook events in your app (webhooks)."
+description: "Use when deciding whether a process is worth automating, sizing ROI and build-vs-buy, choosing an automation platform, or diagnosing why a fleet of automations keeps breaking — the decision layer before anyone builds. NOT building the flow (that is `automation-flows`, or `n8n` / `make` / `zapier` / `power-automate` to drive a live platform)."
 tags: [automation, strategy, roi, build-vs-buy, platform-selection, orchestration, idempotency, n8n, make, zapier, power-automate]
 recommends: [automation-flows, n8n, make, zapier, power-automate]
 profiles: [core, full]
@@ -110,14 +110,6 @@ These are the guarantees every automation must meet regardless of platform. This
 | **Hidden single point of failure** | One personal token / one undocumented flow everyone depends on | Service accounts, documented dependencies, no personal-account glue |
 | **No owner** | Orphaned automations rot; nobody notices the break or knows how it works | Name an owner + a one-page runbook per automation |
 | **Choosing platform by familiarity** | Bill 10× higher than the right billing unit; "our automation bill exploded" | Pick by billing unit for your run shape (§3) |
-
-## Related skills
-
-- `../automation-flows/SKILL.md` — **build layer**: designs the flow and emits the importable artifact once this skill has decided *whether* and *where*. Strategy decides; automation-flows designs.
-- `../n8n/SKILL.md`, `../make/SKILL.md`, `../zapier/SKILL.md`, `../power-automate/SKILL.md` — **operate layer**: drive that platform's live API/MCP to CRUD, activate, and run. Route here after §3.
-- `../api-connector-builder/SKILL.md` — when the answer is custom code, not a platform: typed client with auth/pagination/backoff.
-- `../webhooks/SKILL.md` — when you need to *receive* events in your own app (this skill treats webhooks as triggers, it doesn't build the receiver).
-- `../secure-coding/SKILL.md` — secrets/rotation engineering behind the orchestration policy in §4.
 
 ## Checklist
 


### PR DESCRIPTION
## Metrics

| | before | after | Δ |
| --- | --- | --- | --- |
| `description` chars | 981 | **343** | −638 (−65%) |
| body bytes | 14961 | **13510** | −1451 (−10%) |
| body lines | 131 | **123** | −8 |

Target for the description is ≤350 chars; hard limit 1024. Body ceiling is 400 lines.

## What went

- **The `Triggers:` phrase list** (10 quoted prompts, EN + ES). The description sits in context on every turn the skill is installed, invoked or not — keyword lists are pure cost, and the model routes by meaning anyway.
- **Two of the three `NOT` clauses.** `api-connector-builder` and `webhooks` were never the near-miss; the sibling this skill actually gets confused with is `automation-flows`, so the boundary now spends its characters there. Both dropped siblings are still routed from the body.
- **The trailing `## Related skills` index** (7 lines). Every link in it already appears inline at point of use — the routing paragraph under the title covers `automation-flows`, `n8n`, `make`, `zapier`, `power-automate`, `api-connector-builder`, `webhooks`; `secure-coding` is linked from §4 next to the secrets policy it belongs to. A tail index that repeats links the reader has already passed is a second copy to keep in sync.

## What stayed, and why

- **§5 anti-patterns table** — the rubric requires one, and this is the real thing: concrete failure modes (silent failure, no kill-switch, choosing platform by familiarity) rather than a rationalization bank restating rules from above.
- **§3 platform matrix and §2 build-vs-buy table** — genuine branch points. This skill's whole job is the routing decision those tables drive.
- **The two honest capability limits** — no public API to create a Zap, no clean public API to author Power Automate end-user "My flows". A plan that assumes either is wrong, so the warning is load-bearing.
- **The closing checklist** — it is the output contract of the decision pass: the requirements handed to the build skill. Not a restatement of the description.

No recommendation, figure, price, platform claim, or reference link was changed. This was a context-engineering pass, not a content rewrite.

## Verification

- `bash scripts/eval-lint.sh` → `automation-strategy  PASS (should_trigger=7, should_not_trigger=6, capability=1)`
- Description 343 chars, parses as single-line quoted YAML.
- All 3 files under `references/` still linked from the body (`automate-decision-and-roi.md` §1/§2, `platform-selection-matrix.md` §3, `orchestration-and-antipatterns.md` §4).
- All 8 `../<sibling>/SKILL.md` links resolve to real skills.
- `manifest.json` untouched (derived; orchestrator regenerates). `npm test` / `npm run validate` not run — no `node_modules` in this worktree, per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)