### PR TITLE
refactor(bookkeeping): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/bookkeeping/SKILL.md
+++ b/skills/bookkeeping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bookkeeping
-description: "Use when a small business needs clean, audit-ready books — standing up a chart of accounts, recording a transaction and unsure which account or which side (debit vs credit), a bank feed full of uncategorized lines, a month-end ledger that won't reconcile to the bank, or choosing cash vs accrual. Triggers: 'set up a chart of accounts', 'where does this transaction post', 'which side is a debit when I pay rent', 'my books don't tie out to the bank', '300 transactions sitting uncategorized', 'cash or accrual accounting', 'how long do I keep receipts', 'categoriza los movimientos del banco', 'mi contabilidad está hecha un desastre', 'cuadra el libro con el extracto', 'comptabilitat feta un desastre'. The loop is record → classify → reconcile so the numbers are trustworthy. NOT analyzing runway/burn/P&L or the monthly finance cadence (that is finance-ops), NOT issuing a customer invoice (that is invoicing), NOT setting a price (that is pricing), NOT future projections (that is financial-model)."
+description: "Use when a small business needs audit-ready books — a chart of accounts, posting a transaction to the right account and side, clearing an uncategorized bank feed, cash vs accrual, or a ledger that won't tie to the bank. NOT interpreting the numbers — runway, burn, P&L cadence (that is `finance-ops`), NOT issuing invoices (that is `invoicing`)."
 tags: [bookkeeping, double-entry, chart-of-accounts, reconciliation, ledger, accounting, categorization]
 recommends: [finance-ops, invoicing, pricing, financial-model, cost-tracking, stripe, spreadsheet-ops]
 origin: risco
@@ -14,7 +14,7 @@ The whole job is one loop: **Record → Classify → Reconcile.** Record the raw
 
 ## Route out before you start
 
-This skill answers "where does this transaction go and does the ledger balance." When the ask is something else, stop and route:
+"Where does this post and does it balance" is bookkeeping; "what do these numbers mean for the business" is not. Route out when the ask is:
 
 - Interpreting the numbers — runway, burn, P&L review, monthly finance cadence → `../finance-ops/SKILL.md`.
 - Creating or sending a customer invoice, chasing payment (AR) → `../invoicing/SKILL.md`.
@@ -23,8 +23,6 @@ This skill answers "where does this transaction go and does the ledger balance."
 - Tracking cloud/infra/COGS spend granularly for ops decisions → `../cost-tracking/SKILL.md`.
 - Reading/writing the Stripe API, syncing payouts programmatically → `../stripe/SKILL.md`.
 - Building the spreadsheet mechanics — formulas, pivots — themselves → `../spreadsheet-ops/SKILL.md`.
-
-Rule of thumb: "where does this post and does it balance" is bookkeeping; "what do these numbers mean for the business" is finance-ops.
 
 ## Rule 1 — every entry balances: debits = credits
 
@@ -176,9 +174,3 @@ Spain (autónomo, estimación directa simplificada): the obligation is **libros 
 | Mixing personal and business in one account | Untraceable books, tax and liability exposure | Separate business account; owner draws/capital for transfers |
 | Trusting bank-feed auto-match blindly | Miscategorizes transfers, refunds, draws | Review every match against type/date/amount |
 | Over-splitting the COA into 200 accounts | Every classification becomes a coin flip | Start at ~20–30; merge when you hesitate |
-
-## References
-
-- `references/chart-of-accounts.md` — full numbered example COA across the five categories, contra accounts (accumulated depreciation, allowance for doubtful accounts), add-vs-merge rules, the over-splitting failure mode.
-- `references/reconciliation-playbook.md` — step-by-step month-end reconciliation, the full won't-tie-out diagnostic ladder, and the jurisdiction detail (IRS retention table + Spain libros registro de IVA fields).
-- `references/tricky-transactions.md` — the classification cases that bare judgment gets wrong: transfers, refunds, partial/overpayments, loan & finance splits, payroll decomposition, prepaids & deferrals, accruals, sales tax/VAT collected, merchant-fee netting (Stripe/PayPal gross-vs-net), bad debt, foreign currency, personal/mixed-use — each with the right journal entry and the wrong one it replaces.


### PR DESCRIPTION
## Metrics

| | Before | After |
| --- | --- | --- |
| `description` chars | 1004 | **345** (target ≤350, hard limit 1024) |
| Body | 185 lines / 15,751 B | **177 lines / 14,097 B** |
| eval-lint | — | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

Diff is `1 file changed, 2 insertions(+), 10 deletions(-)`. This skill already met most of the
rubric — 185 lines against a 400-line ceiling, an anti-patterns table, every reference linked
inline — so the honest pass is small and concentrated on the per-turn cost.

## What went

- **The `Triggers:` list.** 11 quoted phrases in three languages (EN/ES/CA) inside a description
  that is in context on every turn the skill is installed, invoked or not. The model matches by
  meaning; the keyword list was pure per-turn cost.
- **Two of the four `NOT` boundaries** (`pricing`, `financial-model`). The test is discrimination,
  not coverage: `finance-ops` is the nearest sibling and `invoicing` the next, and those two settle
  the routing. All seven siblings still route from the body, where they cost nothing until the
  skill fires.
- **The trailing `## References` index.** All three files were already linked inline at their point
  of use — `chart-of-accounts.md` in Rule 3, `tricky-transactions.md` in Rule 4.5,
  `reconciliation-playbook.md` in Rules 5, 6.5 and 7 — each with a description of its contents. The
  index was the same three links a second time.
- **The "Rule of thumb" closer** on the routing section, folded into that section's opening
  sentence: the same bookkeeping-vs-finance-ops distinction stated twice, three lines apart.

## What stayed, and why

- **Rules 1–7 in full.** Not a rule bank restating a flow — each teaches a distinct mechanic
  (debits = credits, normal balances, COA sizing, retention) with its worked entry attached, and
  each states *why* it is absolute instead of shouting NON-NEGOTIABLE.
- **Rule 4.5's six-step classification procedure** and **Rule 6.5's diagnostic ladder** — ordered
  decision procedures for the lines that genuinely branch, which is exactly where the rubric wants
  the tokens spent.
- **The anti-patterns table** — rubric-required, and concrete failure modes rather than rules
  already stated above it.
- **Worked bad/good pairs** (account naming, the two journal entries), the cash-vs-accrual and
  IRS-retention tables, and the routing list.

## Verification

- `bash scripts/eval-lint.sh` → `bookkeeping  PASS (should_trigger=7, should_not_trigger=5, capability=1)`
- Frontmatter parses as YAML; `name` matches the directory, `origin: risco` present.
- All 3 `references/` files still linked from the body; all 9 `../<sibling>/SKILL.md` links resolve;
  both siblings named in the description (`finance-ops`, `invoicing`) exist under `skills/`.
- `manifest.json` untouched (derived — orchestrator regenerates). `npm test` / `npm run validate`
  not run: no `node_modules` in this worktree, per the brief.

Substance preserved exactly — no recommendation, threshold, figure, command, or source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
