### PR TITLE
refactor(business-intelligence): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/business-intelligence/SKILL.md
+++ b/skills/business-intelligence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: business-intelligence
-description: "Use when someone wants to ask business questions over the org's data in plain language and get consistent, trustworthy numbers, when a metric (revenue, MRR, active users, gross margin) must be defined once so every dashboard/report/agent computes it identically, when wiring an LLM or agent to query data without hallucinating SQL, or when two teams report different numbers for the same thing. Triggers: 'semantic layer', 'metrics layer', 'define MRR once', 'self-serve analytics in plain English', 'text-to-SQL but trustworthy', 'sales and finance disagree on revenue', 'the agent keeps hallucinating SQL', 'dbt Semantic Layer', 'MetricFlow', 'Cube', 'capa semántica', 'consultar dades en llenguatge natural'. NOT designing chart layout or panels (that is dashboard), NOT choosing which KPIs to track (that is kpi-framework), NOT writing the raw query by hand (that is sql)."
+description: "Use when a metric (revenue, MRR, margin) needs defining once in a governed semantic layer so every dashboard, report and agent returns the same number, or when an LLM must answer data questions in plain language without hallucinating SQL. NOT chart layout (that is `dashboard`), NOT which KPIs to track (that is `kpi-framework`), NOT a hand-written query (that is `sql`)."
 tags: [business-intelligence, semantic-layer, metrics-layer, text-to-sql, natural-language-query, dbt, cube]
 recommends: [sql, dashboard, kpi-framework, reporting, analytics, forecasting, clickhouse-analytics, duckdb]
 origin: risco
@@ -119,15 +119,6 @@ Question: "MRR by plan, monthly, last 2 quarters, EU customers only"
   filter      -> region = 'EU'
 ```
 
-```text
-Pregunta (ES/CA): "ingresos por región, mensual, últimos 2 trimestres, solo UE"
-  metric      -> gross_revenue
-  group by    -> region
-  time grain  -> month
-  date filter -> last 2 quarters
-  filter      -> region = 'EU'
-```
-
 You hand the layer that spec; it generates the governed SQL. You then explain the answer back in business terms ("EU MRR grew 8% QoQ, driven by the Pro plan"), not as a table dump.
 
 ## Wire the agent
@@ -155,22 +146,17 @@ Author toward the **Open Semantic Interchange** standard so definitions survive 
 
 ## Anti-patterns
 
-| Rationalization | Reality | STOP |
+| Anti-pattern | Why it bites | Instead |
 |---|---|---|
-| "Just free-hand the SQL this once, it's faster" | "Once" becomes the fourth conflicting revenue figure; it's unauditable | Add/query a metric |
-| "Each dashboard can define revenue itself" | That is exactly how you get three numbers and a fire drill | One metric, all consumers query it |
-| "The time dimension grain is obvious, skip declaring it" | Undeclared grain → silent daily-vs-monthly mismatches | Declare `time_granularity`/`grain` |
-| "Give the agent warehouse creds, it'll figure out the joins" | Raw text-to-SQL is 84-90% (33% in 2023); unauditable | Expose metrics via MCP/API |
-| "Stand up a semantic layer for this 200-row CSV" | Pure overhead for one analyst | `../sql/SKILL.md` / `../duckdb/SKILL.md` |
-| "The LLM is smart enough to write correct SQL" | The dbt 2026 benchmark says the layer is +8-14pts more accurate | Ground it in the layer |
-| "Hard-code the EU filter into the metric" | Now you need a second metric for every region | Pass filters at query time |
+| Free-handing the SQL "just this once" because it's faster | "Once" becomes the fourth conflicting revenue figure; it's unauditable | Add/query a metric |
+| Letting each dashboard define revenue itself | That is exactly how you get three numbers and a fire drill | One metric, all consumers query it |
+| Skipping the time dimension's grain because it's "obvious" | Undeclared grain → silent daily-vs-monthly mismatches | Declare `time_granularity`/`grain` |
+| Handing the agent warehouse creds to figure out the joins | Raw text-to-SQL is 84-90% (33% in 2023) and unauditable; the dbt 2026 benchmark puts the layer +8-14pts ahead | Expose metrics via MCP/API |
+| Standing up a semantic layer for a 200-row CSV | Pure overhead for one analyst | `../sql/SKILL.md` / `../duckdb/SKILL.md` |
+| Hard-coding the EU filter into the metric | Now you need a second metric for every region | Pass filters at query time |
 
 ## Verify
 
 Run `scripts/verify.sh [path]` on your semantic-model directory. It is read-only, never touches a warehouse, and discovers candidate YAML, then warns (advisory) on: a metric with no underlying measure, a measure with no declared `agg`, a time dimension with no grain, duplicate metric names, and a `.sql` beside the model hand-rolling an aggregate the layer should own. It exits non-zero only on unparseable YAML; an empty or clean target passes clean.
 
-## See also
-
-- `references/authoring-semantic-models.md` — multi-entity models, metric types, semi-additive measures, time spines, fan-out traps.
-- `references/wiring-agents-and-apis.md` — MCP metrics-tool pattern, dbt SL / Cube query shapes, agent guardrails.
-- Siblings: `../sql/SKILL.md` · `../dashboard/SKILL.md` · `../kpi-framework/SKILL.md` · `../reporting/SKILL.md` · `../analytics/SKILL.md` · `../forecasting/SKILL.md`
+Siblings: `../sql/SKILL.md` · `../dashboard/SKILL.md` · `../kpi-framework/SKILL.md` · `../reporting/SKILL.md` · `../analytics/SKILL.md` · `../forecasting/SKILL.md`


### PR DESCRIPTION
Context-engineering pass on `skills/business-intelligence/` per `scripts/skill-migration-brief.md`. No substance changed — no recommendation, version, figure, command or claim was touched.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 876 | **371** (-58%) |
| SKILL.md bytes | 11123 | **10042** (-10%) |
| SKILL.md lines | 176 | **162** |
| eval-lint | — | **PASS** (should_trigger=5, should_not_trigger=5, capability=1) |

The body was already inside the rubric (176 lines against a 400-line ceiling, anti-patterns table present, both references linked inline), so this is primarily a description pass. Small honest diff: 9 insertions, 23 deletions.

## What went

- **The `Triggers: '…'` list** — 12 phrases across EN/ES/CA. It is paid for on every turn the skill is installed, invoked or not, and the model routes by meaning. This is the bulk of the 505-char description saving.
- **The ES/CA duplicate of the query-decomposition example** — same four-part spec as the English block immediately above it.
- **The `## See also` reference index** — both `references/` files are already linked inline at their point of use, so the tail bullets were a second copy of the same two links.

