### PR TITLE
refactor(compose-multiplatform): cut the trigger-phrase list from the description

### DIFF
--- a/skills/compose-multiplatform/SKILL.md
+++ b/skills/compose-multiplatform/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-multiplatform
-description: "Use when building shared UI across Android, iOS, and desktop from one Kotlin codebase with Compose Multiplatform — shared commonMain @Composables, expect/actual for platform divergence, native interop, multiplatform ViewModel/navigation/Koin. Triggers: 'share one Compose UI across Android and iOS', 'my expect has no actual and the build fails', 'where does this code go — commonMain or iosMain', 'embed a SwiftUI/UIKit view inside shared Compose with UIKitView', 'host shared Compose in a SwiftUI app', 'add a desktop target and package it', 'compartir la UI entre Android i iOS amb Kotlin', 'una sola UI para Android, iOS y escritorio'. NOT a single-platform native build (that is kotlin-android / swift-ios), and NOT Dart/Flutter cross-platform UI (that is flutter)."
+description: "Use when building one shared Compose UI in Kotlin across Android, iOS, and desktop — commonMain @Composables, expect/actual, source-set placement, native interop, multiplatform ViewModel/navigation/Koin. NOT a single-platform native build (that is kotlin-android / swift-ios), and NOT Dart/Flutter cross-platform UI (that is flutter)."
 tags: [kotlin, kmp, compose-multiplatform, cross-platform, shared-ui, expect-actual, ios, android]
 recommends: [kotlin-android, swift-ios, flutter, tauri]
 origin: risco


### PR DESCRIPTION
## Metrics

| | Before | After |
|---|---|---|
| `description` chars | 770 | **334** (target ≤350, hard limit 1024) |
| SKILL.md bytes | 11186 | **10748** |
| SKILL.md lines | 190 | 190 (ceiling 400) |
| `eval-lint.sh` | — | **PASS** (should_trigger=6, should_not_trigger=4, capability=1) |

## What went

- The `Triggers: '…'` list — eight phrases across English, Catalan, and Spanish. It is paid for on every turn the skill is installed, invoked or not, and the model matches by meaning, so the keyword list bought nothing.

## What stayed, and why

- **The body, unchanged.** It already meets the rubric: no rule bank, no "When to use" section restating the description, no trailing reference index, no re-teaching of what `kotlin-android` or `swift-ios` own. Nothing in it could be cut without losing routing.
- **The source-set placement table** — the daily "commonMain or iosMain?" decision, and a genuine branch in the flow.
- **The anti-patterns table** — concrete failure modes (platform import in `commonMain`, orphan `expect`, Web-as-production), not rules already stated above it. Required by the rubric.
- **The `expect`/`actual` rules** — each states the reason it exists and sits next to the mechanism it governs, which is the form the brief asks for.
- **The 2026 versions floor and the bad/good `expect class` vs common-`interface` pair** — substance and judgment-by-demonstration.

## Invariants checked

- Both `references/` files are still linked inline at point of use: `project-setup.md` (Gradle wiring) and `ios-interop.md` (twice, in the interop section).
- The `NOT` boundary names real siblings: `skills/kotlin-android/`, `skills/swift-ios/`, `skills/flutter/` all exist.
- `manifest.json` untouched — the orchestrator regenerates it.
- No substance changed: no version, command, figure, or recommendation was altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
