### PR TITLE
refactor(backups): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/backups/SKILL.md
+++ b/skills/backups/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backups
-description: "Use when designing or auditing a backup-and-restore program that must survive a real disaster — picking defensible RPO/RTO targets, building a 3-2-1-1-0 layout, wiring point-in-time recovery, adding offsite+immutable copies, or proving restores actually work. Triggers: 'we have no real backups, design something', 'what RPO/RTO should we target', 'set up PITR for Postgres', 'are our backups any good', the non-obvious 'our backups live on the same server as the database', and Catalan 'com provo que les còpies de seguretat funcionen de debò'. NOT tuning Postgres internals or writing the archive_command (that is postgresdb)."
+description: "Use when designing or auditing a backup-and-restore program that must survive a real disaster: setting defensible RPO/RTO targets, laying out 3-2-1-1-0 copies that are offsite and immutable, wiring point-in-time recovery, and proving restores work on a schedule. NOT tuning Postgres internals or writing the archive_command (that is `postgresdb`)."
 tags: [backups, disaster-recovery, pitr, rpo-rto, restore]
 recommends: [postgresdb, secure-coding, monitoring]
 origin: risco
@@ -127,11 +127,5 @@ The fill-in-the-blank restore runbook, the scheduled-test checklist, and the act
 | Encrypted backup, key only in the vault that's gone | Backup is recoverable but unreadable | Store the key in a separate blast radius (§3) |
 | Trusting managed snapshots without knowing the ceiling | RDS caps at 35 days; longer needs an exported copy | Know the retention ceiling, export beyond it (§3) |
 | Counting "job succeeded" as success | The job wrote a corrupt/empty archive | `check`/`verify` + a real test restore (§6–7) |
-
-## References
-
-- `references/engine-recipes.md` — copy-paste config and commands per engine: pgBackRest stanza + full/diff + PITR `--type=time`, WAL-G, RDS `restore-db-instance-to-point-in-time`, XtraBackup + binlog, Redis RDB/AOF, restic/Borg against an Object-Lock bucket.
-- `references/restore-runbook.md` — fill-in restore runbook template, the scheduled-restore-test checklist, and the actual-RTO log table.
-- Engine internals (archive_command, VACUUM, migrations): `../postgresdb/SKILL.md`. Encryption-key management as a security control: `../secure-coding/SKILL.md`.
 
 `scripts/verify.sh <path-to-policy-or-runbook>` lints a produced backup-policy/runbook artifact for the five pillars (RPO, RTO, offsite, immutability, scheduled-restore + verification). It is a completeness lint, not a backup executor.


### PR DESCRIPTION
Context pass over `skills/backups/SKILL.md` against `scripts/skill-rubric.md`. No substance changed — no recommendation, version, command, or figure was touched.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 628 | **347** (target ≤350, hard limit 1024) |
| Body bytes | 11933 | **11068** |
| Body lines | 137 | **131** |
| eval-lint | PASS | **PASS** (`should_trigger=6, should_not_trigger=5, capability=1`) |

## What went

- **The `Triggers: '…'` phrase list in the description.** Four English examples plus a Catalan one, ~280 chars paid on every turn the skill is installed whether or not it fires. The model matches by meaning; the keyword list added no discrimination the `what it does · when · NOT` shape does not already carry.
- **The trailing `## References` index.** Both files were already linked inline at point of use — `references/engine-recipes.md` at §3 and §4, `references/restore-runbook.md` at §6 — and its third bullet restated the `postgresdb` / `secure-coding` delegation already made in "Start here" and §4.

## What stayed, and why

- **The anti-patterns table** — rubric-required, and it names concrete failure modes rather than restating rules already given above it.
- **Four decision tables** — RPO→cadence, RTO→topology, per-engine mechanism/PITR, restore-test cadence. The flow genuinely branches on all four.
- **The three restore rules in §6** — they sit next to the step they govern, which is where a rule gets followed rather than skimmed.
- **The `scripts/verify.sh` line** — an output contract, not a reference index.

## Invariants checked

- Both `references/` files still linked from the body.
- `../postgresdb/SKILL.md`, `../secure-coding/SKILL.md`, `../monitoring/SKILL.md` all resolve; all three `recommends` ids are real skills.
- Frontmatter parses as YAML; `name` matches the dir id; `origin: risco` intact.
- `manifest.json` untouched, per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)