### PR TITLE
refactor(dashboard): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dashboard
-description: "Use when building or fixing a KPI dashboard that decision-makers will actually open and act on within one screen — arranging which metrics earn a tile, framing each tile so it answers a decision at a glance, and picking the right chart per metric. Triggers: 'build a KPI dashboard for leadership', 'exec dashboard on one screen', 'nobody opens the dashboard we built', '20 tiles and I still can't tell if the business is healthy', 'which chart for each of these metrics', 'munta un dashboard de KPIs per a direcció amb el north-star a dalt', 'el dashboard tiene demasiados gráficos y nadie lo mira'. NOT defining the metrics or their targets (that is kpi-framework), wiring the data (that is analytics), or writing a narrative status report (that is reporting)."
+description: "Use when building or fixing a KPI dashboard decision-makers must read in one screen: which metrics earn a tile, how each tile is framed to answer a decision, and which chart fits it. NOT defining the metrics or their targets (that is kpi-framework), wiring the data (that is analytics), or writing a narrative status report (that is reporting)."
 tags: [kpi-dashboard, data-visualization, executive-dashboard, chart-selection, dashboard-design, at-a-glance]
 recommends: [kpi-framework, analytics, reporting, forecasting, business-intelligence, ab-testing, design, spreadsheet-ops]
 origin: risco
@@ -15,19 +15,11 @@ A dashboard is read in **5 seconds by someone who will not scroll**. If a busy r
 
 You do **not** decide which metrics matter (that is [kpi-framework](../kpi-framework/SKILL.md)) and you do **not** wire the data source (that is [analytics](../analytics/SKILL.md)). You take a metric set that already exists and make it readable at a glance.
 
-Run `scripts/verify.sh dashboard.yaml` before you hand off. It checks shape and discipline (tile budget, one north-star, required keys, banned charts) — never whether the numbers are correct.
-
-## The one rule: the 5-second read
-
-A dashboard is a **glance, not a report**. The reader looks at the top-left, gets the headline, and decides whether anything needs their attention. Everything you do serves that.
-
-- One north-star tile, read first, top-left. Why: a screen with no clear entry point forces the reader to hunt, and they won't.
-- If a tile does not change a decision, it is decoration. Cut it (Decision Test below).
-- A bare number is not actionable. Every number carries a comparison.
+Run `scripts/verify.sh dashboard.yaml` before you hand off. It checks shape and discipline — tile count 1-9, exactly one `north_star: true`, the required keys on every tile, no banned charts — never whether the numbers are correct.
 
 ## The Decision Test gate
 
-No tile exists until its metric names the **action it drives**. Ask: *what does someone do differently based on this number?* If the answer is vague ("good to know", "shows we're growing"), the metric is vanity — cut it or convert it.
+No tile exists until its metric names the **action it drives**. Ask: *what does someone do differently based on this number?* If the answer is vague ("good to know", "shows we're growing"), the metric is vanity — cut it or convert it. A tile that changes no decision is decoration.
 
 | Vanity metric (Bad) | Actionable conversion (Good) | Decision it drives |
 | --- | --- | --- |
@@ -94,12 +86,7 @@ Choose the chart from the **shape of the question**, not from what looks impress
 | Correlation | Scatter | Shows relationship between two measures |
 | Distribution | Histogram | Shape of spread, not just average |
 
-Kill-list (verify.sh enforces the first two):
-
-- No `pie` beyond 5 categories — slices become unreadable. Use a sorted bar.
-- No `gauge` / `dial` — they waste space and resist comparison. Use a **bullet chart**.
-- No dual-axis trickery — two y-axes invent correlations that aren't there.
-- No 3D, no donut-with-center-number gimmicks.
+Kill-list: no `pie` beyond 5 categories (sorted bar instead) and no `gauge` / `dial` (bullet chart instead) — verify.sh rejects both; no dual-axis, which invents correlations that aren't there; no 3D and no donut-with-center-number gimmicks.
 
 ## Layout & data-ink
 
