### PR TITLE
refactor(clickhouse-analytics): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/clickhouse-analytics/SKILL.md
+++ b/skills/clickhouse-analytics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clickhouse-analytics
-description: "Use when standing up a ClickHouse server for high-volume OLAP analytics, picking a MergeTree engine plus ORDER BY/PARTITION BY keys, ingesting billions of event/log/metric rows (async inserts, batch sizing, dedup), building materialized-view pre-aggregations, or optimizing a slow ClickHouse query. Triggers: 'design a ClickHouse table for 2B events/day', 'which MergeTree engine and ORDER BY', 'queries scan the whole table, the primary key isn't pruning', 'parts keep piling up and merges can't keep up', 'pre-aggregate at insert time so dashboards stay sub-second', 'AggregatingMergeTree materialized view for uniq users per hour', 'montar ClickHouse para analítica de eventos a gran escala', 'consultes lentes a ClickHouse, l'índex no poda particions'. NOT local file analytics with no server (that is duckdb), NOT app transactional CRUD/OLTP indexing (that is postgresdb)."
+description: "Use when running a ClickHouse server for high-volume OLAP: choosing a MergeTree engine and ORDER BY/PARTITION BY keys, ingesting billions of event/log/metric rows, pre-aggregating with materialized views, or fixing a query that scans instead of pruning. NOT in-process file analytics (that is `duckdb`), NOT OLTP CRUD indexing (that is `postgresdb`)."
 tags: [clickhouse, olap, columnar, mergetree, analytics, materialized-views, data-ingestion, sql]
 recommends: [duckdb, postgresdb, dashboard, kpi-framework, reporting, business-intelligence]
 origin: risco
@@ -10,11 +10,7 @@ origin: risco
 
 ClickHouse is a multi-user, always-on, replicated columnar server built to ingest continuous high-volume writes and answer aggregation queries over billions of rows in milliseconds. You reach for it when the workload is "append a firehose of events/logs/metrics, then GROUP BY them for dashboards." Target **26.3 LTS** (v26.3.12.3, 2026-05-22) — several defaults below changed in the 26.x line, so version matters.
 
-The one-line fork before you write any DDL:
-
-- Files on a laptop, in-process, no server, no concurrent writers → that is **duckdb**, not this skill.
-- App CRUD, point updates, foreign keys, row locks, RLS, migrations → that is **postgresdb**.
-- `clickhouse-server`, replication, concurrent writers, 100M+ rows/s ingest → **this skill**.
+The fork before you write any DDL: files on a laptop, in-process, no server, no concurrent writers → `../duckdb/SKILL.md`; app CRUD, point updates, foreign keys, row locks, RLS, migrations → `../postgresdb/SKILL.md`; `clickhouse-server`, replication, concurrent writers, 100M+ rows/s ingest → this skill.
 
 Instrumenting capture (GA4/PostHog) is `../analytics/SKILL.md`; charting the result for humans is `../dashboard/SKILL.md`; deciding which metrics matter is `../kpi-framework/SKILL.md`. ClickHouse is the engine underneath all three.
 
@@ -33,8 +29,6 @@ The engine decides dedup and merge behavior, and you cannot change `ORDER BY`/`P
 Default to `MergeTree`. Move to `AggregatingMergeTree` only when you are pre-aggregating through a materialized view. Full matrix and reasoning: `references/schema-and-engines.md`.
 
 ## Schema rules
-
-Each rule, then the one-line reason.
 
 1. **`ORDER BY` is your single biggest perf lever — a good one cuts query time ~100x.** It defines the sparse primary index that prunes which granules get read. Get this right above everything else.
 2. **Order the key low-cardinality → high-cardinality, left to right, driven by `WHERE`/`GROUP BY` — never by join keys.** 3–5 columns. The leftmost column should be the one you filter on most; cardinality rises as you go right. Timeseries: put the raw timestamp last, often `(tenant_id, toStartOfDay(ts), event_type, ts)`.


### PR DESCRIPTION
## Metrics

| | Before | After |
|---|---|---|
| `description` chars | 877 | **350** |
| SKILL.md bytes | 12198 | **11599** |
| SKILL.md lines | 165 | **159** |
| `eval-lint` | PASS | **PASS** (7 should_trigger / 5 should_not_trigger / 1 capability) |

## What went

- **The `Triggers:` phrase list** (8 quoted prompts across EN/ES/CA) — 527 of the 877 description chars. The description is in context on every turn the skill is installed, invoked or not, so keyword lists are pure per-turn cost; the model matches by meaning, and those exact intents already live in `evals/cases.yaml` where they cost nothing at runtime.
- **The five-line pre-DDL fork block**, collapsed to one line. Every signal survives verbatim (laptop/in-process/no-concurrent-writers; CRUD/point-updates/FK/row-locks/RLS/migrations; `clickhouse-server`/replication/100M+ rows/s), and the bold sibling names are now real `../duckdb/SKILL.md` and `../postgresdb/SKILL.md` links.
- **"Each rule, then the one-line reason."** — a signpost restating the structure directly below it.

## What stayed, and why

This skill already met most of the rubric at 165 lines, so the honest diff is small.

- **The anti-patterns table** — required by the rubric, and it names concrete failure modes rather than restating rules.
- **The engine decision table** — the flow genuinely branches on it, and the choice is irreversible without a rebuild.
- **The five schema rules** — each already sits next to the DDL it governs and states *why* inline, not in an appendix; this is the shape the rubric asks for, not a rule bank.
- **Bad/good ingestion and MV pairs** — they teach judgment by demonstration.
- **Query-optimization ladder, Operations, and the `verify.sh` contract** — all actionable and unduplicated.

## Invariants checked

- All three `references/` files (`schema-and-engines.md`, `ingestion-and-mvs.md`, `query-optimization.md`) remain linked inline from the body.
- All five `../<sibling>/SKILL.md` links resolve to real skills: `duckdb`, `postgresdb`, `analytics`, `dashboard`, `kpi-framework`.
- `description` parses as single-line quoted YAML, 350 chars, opens with "Use when", carries an explicit `NOT … (that is <sibling>)` boundary.
- No `manifest.json` edit. No recommendation, version (26.3 LTS / 26.2 / 26.1 defaults), figure, or command changed — this was a context-engineering pass, not a content rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)