### PR TITLE
refactor(brand-identity): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/brand-identity/SKILL.md
+++ b/skills/brand-identity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brand-identity
-description: "Use when defining a project's visual identity foundation from scratch or consolidating ad-hoc brand assets into one system: a logo brief, a color system, a type system, usage rules, and an exported design-tokens.json that downstream skills consume. Use when there is no visual foundation yet, or a rebrand must unify scattered colors/fonts. Triggers: 'build our brand identity', 'create a brand book / brand guidelines', 'logo brief', 'pick our color palette', 'define our type system', 'consolidate our random fonts and hex codes scattered across files into one system', 'necesito una identidad de marca', 'crea la guia de marca amb les normes d'us del logo'. NOT the applied UI/pixels (that is design), NOT the words/tone (that is brand-voice), NOT a journalist asset pack (that is press-kit)."
+description: "Use when a project needs its visual foundation built or consolidated into one system: logo brief, color system in HEX/RGB/CMYK/OKLCH with proven AA contrast, type system, usage rules, and an exported W3C design-tokens.json that later skills consume. NOT the applied UI pixels (that is design), NOT the words or tone (that is brand-voice)."
 tags: [brand, identity, logo, color, typography]
 recommends: [design, brand-voice, press-kit, presentations]
 origin: risco
@@ -10,46 +10,19 @@ origin: risco
 
 *This skill emits the brand book — logo brief, color system, type system, usage rules — and a machine-readable `design-tokens.json` that `design` consumes. You write the rules every later pixel must obey; you do not paint the live UI.*
 
-A brand identity with nothing checkable behind it is a mood board. The bar here is a **brand book that compiles**: roles named, every color carrying four channels, contrast pairs proven against WCAG, and a tokens file that `scripts/verify.sh` can validate. Hit that bar or it is not done.
+A brand identity with nothing checkable behind it is a mood board. The bar here is a **brand book that compiles**: roles named, every color carrying four channels, contrast pairs proven against WCAG, and a tokens file that `scripts/verify.sh` can validate.
 
-## When to use / When NOT to use
+All four parts ship together — logo brief, color system, type system, usage guidelines with the tokens export. A part missing its bar is incomplete, not "lite".
 
-Use when:
-
-- A new product/company has no visual foundation and needs one defined.
-- A rebrand must consolidate ad-hoc colors, fonts, and one-off logos into a single system.
-- `design` is about to build the site and STOPS because no brand study exists — you produce that study's visual half.
-- The user asks for a logo brief, a palette with documented values, or a type system.
-
-Do NOT use — route instead:
-
-| Request | Route to | Why |
-| --- | --- | --- |
-| "Write our tone of voice, tagline, naming, messaging pillars" | `../brand-voice/SKILL.md` | Verbal identity — the words, not the pixels. |
-| "Make this landing page look premium / pick layout + motion / ship the Tailwind" | `../design/SKILL.md` | The applied UI layer — it consumes this foundation, it is not it. |
-| "Write the hero headline, value prop, CTA copy" | `../marketing/SKILL.md` | Page words, not the visual system. |
-| "Assemble a press kit — boilerplate, logos-for-press, fact sheet" | `../press-kit/SKILL.md` | Media packaging of finished assets, not system definition. |
-| "Build the investor pitch deck visuals" | `../presentations/SKILL.md` | Deck composition, not the brand foundation. |
-
-**The one-line test:** "define what our brand looks like everywhere" → here. "make *this surface* look premium" → `design`.
-
-## The deliverable contract (four parts)
-
-Every brand-identity engagement ships all four. Each has a MUST-contain bar; a part missing its bar is incomplete, not "lite".
-
-1. **Logo brief** — MUST define the variation set (primary / stacked / mark-only / mono), the clear-space rule, minimum sizes, and the file + favicon export matrix. *Why:* a logo that only works in one context is not a system; it breaks the first time someone needs a favicon or a one-color print.
-2. **Color system** — MUST give every color a role (primary / secondary / neutral / accent) and four channels (HEX + RGB + CMYK + OKLCH), document AA contrast pairs, and define light/dark roles. *Why:* HEX alone fails print (no CMYK) and wide-gamut screens (no OKLCH); undocumented contrast ships inaccessible.
-3. **Type system** — MUST name 2–3 typefaces max with a scale, weights, and a one-line pairing rationale. *Why:* more than three families reads as chaos; an undocumented scale gets re-guessed on every screen.
-4. **Usage guidelines** — MUST give do/don't rules, a misuse table, and an exported W3C-format `design-tokens.json`. *Why:* the tokens file is the hand-off contract; without it `design` re-derives your palette by eye and drifts.
+The one-line boundary test: "define what our brand looks like everywhere" → here. "make *this surface* look premium" → `design`.
 
 ## Logo brief
 
 Specify a system, not a single picture. The mark must survive from favicon to billboard, in color and in one ink.
 
