### PR TITLE
refactor(calendar-scheduling): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/calendar-scheduling/SKILL.md
+++ b/skills/calendar-scheduling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: calendar-scheduling
-description: "Use when adding booking/scheduling to a product — a 'pick a slot' page, an embedded Cal.com/Calendly widget, or a flow that shows real availability and writes the confirmed meeting to Google/Outlook/Apple — and when fixing the three classic bugs: double-booking, wrong-time-after-DST, and orphaned events on reschedule. Triggers: 'add a book-a-call page', 'embed Cal.com and white-label it', 'show my real availability and create the calendar event', 'we keep getting double-booked when two people pick the same slot', 'bookings show the wrong time after the clocks changed', 'fire a webhook on each booking', 'añade reservas de citas a la web y evita solapamientos con mi calendario de Outlook', 'evita que se reserve dos veces el mismo hueco'. NOT raw calendar CRUD, free/busy plumbing, or watch channels for an internal app with no booking surface (that is google-workspace), NOT a generic non-booking inbound event receiver (that is webhooks), NOT charging for a paid appointment (that is stripe)."
+description: "Use when a product needs a booking surface — a pick-a-slot page, a Cal.com/Calendly embed, or real availability plus the confirmed meeting written to Google/Outlook — or when fixing double-booking, DST drift, or orphaned reschedule events. NOT calendar CRUD with no booking surface (that is `google-workspace`), NOT the payment (that is `stripe`)."
 tags: [scheduling, booking, calendar, calcom, calendly, google-calendar, availability, webhooks]
 recommends: [google-workspace, webhooks, automation-flows, email-connector, stripe, sales-pipeline]
 profiles: []
@@ -12,17 +12,9 @@ origin: risco
 Scheduling is always two halves bolted together: a **booking surface** (an
 external person reserves a slot — embed, atom, or API call) and **calendar
 sync** (you read free/busy to compute availability and write the confirmed
-event back). Ship one without the other and you get the three bugs this skill
-exists to prevent:
-
-- **Double-booking** — two people grab the same slot because availability was
-  computed in the browser or written before a re-check.
-- **Timezone drift** — a meeting shows the wrong hour after a DST change because
-  a wall-clock time was stored instead of an instant + IANA zone.
-- **Orphaned events** — a reschedule creates a *second* calendar event instead
-  of moving the first, so the calendar fills with phantoms.
-
-Everything below is in service of not shipping those.
+event back). Ship one without the other and you get the three bugs the rest of
+this skill exists to prevent: **double-booking**, **timezone drift** after a DST
+change, and **orphaned events** on reschedule.
 
 ## Decide the altitude first
 
@@ -38,7 +30,9 @@ Pick the lowest-code option that still owns the data model you actually need.
 Why per row: the embed is zero-maintenance but a black box; the atom/API buys
 your own UI without owning sync; raw provider is full control and full
 liability; a unified API trades a vendor for not maintaining three calendar
-integrations. Full comparison in `references/provider-matrix.md`.
+integrations. Hosting, auth/scopes, webhook events, cross-domain support and
+when each wins, per provider:
+[`references/provider-matrix.md`](references/provider-matrix.md).
 
 - **Cal.com** is open-source and self-hostable. Self-hosted instances get
   **unlimited API access** (no cloud rate limit) and full white-label by
@@ -78,9 +72,6 @@ Scope ladder, narrowest first:
 - `calendar` / `calendar.events` — restricted; request only if you genuinely
   manage arbitrary events the app didn't create.
 
-**Calendly:** OAuth 2.1 or a personal access token. **Cal.com self-host:** no
-rate-limit anxiety, so no token-bucket gymnastics needed in your client.
-
 ## Availability without double-booking — the core flow
 
 Both classic races (computing slots in the browser, and writing the event
@@ -107,8 +98,10 @@ Decision — do you need a hold step?
 | Multi-step booking form, payment, or high contention | Yes — a TTL lock so the slot survives the form and releases if abandoned |
 
 Google's availability primitive is `freebusy.query` (POST, returns busy blocks
-per calendar); the write is `events.insert`. Payloads in
-`references/google-calendar-sync.md`.
+per calendar); the write is `events.insert`. Both payloads (with
+`conferenceData` for Meet), `watch` channels + sync tokens, recurring-event edge
+cases and refresh-token handling:
+[`references/google-calendar-sync.md`](references/google-calendar-sync.md).
 
 ## Timezone correctness
 