@@ -177,7 +164,7 @@ layout:
   groups: [growth, revenue, health]
 ```
 
-verify.sh parses this, counts tiles (must be 1-9), checks exactly one `north_star: true`, requires `metric/chart/comparison/owner/refresh/decision` on every tile, and rejects banned charts.
+The keys verify.sh requires on every tile: `metric`, `chart`, `comparison`, `owner`, `refresh`, `decision`.
 
 ## Anti-patterns
 
@@ -195,11 +182,4 @@ verify.sh parses this, counts tiles (must be 1-9), checks exactly one `north_sta
 
 ## Handoff
 
-- Metrics undefined? Define the north-star, metric tree, targets and owners first → [kpi-framework](../kpi-framework/SKILL.md).
-- No data behind the tiles? Instrument events, funnels, attribution → [analytics](../analytics/SKILL.md).
-- Need a written status with commentary on *why* a number moved → [reporting](../reporting/SKILL.md).
-- Projecting a metric forward under scenarios → [forecasting](../forecasting/SKILL.md).
-- Self-serve slice-and-dice / semantic layer → [business-intelligence](../business-intelligence/SKILL.md).
-- Reading out an experiment / variant significance → [ab-testing](../ab-testing/SKILL.md).
-- Visual polish, spacing, type scale of the rendered screen → [design](../design/SKILL.md).
-- Pulling/joining the underlying numbers in a sheet → [spreadsheet-ops](../spreadsheet-ops/SKILL.md).
+Beyond the routes named above: reading out an experiment or variant significance → [ab-testing](../ab-testing/SKILL.md); visual polish, spacing and type scale of the rendered screen → [design](../design/SKILL.md); pulling or joining the underlying numbers in a sheet → [spreadsheet-ops](../spreadsheet-ops/SKILL.md).


### PR DESCRIPTION
Context-engineering pass on `skills/dashboard/SKILL.md` per `scripts/skill-migration-brief.md`. No substance changed — no recommendation, figure, command, or claim was altered.

## Numbers

| | Before | After |
| --- | --- | --- |
| `description` chars | 761 | **344** |
| SKILL.md bytes | 11,426 | **9,903** |
| SKILL.md lines | 206 | **185** |

`bash scripts/eval-lint.sh` → `dashboard  PASS (should_trigger=7, should_not_trigger=6, capability=1)`

## What went

- **The `Triggers:` list** (7 phrases, EN/ES/CA). It sat in context on every turn the skill is installed, invoked or not, while the model matches by meaning regardless. Replaced with the rubric shape: what it does · when · an explicit `NOT` boundary naming three real siblings.
- **"The one rule: the 5-second read"** — a rule bank that restated the three sections immediately below it. Each claim survives at its point of use (north-star → Tile budget + Layout; comparison → Framing every tile; all three → anti-patterns table). Its one unique line moved into the Decision Test gate, the step it governs.
- **The tail Handoff index** — 5 of its 8 routes already appear inline where the reader needs them. Kept only the 3 that appear nowhere else (ab-testing, design, spreadsheet-ops).
- **The duplicated verify.sh contract**, stated twice. Now once each, split by where the reader needs it: the checks at the run instruction, the required tile keys next to the manifest.
- **The chart kill-list**, compressed from a bulleted block to one line — all four bans and their replacements intact.

## What stayed, deliberately

- The **anti-patterns table** — the rubric requires one, and it names concrete failure modes rather than restating rules already given above it.
- The Decision Test vanity→actionable conversion table and the tiering checklist: the flow genuinely branches at both.
- The chart-shape matrix, and the bad/good pairs for tile framing and layout that teach judgment by demonstration.
- The **full five-tile `dashboard.yaml`** — trimming it would have dropped the example below the 5-9 tile budget the skill itself prescribes.

## Invariants checked

- Both `references/` files (`chart-selection.md`, `tile-schema.md`) still linked inline from the body.
- All 8 `../<sibling>/SKILL.md` links resolve to real skills.
- `description` parses as single-line quoted YAML, 344 chars (≤350 aim, ≤1024 hard limit).
- `manifest.json` untouched; only `skills/dashboard/` in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)