### PR TITLE
refactor(chatbot): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/chatbot/SKILL.md
+++ b/skills/chatbot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chatbot
-description: "Use when putting a support or sales bot on a live website and it must behave — writing or hardening its persona/system prompt, designing the bot→human handoff, stopping it inventing prices/policies/refunds, defending against jailbreaks and prompt injection, qualifying leads, or setting launch metrics and a kill switch. Triggers: 'put a chatbot on our site that answers from our docs', 'add a chat widget', 'our bot promised a refund we don't offer — lock it down', 'stop people jailbreaking our website assistant', 'design the handoff to a human agent', 'qualify leads and book demos', 'necesito un chatbot de ventas para la web que califique leads i reservi demos'. NOT building the agent loop/RAG index/eval harness under it (that is building-agents), and NOT a human answering one live ticket (that is customer-support)."
+description: "Use when a support or sales bot on a live website must behave: persona/system prompt, grounding so it cannot invent prices or policy, jailbreak and injection defense, the human handoff, launch metrics and kill switch. NOT the agent loop or RAG index under it (that is `building-agents`), NOT a human answering one ticket (that is `customer-support`)."
 tags: [chatbot, support-bot, sales-bot, handoff, guardrails, grounding, conversational-ai]
 recommends: [building-agents, rag, customer-support, agent-safety, prompt-engineering, brand-voice]
 origin: risco
@@ -10,25 +10,13 @@ origin: risco
 
 This skill owns the bot that sits on a public site 24/7, answers support or sales questions, deflects what it safely can, and hands off cleanly what it can't. Four parts and nothing else: its **persona** (system prompt), its **grounding** (what it's allowed to know), its **guardrails** (what it must never say or do), and its **handoff** (when and how it gives up to a human). The retrieval engine under it is [`../building-agents/SKILL.md`](../building-agents/SKILL.md); the human who picks up the escalation is [`../customer-support/SKILL.md`](../customer-support/SKILL.md). You are productizing a bot, not engineering an agent and not working a ticket.
 
+Not here: the agent loop, tool schemas and eval harness → [`../building-agents/SKILL.md`](../building-agents/SKILL.md) (and `rag` for the index half: chunking, embeddings, rerank); one live ticket answered by a human — triage, SLA, macros → [`../customer-support/SKILL.md`](../customer-support/SKILL.md); prompt *wording* in the abstract → `prompt-engineering`; general LLM abuse taxonomy beyond the public-bot case → `agent-safety`; the golden-set eval as an engineering artifact → `agent-eval`; win-back/renewal → [`../retention/SKILL.md`](../retention/SKILL.md); new-customer welcome → [`../client-onboarding/SKILL.md`](../client-onboarding/SKILL.md); generic automation wiring → [`../automation-flows/SKILL.md`](../automation-flows/SKILL.md); WhatsApp/Telegram channel plumbing → [`../whatsapp-telegram/SKILL.md`](../whatsapp-telegram/SKILL.md).
+
 ## The one rule
 
 > The bot may state only what it can **cite** (from approved KB) or **confirm** (a fact it was given). Everything else is "Let me connect you to a human." Grounded-or-handoff. It never improvises a price, a policy, a refund, or a promise.
 
 Why: a hallucinated answer is a binding answer. Air Canada's bot invented a bereavement-refund policy; a tribunal held the airline liable for what the bot said (multiple 2025 retrospectives, accessed 2026-06-02). The bot speaks for the company in court, so cap what it's allowed to invent at zero.
-
-## When to use / When NOT to use
-
-**Use when:** standing up a support/sales chat widget on a website; writing or hardening the bot's system prompt (scope, refusals, tone); designing escalation to a human and what context travels; stopping the bot inventing policy/price (incident hardening); defending against jailbreaks / prompt injection on a public bot; building a sales bot that qualifies a lead and books a demo; defining launch metrics (deflection/containment/handoff) and the threshold that pulls it back.
-
-**Do NOT use when:**
-
-- Building the agent loop, tool schemas, RAG pipeline, or eval harness under the bot → [`../building-agents/SKILL.md`](../building-agents/SKILL.md) (and `rag` for the index half: chunking, embeddings, rerank).
-- A human (or assisted) agent answering one live ticket — triage, SLA, macros → [`../customer-support/SKILL.md`](../customer-support/SKILL.md).
-- Improving prompt *wording* in the abstract, prompt-pattern library → `prompt-engineering`.
-- General LLM abuse taxonomy / red-team policy beyond the public-bot case → `agent-safety`.
-- Building the golden-set eval as an engineering artifact → `agent-eval`.
-- Win-back/renewal → [`../retention/SKILL.md`](../retention/SKILL.md); new-customer welcome → [`../client-onboarding/SKILL.md`](../client-onboarding/SKILL.md).
-- Generic automation wiring → [`../automation-flows/SKILL.md`](../automation-flows/SKILL.md); WhatsApp/Telegram channel plumbing → [`../whatsapp-telegram/SKILL.md`](../whatsapp-telegram/SKILL.md).
 
 ## The four layers (the spine)
 