@@ -179,15 +172,6 @@ that orchestration is **automation-flows**, not here.
 | Cache a single-use scheduling link forever | Calendly links expire after 90 days | Generate on demand; treat expiry as expected |
 | Poll the calendar for changes | Slow, rate-limited, misses edits | `watch` push channels + incremental sync tokens |
 | Write new code against Calendly v1 | v1 API + webhooks dead since May 2025 | Calendly v2 (OAuth 2.1 / PAT) |
-
-## References
-
-- `references/provider-matrix.md` — Cal.com vs Calendly vs Google direct vs
-  Nylas v3 vs Cronofy: hosting, auth/scopes, webhook events, cross-domain,
-  when each wins.
-- `references/google-calendar-sync.md` — `freebusy.query` and `events.insert`
-  (with `conferenceData` for Meet) payloads, `watch` channels + sync tokens,
-  recurring-event edge cases, refresh-token handling.
 
 Adjacent skills: raw calendar CRUD / watch channels with no booking →
 [`../google-workspace/SKILL.md`](../google-workspace/SKILL.md); charging for a


### PR DESCRIPTION
Context-engineering pass on `skills/calendar-scheduling/SKILL.md` against `scripts/skill-rubric.md`. No substance changed — every recommendation, version, endpoint, scope, figure and date is byte-identical to `main`.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 1001 | **347** (target ≤350, hard limit 1024) |
| body bytes | 11811 | **10502** |
| body lines | 197 | **181** (ceiling 400) |
| `scripts/eval-lint.sh` | PASS | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

## What went

- **The `Triggers: '…'` phrase list** — 8 quoted phrases across English and Spanish, in context on every turn the skill is installed whether or not it fires. The model matches by meaning; the list was pure per-turn cost. This is the bulk of the 654 chars saved.
- **One of the three NOT boundaries.** Kept `google-workspace` (the nearest miss — raw calendar CRUD with no booking surface) and `stripe`. Dropped the `webhooks` clause from the description: it is already stated in the body next to the booking-lifecycle mapping it governs, which is where a rule gets followed rather than skimmed. Discrimination against the nearest sibling is unchanged.
- **The intro's three-bullet preview** of double-booking / timezone drift / orphaned events. Each has its own section below *and* a row in the anti-patterns table — the same content at a third layer. Compressed to one sentence that still names all three.
- **A duplicated fact pair** at the end of the scopes section (`**Calendly:** OAuth 2.1 or a PAT` / `**Cal.com self-host:** no rate-limit anxiety`). Both already appear verbatim in the altitude section 30 lines above.
- **The trailing `## References` index.** Both files were already pointed to inline at point of use; the index's extra detail (per-provider hosting/auth/webhook events; Meet `conferenceData`, `watch` channels, sync tokens, refresh-token handling) was folded into those inline mentions, which are now real markdown links rather than bare code spans.

## What deliberately stayed

- **The anti-patterns table, whole (9 rows).** The rubric requires one, and these are concrete failure modes — not a rationalization bank restating rules already given above.
- **Both decision tables.** The altitude table (embed / Booker atom / raw provider / unified API) and the hold-step branch. The flow genuinely forks at both.
- **Both bad/good worked pairs** (restricted vs granular OAuth scopes; floating wall-clock vs instant + IANA `timeZone`) **and** the scope ladder. The pair teaches by demonstration, the ladder discriminates five tiers; neither substitutes for the other.
- **The `Adjacent skills:` routing line**, all four links intact — including `sales-pipeline` and `email-connector`, which appear nowhere else.

## Gates

- `bash scripts/eval-lint.sh` → `calendar-scheduling    PASS (should_trigger=7, should_not_trigger=5, capability=1)`
- Both `references/` files still linked from the body (unlinked references are never loaded).
- All four `../<sibling>/SKILL.md` links resolve; `google-workspace` and `stripe` named in the description both exist.
- `description` parses as single-line quoted YAML at 347 chars.
- `manifest.json` untouched — the orchestrator regenerates it after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
