### PR TITLE
refactor(aws-essentials): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/aws-essentials/SKILL.md
+++ b/skills/aws-essentials/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aws-essentials
-description: "Use when standing up the core AWS surface a small product needs — create a private S3 bucket for uploads, provision an encrypted RDS Postgres, choose ECS Fargate vs EC2 for a container, put CloudFront in front of S3, write or tighten an IAM policy, or harden a fresh account (root MFA, no long-lived keys). Triggers: 'set up an S3 bucket for user uploads', 'this role has AdministratorAccess, scope it down', 'spin up Multi-AZ Postgres on RDS', 'my bucket is public and I don't know why', 'this role can do everything', 'I can't encrypt RDS now', 'Fargate or EC2 for a low-traffic app', 'monta un bucket S3 privado', 'permisos mínims a IAM', 'posa CloudFront davant del bucket'. NOT the CI pipeline that ships your container (that is deployment), NOT app-code access-control review (that is secure-coding)."
+description: "Use when standing up the core AWS surface a small product needs: hardening a fresh account, a private S3 bucket, encrypted RDS Postgres, ECS Fargate vs EC2, CloudFront + OAC, or scoping an IAM policy to least privilege. NOT the CI pipeline that ships the container (that is `deployment`), NOT app-code access-control review (that is `secure-coding`)."
 tags: [aws, cloud, iam, s3, infrastructure]
 recommends: [deployment, secure-coding, dynamodb, postgresdb]
 origin: risco
@@ -16,19 +16,6 @@ god-mode app roles, long-lived keys, unencrypted databases). Pick the right tier
 ```text
 account hardening → IAM (roles + scoped policies) → S3 (private) / RDS (encrypted) / ECS Fargate → CloudFront (OAC) → infra exists, wired, least-privilege
 ```
-
-## Operating posture — three rules
-
-- **Secure by default: keep the defaults AWS already hardened.** New S3 buckets are private
-  since April 2023 (Block Public Access on, ACLs disabled, SSE-S3 encryption). Do not undo them.
-- **Least privilege: scope every policy, never `"*"` on `"*"`.** A role that can do everything
-  is a breach waiting for one leaked credential. Start from a managed policy, then tighten.
-- **Roles, not keys.** Temporary credentials from a role beat a long-lived `AKIA…` access key
-  that lives forever in a `.env` and ends up on GitHub. Apps get task roles; CI gets OIDC.
-
-Boundary in one sentence: **this skill provisions and secures the AWS account and its core
-services; `../deployment/SKILL.md` puts your container on it; `../secure-coding/SKILL.md` audits
-the code inside it.**
 
 ## Service decision table
 
@@ -61,7 +48,9 @@ Do this once, before anything else. Each line has a reason; skip none.
 
 Two principal types. **IAM users** = long-lived humans/keys; avoid them for workloads. **Roles**
 = an identity something *assumes* to get temporary credentials — this is what ECS tasks, Lambda,
-CI, and federated humans use. Default to roles.
+CI, and federated humans use. Default to roles: a temporary credential beats a long-lived `AKIA…`
+key that lives forever in a `.env`. (IAM governs who may call AWS APIs; access control *inside*
+your app code is `../secure-coding/SKILL.md`.)
 
 A policy is a JSON document. The four parts that matter:
 
@@ -181,7 +170,8 @@ Two more non-negotiables: the DB security group **references the app's security 
 `0.0.0.0/0` (a DB open to the internet is a breach, not a convenience); credentials live in
 **Secrets Manager** with managed rotation (`--manage-master-user-password` above), never in task
 env vars. Use `--multi-az` for production HA. Full recipe (SG wiring, Secrets Manager rotation,
-connecting from ECS) → `references/rds-cloudfront-recipes.md`.
+connecting from ECS) → `references/rds-cloudfront-recipes.md`. Schema, indexes and query tuning
+once the instance exists → `../postgresdb/SKILL.md`.
 
 ## CloudFront + OAC — public web content, private bucket
 
@@ -214,10 +204,3 @@ Full CLI: create OAC → distribution → S3 bucket policy JSON → invalidation
 | Root user for daily ops | Highest blast radius, no per-action attribution | Root only for root-only tasks; admin via Identity Center |
 | No MFA on root | One phished password = total account loss | Passkey/security-key MFA on root and every human |
 | Confusing task role and execution role | App gets 403 at runtime, or ECS can't pull the image | Execution = pull image/logs; task = app's runtime perms |
-
-## Cross-links
-
-- `../deployment/SKILL.md` — Dockerfile, CI/CD, OIDC to ECR, the actual ship-the-container step.
-- `../secure-coding/SKILL.md` — app-code access control / OWASP (vs cloud IAM here).
-- `../postgresdb/SKILL.md` — schema, indexes, query tuning once the RDS instance exists.
-- For key-value / single-table serverless data instead of RDS, reach for the `dynamodb` skill.


### PR DESCRIPTION
Context-engineering pass on `skills/aws-essentials/SKILL.md` per `scripts/skill-migration-brief.md`. No substance changed: every command, version, figure and recommendation is byte-identical to before.

| Metric | Before | After |
|---|---|---|
| `description` chars | 806 | **350** |
| Body bytes | 13184 | **11806** |
| Body lines | 224 | **207** |
| `scripts/eval-lint.sh` | — | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

## What went

- **The `Triggers:` list** — ten quoted phrases across EN/ES/CA. The description is in context on every turn the skill is installed, invoked or not; the model matches by meaning, so the list was pure per-turn cost. The description now carries what it does, when to reach for it, and the `NOT ... (that is deployment) / NOT ... (that is secure-coding)` boundary — both real siblings.
- **"Operating posture — three rules"** — a rule bank whose three rules were each already stated at the step they govern: Apr-2023 S3 defaults in the S3 section, `Action`/`Resource` scoping in the IAM section and the anti-patterns table, roles-over-keys in the hardening checklist. Its one non-duplicated detail (the long-lived `AKIA…` key in a `.env`) moved next to "default to roles" in the IAM section.
- **"Boundary in one sentence"** — a verbatim restatement of the description's boundary. The `secure-coding` half is now inline in the IAM section, phrased as the distinction a reader needs at that point (cloud IAM vs authorization inside app code).
- **"Cross-links" tail index** — `deployment` and `dynamodb` were already linked at point of use; `postgresdb` moved inline into the RDS section, so no link was lost.

## What stayed, and why

- **The anti-patterns table** (12 rows) — required by the rubric and a different animal from a rationalization bank: concrete failure modes with why-it-bites and a fix, not rules restated.
- **The service decision table** — the flow genuinely branches (S3 / RDS / Fargate vs EC2 / CloudFront / "you may not need AWS").
- **The account zero-day hardening checklist** — a real ordered gate, not prose.
- **Both worked bad/good pairs** (the `"*"`-on-`"*"` policy, the public-read bucket) — they teach judgment by demonstration.
- All CLI blocks, the IAM/trust policy JSON, the Fargate cold-start and utilization figures, the RDS encrypt-at-create constraint, and the OAC-over-OAI guidance — untouched.

## Invariants checked

- `references/iam-least-privilege.md` and `references/rds-cloudfront-recipes.md` are both still linked from the body.
- Every `../<sibling>/SKILL.md` link resolves: `cloudflare`, `vercel`, `deployment`, `secure-coding`, `postgresdb`.
- Frontmatter parses as YAML; `name`/`origin`/`tags`/`recommends` unchanged; `description` well under the 1024 hard limit.
- `manifest.json` deliberately untouched — the orchestrator regenerates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)