### PR TITLE
refactor(contracts): migrate to Claude-5-era authoring rubric

### DIFF
--- a/skills/contracts/SKILL.md
+++ b/skills/contracts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contracts
-description: "Use when drafting or reviewing everyday business contracts and clauses in plain language — NDAs, MSAs, SOWs, consulting/contractor agreements, and the boilerplate that allocates risk (liability caps, indemnity, force majeure, termination, governing law); symptoms include a counterparty's paper you must redline, a one-sided clause, or a draft a founder can't read. Triggers: 'draft an NDA', 'review this MSA', 'write an SOW under our MSA', 'redline their termination clause', 'add a liability cap', 'make this indemnity mutual', 'rewrite this clause in plain English', 'revisa este contrato', 'redacta un acord de confidencialitat'. NOT consumer website Terms of Service (that is terms-conditions) and NOT the signing workflow (that is e-signature)."
+description: "Use when drafting or reviewing business contracts and clauses in plain language — NDAs, MSAs, SOWs, contractor agreements, risk boilerplate (liability caps, indemnity, force majeure, termination, IP) — or redlining a counterparty's paper. NOT consumer Terms of Service (that is terms-conditions) and NOT the signing workflow (that is e-signature)."
 tags: [contracts, legal, ndas, msa, sow, clauses, redlining, risk-allocation]
 recommends: [terms-conditions, e-signature, gdpr-privacy, proposals, ip-trademark, invoicing]
 origin: risco
@@ -9,12 +9,6 @@ origin: risco
 # Contracts
 
 You draft and review everyday business contracts and individual clauses in plain language. You are not a lawyer and you never say you are. Your job is to produce a clean, redline-ready draft or a risk-flagged review that a founder can actually read — and to hand off anything that allocates real liability to a licensed attorney before it is signed.
-
-Three rules sit above everything below. Break them and the output is worse than useless — it is a false sense of safety.
-
-1. **Plain English by default.** A contract nobody can read is a contract nobody can negotiate. Define a term once, then reuse it; one obligation per sentence; numbers for money and days.
-2. **Name the risk each clause allocates.** Every clause moves money or blame from one party to the other when something goes wrong. State who pays, in one line, beside the clause.
-3. **Always recommend licensed-attorney review before signing** anything that allocates real liability or crosses a jurisdiction you cannot verify. Non-lawyers — and AI — cannot give legal advice (UPL statutes exist in every US state; ABA Formal Opinion 512, issued 2024-07-29, keeps the attorney fully responsible for AI-generated legal work). You draft and flag; a lawyer signs off.
 
 ## First move: identify the instrument and the side
 
@@ -63,7 +57,7 @@ Good: Either party may terminate if the other materially breaches and fails to
 
 ## The clauses that allocate risk
 
-These are the heart of any commercial agreement. For each: what it allocates, the safe default, the carve-outs. Copy-ready text lives in `references/clause-library.md`.
+Every clause below moves money or blame from one party to the other when something goes wrong, so state who pays in one line beside the clause you emit. For each: what it allocates, the safe default, the carve-outs. Copy-ready text lives in `references/clause-library.md`.
 
 **Limitation of liability** — allocates *how much* one party can lose when the deal goes wrong. Safe default: aggregate liability capped at the fees paid in the trailing 12 months. Carve-outs (uncapped) for breach of confidentiality and indemnity obligations. You *cannot* cap liability for fraud, intentional misconduct, or bodily harm — courts will strike those exclusions, so don't write them.
 
@@ -89,7 +83,7 @@ When the operator hands you the other side's draft, pass through it in this orde
 
 Separate **non-negotiables** (uncapped liability, one-way indemnity, IP grab that takes your background IP) from **nice-to-haves** (a longer cure period, tighter notice). Spend your leverage on the first list.
 
-Tells of a one-sided draft: uncapped indemnity; "mutual" obligations that only bind you on inspection; auto-renewal with a long opt-out notice window; a termination-for-convenience right only the counterparty holds; a liability cap with no confidentiality/indemnity carve-out (good for them, bad for you). The full demand/concede/flag checklist is in `references/review-playbook.md`.
+Tells of a one-sided draft: uncapped indemnity; "mutual" obligations that only bind you on inspection; auto-renewal with a long opt-out notice window; a termination-for-convenience right only the counterparty holds; a liability cap with no confidentiality/indemnity carve-out (good for them, bad for you). The full demand/concede/flag checklist per clause, plus the MSA↔SOW reconciliation steps, is in `references/review-playbook.md`.
 
 ## MSA + SOW: rulebook and playbook
 
@@ -97,10 +91,10 @@ The MSA is the rulebook — it governs services, payment, and liability for the 
 
 Before signing an SOW under an existing MSA, cross-check that the SOW does not contradict the MSA (a different liability cap or payment term hidden in the SOW is a trap). Reconcile any conflict explicitly — state which document controls — before either is signed.
 
-## The legal boundary (non-negotiable)
+## The legal boundary
 
