### PR TITLE
refactor(agent-safety): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/agent-safety/SKILL.md
+++ b/skills/agent-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-safety
-description: "Use when putting guardrails on an LLM agent that already runs — limiting its task scope, gating its tools to least privilege, defending against prompt injection from untrusted content (web pages, emails, RAG docs), requiring human approval on irreversible actions, capping runtime, or after an agent did something it should not have. Triggers: 'lock down the MCP tools', 'the agent deleted prod', 'an email told it to wire money and it did', 'our support agent can run any shell command', 'the agent keeps repeating a wrong instruction across sessions', 'review what this autonomous agent is allowed to do before we ship', 'posa límits a l'agent', 'l'agent ha fet una cosa que no tocava'. NOT building the agent loop, tools, or RAG (that is building-agents)."
+description: "Use when bounding an LLM agent that already runs — scoping its task domain, gating tools to least privilege, defending against prompt injection in untrusted web/email/RAG text, requiring human approval on irreversible actions, capping runtime and cost, or triaging what it already did. NOT building the loop, tools, or RAG (that is `building-agents`)."
 tags: [agent-security, guardrails, prompt-injection, least-privilege, owasp-agentic]
 recommends: [building-agents, secure-coding, agent-eval]
 origin: risco
@@ -11,8 +11,13 @@ origin: risco
 You are the security review for an agent's **agency**, not for its code. The loop works,
 tools are wired, memory persists — your job is to make that autonomy *bounded*. If you
 want to review ordinary endpoints, auth, or secrets handling, that is
-`../secure-coding/SKILL.md`. If the loop or tools do not exist yet, that is
+`../secure-coding/SKILL.md` — this skill is the *Agentic* Top 10, the risks that exist only
+because a model has tools and autonomy. If the loop or tools do not exist yet, that is
 `../building-agents/SKILL.md`. You arrive *after* both.
+
+`references/threat-model.md` carries the OWASP Agentic Top 10 2026 risks mapped to the
+controls below, the pre-ship guardrail checklist, and the incident-triage flow for "the
+agent did X" — open it when you are reviewing before ship or reconstructing an incident.
 
 ## The ownership split
 
@@ -162,15 +167,3 @@ Log every tool call (arguments redacted) and alert on repeated approval-bypass a
 | Scope/limits stated only in the prompt         | Prompt is advisory; the model can be talked out of it         | Enforce at the tool/harness boundary                |
 | No loop / cost / rate cap                       | A hijacked or looping agent runs until it runs out of money   | Hard fail-closed kill-switches                      |
 | Redact PII only in the UI                       | The secret was already written to memory/logs                 | Redact before persistence, at the source            |
-
-## References
-
-- `references/threat-model.md` — OWASP Agentic Top 10 2026 risks mapped to the controls
-  above, a pre-ship guardrail checklist, and an incident-triage flow for "the agent did X".
-
-## Related
-
-- `../building-agents/SKILL.md` — builds the loop, tools, RAG, MCP server. Hand off here once
-  it exists; it recommends secure-coding, agent-safety is the deeper guardrail layer.
-- `../secure-coding/SKILL.md` — STRIDE/OWASP for ordinary code and web endpoints. agent-safety
-  is the *Agentic* Top 10: risks that exist only because a model has tools and autonomy.


### PR DESCRIPTION
Context-engineering pass on `skills/agent-safety/` only. No substance changed: no recommendation, version, command, or figure was touched.

## Numbers

| | before | after |
|---|---|---|
| `description` | 758 chars | **351 chars** |
| body | 176 lines / 11193 bytes | **169 lines / 10578 bytes** |
| `scripts/eval-lint.sh` | PASS | **PASS** (should_trigger=6, should_not_trigger=5, capability=1) |

## What went

- **The `Triggers: '…'` phrase list** (eight quoted phrases, EN + CA) — 407 of the 758 description chars. The description is in context on every turn the skill is installed, invoked or not; the model matches by meaning, so a keyword list is per-turn cost with no discriminative power. The surviving description keeps what it does, when to reach for it, and the boundary.
- **The trailing `## References` index** — folded to an inline mention at point of use, in the opening block. `references/threat-model.md` is still linked, so it is still loadable.
- **The trailing `## Related` section** — it restated the delegation the intro already makes to `../secure-coding/SKILL.md` and `../building-agents/SKILL.md`. The one distinction it added (this skill is the *Agentic* Top 10, not STRIDE for ordinary endpoints) moved into the intro rather than being dropped.

## What stayed, on purpose

- **The anti-patterns table** — rubric-required, and it names concrete failure modes with a fix column rather than restating rules.
- **Both decision tables** — trust level by content source, and HITL control by risk class. The flow genuinely branches on both.
- **All four bad/good Python pairs** — wildcard `run_shell` vs allowlisted `read_file`, and raw RAG chunk vs quarantined + schema-validated send. They teach the boundary by demonstration.
- **Every control bullet with its `Why:`**, and the load-bearing figures unchanged: ~30 calls/min rate cap, ~\$10 session cost cap, ~93% of permission prompts rubber-stamped, the three OWASP excesses, LLM01 / Agentic T1.

## Boundary check

`building-agents`, `secure-coding` and `agent-eval` all exist under `skills/`; both `../<sibling>/SKILL.md` links resolve; the sole `references/` file is linked from the body. `manifest.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)