### PR TITLE
refactor(chrome-extension): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/chrome-extension/SKILL.md
+++ b/skills/chrome-extension/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chrome-extension
-description: "Use when building, structuring, or shipping a Manifest V3 browser extension and hitting its quirks — the service worker keeps dying or losing state between events, permission warnings scare users away, the Chrome Web Store rejected the listing, or you must drag an old Manifest V2 extension to V3. Triggers: 'build a Chrome extension', 'my background script keeps resetting its state', 'store rejected me for excessive permissions', 'migrate MV2 to MV3', 'content script messaging to the popup', 'declarativeNetRequest ad blocker', 'crear una extensión de Chrome', 'publicar a la Chrome Web Store', 'el service worker se muere'. NOT a generic web app (that is nextjs)."
+description: "Use when building or shipping a Manifest V3 browser extension and hitting its quirks — service worker dying and losing state, permission warnings, a Chrome Web Store rejection, content-script/worker/popup messaging, or an MV2-to-V3 migration. NOT a generic web app (that is `nextjs`), NOT a desktop shell (that is `electron`)."
 tags: [chrome-extension, manifest-v3, browser-extension, service-worker, chrome-web-store]
 recommends: [nextjs, react, gdpr-privacy, secure-coding, vercel]
 origin: risco
@@ -134,7 +134,7 @@ chrome.action.onClicked.addListener(async (tab) => {
 
 - `run_at`: `document_start` (before DOM), `document_end`, or `document_idle` (default, after load). Pick `document_start` only if you must beat the page's own scripts.
 - **Isolated world** (default): your content script's JS is sandboxed from the page's JS — they share the DOM but not variables. Use **MAIN world** (`"world": "MAIN"`) only when you must touch the page's own JS objects, and know it loses the isolation guarantee.
-- For dynamic, user-supplied injection, `chrome.userScripts.execute()` exists (Chrome 135, Mar 2025) — see references.
+- For dynamic, user-supplied injection, `chrome.userScripts.execute()` exists (Chrome 135, Mar 2025) — see [references/store-and-migration.md](references/store-and-migration.md).
 
 ## Storage, alarms, no remote code
 


### PR DESCRIPTION
## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 668 | **326** |
| SKILL.md bytes | 11326 | **11043** |
| SKILL.md lines | 169 | 169 |
| eval-lint | — | **PASS** (should_trigger=6, should_not_trigger=4, capability=1) |

## What went

- **The `Triggers:` phrase list** — nine quoted phrases across English and Spanish (`'build a Chrome extension'`, `'el service worker se muere'`, …). The description is in context on every turn the skill is installed, invoked or not, so it is the most expensive text in the package, and the model already matches by meaning. The list bought no routing the semantic description did not already provide.
- The redundant restatement in the lead ("building, structuring, or shipping" → "building or shipping"; "the service worker keeps dying or losing state between events" → "service worker dying and losing state").

## What stayed, and why

- **The body, at 169 lines, essentially untouched.** It already meets the rubric: no rule bank, no "When to use" section restating the description, no trailing reference index, and the manifest rules sit next to the keys they govern rather than in an appendix. Per the brief's judgment clause, a small honest diff beats an invented one.
- **The anti-patterns table** (9 rows) — concrete failure modes with a "why it breaks" column, not rules restated from above. Rubric requires one.
- **The skeleton and permission decision tables** — the flow genuinely branches (vanilla vs Vite+CRXJS; `activeTab` vs `host_permissions` vs `optional_permissions` vs DNR).
- **The bad/good service-worker pair** — teaches the ephemeral-worker judgment by demonstration, which is this skill's core insight.
- All dated `developer.chrome.com` source citations, versions, figures ($5 fee, 1–3 day review, Chrome 135, ~10 MB / ~100 KB storage limits) — verbatim. This was a context-engineering pass, not a content rewrite.

## Boundary

`NOT a generic web app (that is \`nextjs\`), NOT a desktop shell (that is \`electron\`)`. Both exist under `skills/`; both are already `route_to` targets in this skill's `should_not_trigger` evals. `electron` is the nearer miss for "build an app with web technologies" prompts and was previously unnamed in the description.

## One body line

`chrome.userScripts.execute()` said "see references" with no link, while `references/store-and-migration.md` was only linked from the shipping section further down. Made it a real link so the pointer resolves at point of use. Same file, same claim, no substance change. The references invariant holds: the one file under `references/` is linked from the body (now twice, both inline at point of use).

`manifest.json` deliberately untouched — the orchestrator regenerates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)