### PR TITLE
refactor(bash-scripting): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/bash-scripting/SKILL.md
+++ b/skills/bash-scripting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bash-scripting
-description: "Use when writing or hardening a shell script that has to survive another machine — a CI step, install script, build glue, cron job, git hook, or devcontainer entrypoint — and it 'works on my machine' but fails in CI/Docker/macOS, mangles filenames with spaces, leaks temp files when interrupted, or trips ShellCheck. Triggers: 'works locally but breaks in CI', 'filenames with spaces break my loop', 'set -e didn't catch the error', 'unquoted variable ate my path', 'trap fires twice', 'fix these SC2086 warnings', 'make this run on macOS and Linux', 'should this be #!/bin/bash or #!/bin/sh', 'script que peta en CI però funciona al portàtil', 'fes el script portable / hazlo robusto'. NOT CI workflow structure, runners, caching, matrix (that is github-actions)."
+description: "Use when writing or hardening a shell script that must survive another machine — a CI step, install script, cron job, git hook, devcontainer entrypoint: strict-mode leaks, quoting/word-splitting, arrays, trap cleanup, bash-vs-POSIX portability, ShellCheck findings. NOT CI workflow structure, runners, caching or matrix (that is `github-actions`)."
 tags: [bash, shell, shellcheck, posix, scripting]
 recommends: [github-actions, error-handling, docker, secure-coding]
 origin: risco
@@ -47,7 +47,10 @@ is `#!/bin/sh` you may not get bash — on Debian/Alpine `sh` is `dash`/busybox.
 Two traps to internalize: macOS `/bin/bash` is **3.2** (no `declare -A`,
 no `${var,,}`, no `mapfile`); and bash **5.3** added `${ cmd; }` /
 `GLOBSORT` / `read -E` that will not run on either of the above. Pick a floor
-and stay above it. Deep matrix and workarounds: `references/portability.md`.
+and stay above it — the full bash-vs-POSIX feature matrix, `bash 3.2`
+workarounds, dash/busybox gotchas, the 5.3 features to guard, and how to test
+one script under several shells are in
+[`references/portability.md`](references/portability.md).
 
 ## Strict mode, honestly
 
@@ -222,10 +225,3 @@ belongs to `../github-actions/SKILL.md`, the shell inside the step belongs here.
 | `[ a == b ]` under `#!/bin/sh` | `==` is a bashism; dash errors | POSIX uses `[ a = b ]` |
 | Fixed temp path `/tmp/build` | race + collision + no cleanup | `tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT` |
 | `pipefail` in a `#!/bin/sh` script | not POSIX; dash ignores or errors | use bash, or check pipeline status another way |
-
-## References
-
-- `references/portability.md` — the full bash-vs-POSIX feature matrix, macOS
-  `bash 3.2` workarounds (no `declare -A` / `${var,,}` / `mapfile` — portable
-  equivalents), dash/busybox gotchas, the bash 5.3 feature list to guard or
-  avoid, and how to test the same script under multiple shells.


### PR DESCRIPTION
## Summary

Context-engineering pass on `skills/bash-scripting/SKILL.md`. The skill's body already met the rubric — it has a decision table where the flow branches, worked bad/good pairs, an anti-patterns table, and no rule bank or rationalization appendix. So this is an honest small diff: **5 insertions, 9 deletions**, all of it description and one duplicated tail index. No technique, version, flag, command or figure changed.

| | Before | After |
|---|---|---|
| `description` | 764 chars | **347 chars** (target ≤350) |
| body | 10659 bytes / 231 lines | **10093 bytes / 227 lines** |
| eval-lint | PASS | **PASS** (`should_trigger=7, should_not_trigger=5, capability=1`) |

## What went, and why

- **The `Triggers: '…'` phrase list** — 10 quoted phrases in English, Catalan and Spanish, roughly 400 chars riding in context on every turn the skill is installed whether or not it fires. The model matches by meaning, so the list bought nothing it did not already have.
- **The duplicated symptom clause** (`'works on my machine' but fails in CI/Docker/macOS, mangles filenames with spaces, leaks temp files when interrupted, or trips ShellCheck`) — replaced by the tighter topic list that says the same thing in a third of the space.
- **The trailing `## References` section** — one entry, `references/portability.md`, already named inline at the point of use. Two copies of the same pointer is exactly the drift the rubric warns about. The tail block's substance (feature matrix, `bash 3.2` workarounds, dash/busybox gotchas, 5.3 features to guard, multi-shell testing) moved into that inline mention, which is now a real markdown link so the reference stays reachable.

## What stayed, and why

- **The anti-patterns table.** Required by the rubric, and a different animal from a rationalization bank: every row is a concrete failure mode with its ShellCheck code and the fix, not a rule restated from the prose above it.
- **The bash-vs-POSIX decision table.** The flow genuinely branches on the shebang — what you gain, what you lose, how to lint, how to test.
- **The bad/good pairs** — `local x=$(cmd)` masking exit status, flag arrays vs space-split strings, `find -print0` vs parsing `ls`. These teach judgment by demonstration; a rule would not.
- **The whole body of technique.** Strict-mode leak analysis, the quoting table, `EXIT`-trap cleanup, `getopts`, the ShellCheck codes. Removing correct, dense, actionable content to hit a number is not what the pass is for.
- **The boundary and the delegation.** `NOT CI workflow structure, runners, caching or matrix (that is \`github-actions\`)` in the description, and the inline `../github-actions/SKILL.md` handoff where the skill touches CI.

## Verification

- `bash scripts/eval-lint.sh` → `bash-scripting PASS`
- Description parses as single-line quoted YAML, 347 chars, third person, `Use when …` lead, explicit `NOT` boundary naming a sibling that exists under `skills/`.
- `references/portability.md` — the only file under `references/` — is linked from the body.
- All 10 code fences language-tagged; `../github-actions/SKILL.md` resolves; all four `recommends` ids (`github-actions`, `error-handling`, `docker`, `secure-coding`) are real skills.
- Per the brief: `manifest.json` untouched, no `npm test` / `npm run validate` (no `node_modules` in this worktree), commit scoped to `skills/bash-scripting/`.

## Note for the reviewer

`evals/cases.yaml` keeps a Catalan trigger case (*"Tinc un script que peta en CI però funciona al meu portàtil…"*). The description no longer carries Catalan keywords by design — it routes on meaning, and the surviving text ("must survive another machine", "a CI step") maps onto it directly. Worth confirming in the behavior-eval run, but no change was made to the evals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)