### PR TITLE
refactor(coolify): cut the trigger-phrase list and the duplicate reference index

### DIFF
--- a/skills/coolify/SKILL.md
+++ b/skills/coolify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coolify
-description: "Use when self-hosting apps, managed databases and deploys on a VPS you own with Coolify instead of paying a managed PaaS — installing Coolify on a fresh Ubuntu/Debian box, claiming the first-admin account, deploying from a Git repo (Nixpacks/Railpack/Dockerfile/compose), provisioning Postgres/MySQL/MongoDB/Redis in-product, wiring scheduled DB backups to S3-compatible storage, or custom domains + automatic SSL via the built-in Traefik proxy. Triggers: 'install Coolify', 'self-host my app on a cheap VPS', 'my Vercel/Heroku bill is killing me, move it to a box I own', 'control plane on my own server', 'nightly Postgres backups to R2 in Coolify', 'montar mi propio PaaS en un VPS barato con Coolify', 'autoallotjar les meves apps amb Coolify'. NOT the managed push-and-forget PaaS where someone else owns the box (that is railway), NOT sizing/hardening the VPS itself (that is hetzner / digitalocean), NOT generic Docker image authoring (that is docker)."
+description: "Use when self-hosting apps and databases with Coolify on a VPS you own — install, first-admin lockdown, Git-to-deploy (Nixpacks/Dockerfile/compose), managed Postgres/Redis, scheduled S3 backups, domains + auto-SSL. NOT a PaaS someone else runs (that is `railway`), NOT sizing/hardening the box (that is `hetzner`), NOT authoring Dockerfiles (that is `docker`)."
 tags: [coolify, self-hosting, paas, vps, docker, deployment, devops]
 recommends: [hetzner, digitalocean, docker, postgresdb, backups, domains-dns, github-actions]
 origin: risco
@@ -65,7 +65,9 @@ curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash
 Why root: the installer wires Docker and system services; the docs state non-root is not fully supported.
 Why claim immediately: the registration page is open until someone takes it.
 
-Full install transcript, non-LTS/other-OS notes, and dashboard-domain setup → `references/install-and-proxy.md`.
+Full install transcript, non-LTS/other-OS steps, dashboard-domain setup, Traefik (default) vs Caddy,
+wildcard domains + the DNS-01 challenge, and common SSL failures with their fixes →
+`references/install-and-proxy.md`.
 
 ## Port & firewall matrix
 
@@ -106,7 +108,8 @@ Then:
 4. **Attach the domain + SSL** — add `app.example.com`, point its DNS A record at the box (DNS itself is
    the `domains-dns` skill), and the Traefik proxy provisions Let's Encrypt automatically on ports 80/443.
 
-Build-pack deep-dive + a worked, lint-clean compose example → `references/deploy-recipes.md`.
+Build-pack decision deep-dive plus a worked, lint-clean `docker-compose.yml` (env-ref secrets, named
+volumes, healthcheck, pinned image) — the verify.sh target → `references/deploy-recipes.md`.
 
 ## Managed databases
 
@@ -137,8 +140,8 @@ Backblaze B2, MinIO, Wasabi.
 4. **Run the restore drill — once, before you need it.** Download a dump, decompress, replay it into a
    throwaway DB, confirm the row counts. An untested backup is a guess. Schedule a recurring drill.
 
-Per-provider S3 setup, per-engine dump/restore commands, and the full restore runbook →
-`references/databases-and-backups.md`.
+S3 destination setup for R2/B2/MinIO/Wasabi/AWS, per-engine dump/restore commands, retention, the
+step-by-step restore runbook and its consistency caveats → `references/databases-and-backups.md`.
 
 ## Operate the box
 
@@ -173,15 +176,6 @@ example/your `docker-compose.y*ml`: fails on a hardcoded secret literal (must be
 without a named volume, a missing `healthcheck:`, or a floating `:latest` tag on a build-context service;
 and confirms the canonical port matrix (8000/80/443/6001/6002) is documented. Read-only, no network, no
 live deploy. Exits 0 on a clean/empty target.
-
-## References
-
-- `references/install-and-proxy.md` — full install transcript, non-LTS/other-OS steps, Traefik (default)
-  vs Caddy, wildcard domains + DNS-01 challenge, common SSL failures and fixes.
-- `references/databases-and-backups.md` — per-engine dump commands, S3 destination setup for
-  R2/B2/MinIO/Wasabi/AWS, retention, the step-by-step restore runbook, consistency caveats.
-- `references/deploy-recipes.md` — build-pack decision deep-dive and a worked, lint-clean
-  `docker-compose.yml` (env-ref secrets, named volumes, healthcheck, pinned image) — the verify.sh target.
 
 ## Project grounding (02-DOCS + CLAUDE.md)
 


### PR DESCRIPTION
Context-engineering pass on `skills/coolify/SKILL.md` against `scripts/skill-rubric.md`. No content rewrite: every command, port, version, spec figure and cron example is byte-identical.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 959 | 360 |
| body bytes | 14279 | 13367 |
| body lines | 200 | 194 |

## What went

- **The `Triggers:` phrase list** (seven phrases across EN/ES/CA). The model matches by meaning; that list was in context on every turn the skill is installed, invoked or not. It was also the bulk of the 959 chars.
- **The `## References` tail index.** All three reference files were already linked at point of use — `install-and-proxy.md` from the install path, `deploy-recipes.md` from the build-pack table, `databases-and-backups.md` from both the managed-database and the backup sections. The index was a second copy of links the reader had already passed. The details that lived *only* in the index were folded onto those inline pointers: Traefik vs Caddy, wildcard domains + DNS-01 and the SSL failure fixes → install pointer; R2/B2/MinIO/Wasabi/AWS destinations, retention and consistency caveats → backup pointer; the lint-clean compose shape and its verify.sh-target role → deploy pointer.
- In the description only: the engine and build-pack enumerations trimmed to representatives. The body's build-pack table still names Railpack and the databases section still names MySQL/MariaDB/MongoDB, so the substance stays — it just is not re-paid every turn.

## What stayed, deliberately

- **The anti-patterns table** — 10 concrete failure modes with the mechanism behind each (root install, first-admin takeover, exposed `:8000`, floating `:latest`, anonymous DB volumes, committed secrets, open 5432, untested backups). Failure modes, not a rule bank.
- **The run-where decision table and the port/firewall matrix** — both are real branches in the flow, not restated prose.
- **The mental-model block**, which is what routes to `hetzner`/`digitalocean`, `docker` and `postgresdb` instead of drifting into them.
- **The `scripts/verify.sh` contract** and the 02-DOCS project-grounding block (kept across the pilot).

## Verification

- `bash scripts/eval-lint.sh` → `coolify PASS (should_trigger=6, should_not_trigger=5, capability=1)`
- Description 360 chars, single-line quoted YAML, `NOT … (that is <sibling>)` × 3 — `railway`, `hetzner`, `docker` all exist under `skills/`.
- All three `references/` files still linked from the body.
- Only `skills/coolify/SKILL.md` touched; `manifest.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)