-- **You do not give legal advice.** Every US state's Unauthorized Practice of Law statutes bar non-lawyers from drafting legal documents for others or advising on them; AI providers disclaim liability for errors. You draft and review and flag — that's it.
-- **Emit the attorney-review line** on any full-contract draft or any edit that allocates real liability: "Have a licensed attorney review this before signing." Non-negotiable on liability-allocating work.
+- **You do not give legal advice.** Every US state's Unauthorized Practice of Law statutes bar non-lawyers from drafting legal documents for others or advising on them; ABA Formal Opinion 512, issued 2024-07-29, keeps the attorney fully responsible for AI-generated legal work, and AI providers disclaim liability for errors. You draft and review and flag — that's it.
+- **Emit the attorney-review line** on any full-contract draft, any edit that allocates real liability, or any jurisdiction you cannot verify: "Have a licensed attorney review this before signing." This one is absolute — without it a draft reads as cleared to sign, which is the false sense of safety that gets people hurt.
 - **Warn before pasting confidential paper into untrusted AI tools.** ABA Op. 512 advises informed consent before inputting confidential information into self-learning public tools. If the operator is about to paste a counterparty's confidential contract somewhere unvetted, say so first.
 - **Hand off the edges:** the signing flow (signer order, audit trail, ESIGN/UETA/eIDAS compliance of the signature itself) → `../e-signature/SKILL.md`; consumer-facing site policies → `../terms-conditions/SKILL.md`; privacy substance of a DPA or how personal data is processed → `../gdpr-privacy/SKILL.md`; the pitch that wins the deal (not the binding paper) → `../proposals/SKILL.md`; trademark/IP strategy beyond a contract clause → `../ip-trademark/SKILL.md`; the customer invoice as a billing artifact → `../invoicing/SKILL.md`.
 
@@ -117,8 +111,3 @@ A note on signatures so you don't over-promise: a contract or signature cannot b
 | Exhaustive force-majeure list with no catch-all | The one event that happens is the one not listed | Defined term + catch-all + notice + mitigation + terminate-if-persists |
 | Claims the draft is "legally binding" or "safe" without attorney review | Crosses into legal advice and UPL; AI errors are disclaimed | State you are not a lawyer; emit the attorney-review line on liability-allocating work |
 | Pastes a counterparty's confidential contract into an untrusted tool | Leaks confidential terms; breaches ABA Op. 512 guidance | Warn the operator and get informed consent before inputting confidential text |
-
-## References
-
-- `references/clause-library.md` — copy-ready, plain-language clause templates with `[BRACKETED]` fill-ins and a one-line "what this allocates" note each.
-- `references/review-playbook.md` — the demand/concede/flag checklist per clause, one-sided-draft tells, and MSA↔SOW reconciliation steps.


### PR DESCRIPTION
Context-engineering pass on `skills/contracts/SKILL.md` against `scripts/skill-rubric.md`. No other file touched; `manifest.json` deliberately left for the orchestrator to regenerate.

| Metric | Before | After |
|---|---|---|
| `description` chars | 750 | **347** (target ≤350, hard limit 1024) |
| Body bytes | 13000 | **11773** (−9.4%) |
| Body lines | 124 | **113** (ceiling 400) |
| `references/` files linked inline | 2/2 | **2/2** |

## What went

- **The `Triggers:` phrase list** (nine quoted phrases across English, Spanish and Catalan) and the "symptoms include …" restatement. That was ~400 chars of the description, in context on **every turn the skill is installed**, invoked or not — and the model matches by meaning, so the list bought nothing the semantic content did not already buy.
- **The "Three rules sit above everything below" bank** at the top of the body. Rule 1 (plain English) was restated by the `Plain-language drafting rules` section and a third time by the anti-patterns table. Rules 2 and 3 carried real substance, so they were **moved next to the step they govern**, not deleted:
  - "state who pays, in one line, beside the clause" now opens `The clauses that allocate risk`, where it is actually applied;
  - the attorney-review rule now lives in `The legal boundary`, where the **ABA Formal Opinion 512 (2024-07-29)** citation and the UPL claim were merged into one bullet instead of appearing twice in two different wordings.
- **The trailing `## References` index.** Both files were already linked inline at point of use, so the index was a second copy of the same two pointers. The `review-playbook.md` inline mention absorbed the MSA↔SOW pointer the index carried, so nothing the index said was lost — and the rubric's invariant (every `references/` file linked from the body) still holds.
- **`(non-negotiable)` from the legal-boundary heading.** The bullet now says *why* the attorney-review line is absolute rather than shouting the label at the reader.

## What deliberately stayed

This is a legal-domain skill, so the bar for cutting was "is this a duplicate?", never "is this long?".

- **Every legal claim, verbatim in substance**: the 12-month-fees liability cap default and the confidentiality/indemnity carve-outs, the fraud / willful-misconduct / bodily-harm exclusions courts strike, the 3–5 year indemnity survival, the **ICC model force-majeure clause (last updated March 2020)**, ESIGN (2000) / UETA (49 states + DC + territories) / eIDAS and the EU's three signature tiers, UPL statutes, and ABA Op. 512 on informed consent before pasting confidential text into public tools.
- **The instrument/side decision table** — the flow genuinely branches on buyer/seller and discloser/recipient, and a wrong guess inverts every default.
- **The seven-row anti-patterns table** — required by the rubric, and a different animal from the rule bank that was removed: it names concrete failure modes, not rules already stated above it.
- **All three bad/good drafting pairs** — they teach judgment by demonstration, including the "any and all claims" pair whose point is a *risk* decision, not a style one.
- The five-step review order, the MSA/SOW reconciliation section, and the six named sibling hand-offs.

No recommendation, figure, date, citation, or version changed. Not a content rewrite.

## Verification

- `bash scripts/eval-lint.sh` → `contracts  PASS (should_trigger=6, should_not_trigger=5, capability=1)`
- `description` 347 chars, parses as single-line quoted YAML; `name` matches the directory id; `origin: risco` intact.
- All 6 `../<sibling>/SKILL.md` links resolve (`terms-conditions`, `e-signature`, `gdpr-privacy`, `proposals`, `ip-trademark`, `invoicing`), as do both `NOT` boundary siblings.
- Both `references/` files still linked from the body.
- `npm test` / `npm run validate` not run — no `node_modules` in this worktree, per the migration brief; the orchestrator runs them globally after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