-- **Variation set** — primary (horizontal lockup), stacked (vertical, for square/tight slots), mark-only (the symbol alone, for avatars/favicons), monochrome (single-ink: black, white-knockout). A logo that has no mono version fails the moment it lands on a colored background or a fax.
+- **Variation set** — primary (horizontal lockup), stacked (vertical, for square/tight slots), mark-only (the symbol alone, for avatars/favicons), monochrome (single-ink: black, white-knockout). A logo with no mono version fails the moment it lands on a colored background or a fax. Test the mono version first; if it dies in one color, the design is too fragile.
 - **Clear space** — define it relative to the mark, not in fixed px, so it scales: clear space = the cap-height (or x-height of the mark) on all four sides. Nothing intrudes inside it.
 - **Minimum size** — below this, detail collapses. Defaults: 24px wide digital, 10mm wide print for the full lockup; the mark-only may go smaller (favicon).
-- **Color + mono requirement** — every variation must be reproducible in full color AND in a single ink. Test the mono version first; if it dies in one color, the design is too fragile.
 - **File + favicon matrix** — ship the formats below. SVG is the digital primary (scales, tiny); PNG carries transparency; JPEG is print-safe; 72 DPI digital / 300 DPI print.
 
 | Asset | Format | Notes |
@@ -71,8 +44,8 @@ Full variation grid, clear-space/min-size formulas, and the favicon HTML markup 
 Assign roles first, values second. A color with no role is decoration waiting to be misused.
 
 - **Role taxonomy** — 2–3 primary (the brand's signature), 2–3 secondary (support), a neutral ramp (text, surfaces, borders), and exactly **one accent** reserved for CTAs/highlights. One accent keeps "click here" unambiguous.
-- **Four channels, every color** — HEX (web), RGB (screen math), CMYK (print), OKLCH (perceptual + wide-gamut). The W3C Design Tokens Color Module (2025.10) supports CSS Color 4 spaces including OKLCH and Display P3, so wide-gamut color lives in the token file natively — author in OKLCH and let HEX be the fallback.
-- **AA contrast pairing rule** — every text-on-background pair you document must clear WCAG 2 AA: **4.5:1 for normal text, 3:1 for large text** (≥18.66px bold or ≥24px). AAA is 7:1 / 4.5:1 — reach for it on body text where you can. Pair colors explicitly ("`fg` on `bg`: 12.4:1 ✓"); do not leave it to chance.
+- **Four channels, every color, no exceptions** — HEX (web), RGB (screen math), CMYK (print), OKLCH (perceptual + wide-gamut). This one is absolute because a HEX-only palette silently breaks the two places nobody tests: print (no CMYK) and wide-gamut screens (no OKLCH). The W3C Design Tokens Color Module (2025.10) supports CSS Color 4 spaces including OKLCH and Display P3, so wide-gamut color lives in the token file natively — author in OKLCH and let HEX be the fallback.
+- **AA contrast pairing** — every text-on-background pair you document clears WCAG 2 AA: **4.5:1 normal text, 3:1 large text** (≥18.66px bold or ≥24px). Not negotiable — it is a conformance threshold, not a taste call, and shipping under it ships an inaccessible product. AAA is 7:1 / 4.5:1 — reach for it on body text where you can. Pair colors explicitly ("`fg` on `bg`: 12.4:1 ✓").
 - **Logo-text exemption caveat** — WCAG 1.4.3 exempts logos and brand-name text from the contrast minimums. But a *typed* sub-brand or tagline that is plain text (not a graphical logo) IS subject to text-contrast rules. Mark logo-only tokens exempt; hold everything else to 4.5:1.
 - **Light/dark roles** — define the role in both schemes from day one (`bg`/`fg` invert, brand stays anchored). Retrofitting dark mode onto a light-only palette produces muddy, low-contrast surfaces.
 
@@ -89,7 +62,7 @@ Two to three typefaces, no more. Most brands need exactly two: one display (head
 
 ## Emit the tokens (the hand-off contract)
 
-The `design-tokens.json` is what makes this skill's output machine-readable and the reason `design` does not re-derive your palette by eye. Use the **W3C Design Tokens format**, which reached its first stable version (2025.10) on 2025-10-28 — a vendor-neutral JSON for sharing design decisions, with light/dark and multi-brand themes via group inheritance / `$extends`.
+Ship `design-tokens.json` even when the client only asked for a PDF — it is the one artifact `design` can read, and without it the palette gets re-derived by eye and drifts. Use the **W3C Design Tokens format**, which reached its first stable version (2025.10) on 2025-10-28 — a vendor-neutral JSON for sharing design decisions, with light/dark and multi-brand themes via group inheritance / `$extends`.
 
 ```json
 {
@@ -126,9 +99,9 @@ Full tokens file with light/dark via `$extends`, the Tailwind v4 `@theme` mappin
 
 ## Usage guidelines + anti-patterns
 
-State the misuse rules explicitly — the gap a brand book exists to close is the well-meaning teammate who stretches the logo to fit. Bad → Good:
+State the misuse rules explicitly — the gap a brand book exists to close is the well-meaning teammate who stretches the logo to fit.
 
-| Rationalization | Reality / Fix |
+| Misuse in the wild | Why it breaks / Fix |
 | --- | --- |
 | "Stretch the logo to fill the space" | Non-uniform scaling distorts the mark. Lock aspect ratio; pick the variation that fits (stacked vs primary). |
 | "This blue is close enough" | Off-palette colors fracture recognition. Use the token; if a need is unmet, add a role, don't eyeball one. |
@@ -151,11 +124,12 @@ The skill emits a checkable artifact, so verify it before claiming done. Run aga
 
 It checks: the file parses as JSON; required color roles are present (primary, neutral, accent at minimum); every color token carries a HEX value; and, for each documented text/background pair (declared via `$extensions["com.risco.contrast"]` pairs), it computes the WCAG relative-luminance contrast ratio and **fails any normal-text pair below 4.5:1**. Logo-only tokens are exempt. On an empty or clean target it exits 0 — no false failures.
 
-## Hand-off
+## Boundary + hand-off
 
-Once the brand book and tokens exist, point the next skill at them:
-
-- `../design/SKILL.md` — **applies** this foundation: reads `design-tokens.json`, builds the accessible, fast UI. This skill produces the brand study's visual half that `design` STOPS without.
-- `../brand-voice/SKILL.md` — owns the **words/tone**; pair it with this so copy and visuals agree.
-- `../press-kit/SKILL.md` — **packages** the finished logos/colors for journalists and media.
-- `../presentations/SKILL.md` — consumes the tokens for on-brand decks.
+| Request | Route to | Why |
+| --- | --- | --- |
+| Tone of voice, tagline, naming, messaging pillars | `../brand-voice/SKILL.md` | Verbal identity — the words, not the pixels. Pair it with this so copy and visuals agree. |
+| Make this page premium, pick layout + motion, ship the Tailwind | `../design/SKILL.md` | The applied UI layer: it reads `design-tokens.json` and builds the accessible, fast UI. This skill produces the brand study's visual half that `design` STOPS without. |
+| Hero headline, value prop, CTA copy | `../marketing/SKILL.md` | Page words, not the visual system. |
+| Press kit — boilerplate, logos-for-press, fact sheet | `../press-kit/SKILL.md` | Media packaging of finished assets, not system definition. |
+| Investor pitch deck visuals | `../presentations/SKILL.md` | Deck composition consuming the tokens, not the brand foundation. |


### PR DESCRIPTION
Context-engineering pass on `skills/brand-identity/SKILL.md` per `scripts/skill-migration-brief.md`. No substance changed: same recommendations, versions, figures, and commands.

| Metric | Before | After |
| --- | --- | --- |
| `description` chars | 795 | **338** |
| Body bytes | 12887 | **10622** |
| Body lines | 161 | **135** |
| Hard directives (MUST/NEVER/ALWAYS) | 5 | **0 shouted; 2 kept as stated absolutes with their reason** |
| eval-lint | — | **PASS** (should_trigger=6, should_not_trigger=5, capability=1) |

## Description

Dropped the eight-phrase `Triggers:` list — keyword variants in three languages that the model already matches by meaning, and that are in context on every turn the skill is installed, invoked or not. Dropped the `press-kit` clause too: it did not discriminate, and the route still lives in the body's hand-off table.

Kept the two boundaries that let a reader choose this skill over its nearest siblings — `NOT the applied UI pixels (that is design), NOT the words or tone (that is brand-voice)` — both verified real under `skills/`.

## Removed

- **"When to use / When NOT to use"** — the Use-when bullets restated the description, and its five-row routing table duplicated the trailing "Hand-off" list. Merged both into a single **Boundary + hand-off** table at the end. All five routes survive (`brand-voice`, `design`, `marketing`, `press-kit`, `presentations`), with the `design` hand-off detail folded into its row.
- **"The deliverable contract (four parts)"** — a rule bank restating the four sections that immediately followed it; each MUST-bar and its *Why* was already present in the section it governed, or in the anti-patterns table. Replaced by one line naming the four parts and the "a part missing its bar is incomplete, not lite" standard.
- **The five shouted MUSTs.** Where the model reaches the same conclusion unaided (variation set, clear space, minimum size, 2–3 typefaces), the requirement now simply reads as the instruction.

## Kept — deliberately

- **The anti-patterns table, whole.** Concrete misuse modes ("stretch the logo to fill the space", "this blue is close enough"), not rules restated from above. Only the column header changed, `Rationalization` → `Misuse in the wild`, to shed the borrowed-catalog convention flagged by rubric dimension 7.
- **Two absolutes, each stated next to the step it governs, with the reason it is absolute:**
  - four color channels — HEX-only silently breaks print (no CMYK) and wide-gamut screens (no OKLCH), the two places nobody tests;
  - WCAG 2 AA 4.5:1 / 3:1 — a conformance threshold, not a taste call.
  - The tokens export is stated the same way: ship it even when only a PDF was asked for, because it is the only artifact `design` can read.
- The favicon/format matrix, the worked `design-tokens.json` + CSS mapping, the W3C Design Tokens 2025.10 (2025-10-28) grounding, the WCAG 1.4.3 logo-text caveat, and the **Verify** block for the existing `scripts/verify.sh`.
- Both `references/` files linked inline at point of use — `logo-and-assets.md` and `color-and-tokens.md`.

`manifest.json` untouched; only `skills/brand-identity/SKILL.md` is in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
