### PR TITLE
refactor(codebase-onboarding): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/codebase-onboarding/SKILL.md
+++ b/skills/codebase-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-onboarding
-description: "Use when you land in an unfamiliar or inherited codebase and must get productive fast — map the entry points, the request/data flow, who owns the business logic, the hidden side effects (cron, webhooks, workers, listeners) and the hotspot files, before you touch anything. Triggers: 'I just cloned this repo and don't know where anything is', 'I inherited this project, map it before I change something', 'where does the business logic actually live', 'what happens behind the scenes when a request hits /checkout', 'which files are the dangerous ones nobody understands', 'acabo de heredar este repo y no sé por dónde empezar, mápamelo', 'mapea este codebase'. NOT a deep correctness/security audit of one module (that is analyze)."
+description: "Use when you land in an unfamiliar or inherited codebase and must get productive fast: a breadth-first map of entry points, request flow, module ownership, hidden side effects (cron, webhooks, workers) and churn hotspots, committed as CODEBASE-MAP.md. NOT a deep audit of one module (that is `analyze`) or chasing one failure (that is `debug`)."
 tags: [onboarding, codebase, code-mapping, legacy-code, architecture, reverse-engineering, hotspots]
 recommends: [analyze, debug, decision-records, harness, init, knowledge-ops]
 origin: risco
@@ -68,7 +68,7 @@ git log --format=format: --name-only --since=12.month \
   | grep -v '^$' | sort | uniq -c | sort -nr | head -50
 ```
 
-The richer move is **churn × complexity**: the top-right quadrant (changes constantly *and* is hard to read) is your real danger zone (understandlegacycode.com Hotspots, accessed 2026-06-02). Escalate to that — or to a tree-sitter dependency graph — only when grep + churn is not enough; see the playbook.
+The richer move is **churn × complexity**: the top-right quadrant (changes constantly *and* is hard to read) is your real danger zone (understandlegacycode.com Hotspots, accessed 2026-06-02). Escalate to that — or to a tree-sitter dependency graph — only when grep + churn is not enough: `references/recon-playbook.md` has the churn×complexity recipe (code-maat) and when codegraph PageRank / FileScopeMCP earn their setup cost.
 
 **g. Confirm hands-on.**
 Run the app, walk one end-user journey, send a real request, watch the logs. Reading alone leaves the map unverified; a single real request validates the whole trace in step c.
@@ -106,9 +106,6 @@ rg -n "queue|worker|bull|sidekiq|celery|sqs|rabbitmq|kafka|@task" -i
 
 # Env-driven branches (hidden config-conditional behavior)
 rg -n "process\.env\.|os\.environ|ENV\[|getenv" 
-
-# Hotspots: churn over the last year
-git log --format=format: --name-only --since=12.month | grep -v '^$' | sort | uniq -c | sort -nr | head -50
 ```
 
 ## Writing & maintaining the map
@@ -129,5 +126,3 @@ git log --format=format: --name-only --since=12.month | grep -v '^$' | sort | un
 | Map lives only in chat | Dies with the session; next agent redoes it | Write & commit `CODEBASE-MAP.md` |
 | Guess instead of grep | Confident-wrong is worse than slow-right | Form the hypothesis, then `rg` to confirm or kill it |
 | Stand up a tree-sitter MCP graph on a 5-file repo | Setup costs more than the whole recon | Reserve graph tools for large monorepos; grep + churn first |
-
-See `references/recon-playbook.md` for per-ecosystem entry points and side-effect patterns, the churn×complexity recipe (code-maat), and when a tree-sitter graph (codegraph PageRank, FileScopeMCP) earns its setup cost.


### PR DESCRIPTION
Context-engineering pass on `skills/codebase-onboarding/SKILL.md` per `scripts/skill-migration-brief.md`. Format only — no recommendation, version, command, or figure changed.

## Numbers

| | Before | After |
| --- | --- | --- |
| description | 732 chars | **344 chars** (-53%) |
| body | 10175 bytes / 133 lines | **9539 bytes / 128 lines** |
| eval-lint | — | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

## What went

- **The `Triggers:` list** — seven quoted phrases in English and Spanish. The model matches by meaning; a keyword catalog is pure per-turn cost, paid on every turn the skill is installed whether or not it fires. The phrases it enumerated are already the eval `should_trigger` cases, which is where they belong.
- **The trailing reference index** — the closing `See references/recon-playbook.md for …` line. Its unique substance (the churn×complexity recipe / code-maat, and when codegraph PageRank or FileScopeMCP earn their setup cost) was folded into recon step f, where that escalation decision is actually made. The playbook link still resolves from two other inline points of use, so the reference is not orphaned.
- **A verbatim duplicate command** — the git-churn one-liner appeared identically in step f and again in the command appendix.

## What stayed, and why

- **The anti-patterns table.** Rubric-required, and a different animal from a rationalization bank: it names concrete failure modes (read every file top-to-bottom, trust the README over the code, tree-sitter graph on a 5-file repo) rather than restating rules already given above it.
- **The repo-shape scope table.** The flow genuinely branches on repo size — tiny vs single-service vs monorepo vs polyglot change which recon steps run and whether a graph tool is worth standing up.
- **The two operating rules.** They carry the martinfowler.com (Böckeler) and understandlegacycode.com groundings that dimension 4 rests on; they are cited judgment, not shouted constraint.
- **The `CODEBASE-MAP.md` schema block** — it is the deliverable `scripts/verify.sh` checks for, so it is load-bearing.
- **The rest of the command appendix**, every version (`scc` v3.7.0), every figure (2x onboarding speedup), every source date.

## Boundary

Description now reads what · when · NOT, and names the two real siblings the evals already assert as near-miss routes: `analyze` (deep audit of one module) and `debug` (chasing one failure). Both verified present under `skills/`.

## Verification

- `bash scripts/eval-lint.sh` → `codebase-onboarding    PASS`
- description 344 chars, parses as single-line quoted YAML
- `references/recon-playbook.md` — the only reference file — still linked from the body
- all six `../<sibling>/SKILL.md` links resolve
- `manifest.json` untouched (orchestrator regenerates); no `npm test` / `npm run validate` run (no `node_modules` in this worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)