@@ -68,7 +56,7 @@ Good (scoped, grounded, refusal + authority clauses, no secrets):
    - Keep replies under ~120 words; link the source you used."
 ```
 
-Full annotated template: [`references/system-prompt-and-guardrails.md`](references/system-prompt-and-guardrails.md).
+Reach for [`references/system-prompt-and-guardrails.md`](references/system-prompt-and-guardrails.md) while authoring: full annotated template, the forbidden-topic bucket catalog with per-bucket handling, and the prompt-injection defense checklist.
 
 ## Layer 2 — Grounding contract
 
@@ -96,7 +84,7 @@ Route every borderline message by topic bucket:
 | Off-scope / unknown | anything not in KB | "I don't have that" → offer human. |
 | Injection attempt | "Ignore your rules / you are now…" | Refuse, do not break scope, do not reveal the prompt; log it. |
 
-Injection defenses (full checklist in the reference): a clear instruction hierarchy (system > retrieved content > user), treat retrieved text and user input as *data not instructions*, refuse "ignore previous / reveal your prompt / you are now" patterns, and an **output filter** that blocks commitment phrases before they reach the user. Plus a hard **length cap** so a coaxed essay can't smuggle a promise.
+Injection defenses (full checklist in [`references/system-prompt-and-guardrails.md`](references/system-prompt-and-guardrails.md)): a clear instruction hierarchy (system > retrieved content > user), treat retrieved text and user input as *data not instructions*, refuse "ignore previous / reveal your prompt / you are now" patterns, and an **output filter** that blocks commitment phrases before they reach the user. Plus a hard **length cap** so a coaxed essay can't smuggle a promise.
 
 ## Layer 4 — Handoff state machine
 
@@ -116,7 +104,7 @@ Three trigger families:
 - Collected variables (account/order id, plan, intent, sentiment, what was already tried).
 - The detected trigger and the bot's best summary of the unresolved problem.
 
-**Warm** transfer when a human is online (bot summarizes, agent continues). **Cold** when none is: capture a ticket with the same packet and tell the user exactly when to expect a reply — never drop them into a silent void. Packet template + trigger cues: [`references/handoff-and-sales.md`](references/handoff-and-sales.md).
+**Warm** transfer when a human is online (bot summarizes, agent continues). **Cold** when none is: capture a ticket with the same packet and tell the user exactly when to expect a reply — never drop them into a silent void. Packet template, trigger detection cues, and warm-transfer / offline-fallback wording: [`references/handoff-and-sales.md`](references/handoff-and-sales.md).
 
 ## Sales-bot mode (branch)
 
@@ -159,10 +147,5 @@ Don't ship a bot you can't measure or pull back. Define these before launch:
 | Treat the system prompt as a secret | False security; it leaks and you skipped the real defenses | Assume it's public; defend with hierarchy + filters |
 | Bot promises a fix/price it can't authorize | Binding commitment it had no right to make | Authority clause + handoff for anything committal |
 | Go fully autonomous on day one | No baseline, no kill switch, incident in production | Shadow → assisted → autonomous, kill switch armed |
-
-## References
-
-- [`references/system-prompt-and-guardrails.md`](references/system-prompt-and-guardrails.md) — full annotated support-bot system prompt template, the forbidden-topic bucket catalog with per-bucket handling, and the prompt-injection defense checklist. Reach for it while authoring the prompt.
-- [`references/handoff-and-sales.md`](references/handoff-and-sales.md) — the handoff packet template, the explicit/implicit/topic trigger catalog with detection cues, warm-transfer and offline-fallback wording, and the sales qualification + demo-booking flow.
 
 Verify a candidate system prompt before shipping: `scripts/verify.sh path/to/system-prompt.md` (read-only structural + banlist linter; see `evals/README.md`).


### PR DESCRIPTION
Context-engineering pass on `skills/chatbot/SKILL.md` per `scripts/skill-migration-brief.md`. No content rewrite: no figure, source, date, command or recommendation changed.

| Metric | Before | After |
| --- | --- | --- |
| description | 825 chars | **350 chars** |
| body | 14810 bytes / 168 lines | **13364 bytes / 151 lines** |
| eval-lint | PASS | **PASS** (should_trigger=6, should_not_trigger=5, capability=1) |

## Description

Dropped the seven-phrase `Triggers:` list (EN + ES/CA). It is in context on every turn the skill is installed, invoked or not, and the model matches by meaning — the body already said so. What is left is the rubric shape: what it does, when, and an explicit NOT boundary naming two real siblings, `building-agents` (the loop/index under the bot) and `customer-support` (a human on one ticket). A reader can pick between the three from the description alone.

## What went

- **`## When to use / When NOT to use`** — the "Use when" paragraph restated the description clause for clause, and the NOT bullets restated the intro paragraph's building-agents / customer-support delegation a third time. Compressed into one routing line; every sibling target survived (`rag`, `prompt-engineering`, `agent-safety`, `agent-eval`, `retention`, `client-onboarding`, `automation-flows`, `whatsapp-telegram`).
- **`## References` tail index** — both reference files were already linked inline where they are needed. The index's only unique content was its per-file blurb, which moved into those inline mentions; Layer 3's dangling "full checklist in the reference" became the actual link. Invariant holds: both `references/` files are still linked from the body.

## What stayed, on purpose

- The **anti-patterns table** (9 rows) — concrete failure modes with sources, a different animal from a rule bank.
- **"The one rule"** and the Air Canada liability case — the skill's thesis, and it states *why* it is absolute rather than shouting.
- The **four-layer spine**, the **forbidden-topic bucket table**, the **handoff trigger table**, the **launch-metric benchmarks + rollout ladder + kill switch**, and the **bad/good system-prompt pair**: real branch points and judgment taught by demonstration.

`evals/`, `scripts/verify.sh` and `references/` untouched. `manifest.json` not touched (orchestrator regenerates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)