## What stayed, and why

- **"The one rule"** with the dbt April 2026 benchmark (98.2% / 100% vs 90.0% / 84.1%; 72.7% vs 64.5% unmodeled; 32.7% GPT-4 2023). That is the skill's grounding, not a rule bank, and it already sits next to the behaviour it governs.
- **Both decision tables** — "do you even need a layer?" and "pick the layer" — the flow genuinely branches on consumers/conflict and on dbt SL vs Cube vs warehouse-native.
- **Both bad/good pairs** (three conflicting revenue definitions; agent-with-creds vs `query_metrics` call) — they teach judgment by demonstration.
- **The OSI portability paragraph** with its dated facts (launched 2025-09-23, v1.0 published 2026-01-27) and the MetricFlow Apache-2.0 / Coalesce 2025 note.
- **The anti-patterns table**, which the rubric requires. Reworded the borrowed `Rationalization | Reality | STOP` header to `Anti-pattern | Why it bites | Instead` (rubric dimension 7 flags borrowed rationalization conventions) and merged the two rows describing the same text-to-SQL failure — both the 84-90%/33% and the +8-14pts figures survive in the merged row.
- **The `Verify` block** describing `scripts/verify.sh`.
- **The sibling routing line** (now one line, no heading). Four of those siblings are `route_to` targets in `evals/cases.yaml` and appear nowhere else in the body.

## Checks

- `bash scripts/eval-lint.sh` → `business-intelligence  PASS`
- `description` 371 chars, parses as single-line quoted YAML, opens `Use when`, carries three real `NOT … (that is <sibling>)` boundaries — `dashboard`, `kpi-framework`, `sql` all exist under `skills/`.
- Every file in `references/` is still linked from the body: `authoring-semantic-models.md` (in "Author the model"), `wiring-agents-and-apis.md` (in "Wire the agent").
- All six `../<sibling>/SKILL.md` links resolve.
- `manifest.json` untouched (orchestrator regenerates); `npm test` / `npm run validate` not run — no `node_modules` in this worktree, per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)