### PR TITLE
refactor(worktrees): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/worktrees/SKILL.md
+++ b/skills/worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worktrees
-description: "Use when feature work needs an isolated workspace before code is touched — branch or git worktree off the default branch so the main checkout stays clean while a plan is executed. Triggers: 'isolate this work', 'I don't want to touch main', 'set up a worktree', 'work on a branch for this', 'spin up an isolated checkout', 'start the feature without dirtying my tree', 'create a worktree for the plan', 'I'm on main and need to implement', 'keep the working tree clean', 'parallel checkout for this branch'. The on-demand SDD step that runs right before implement: it confirms a clean, isolated workspace exists (native EnterWorktree first, git worktree fallback), records nothing to runtime, and hands back to implement. NOT the task breakdown (tasks), NOT writing code (implement), NOT branch cleanup/merge after the work (that's the ship phase). Honors the harness accompaniment dial."
+description: "Use when work is about to become commits and needs isolation first — check the tree state, then branch or cut a git worktree off a clean base (native EnterWorktree first, git fallback) so implement never runs on main. NOT what may run concurrently inside those workspaces (that is `parallel`), NOT the merge/cleanup after (that is `ship`)."
 tags: [git, worktree, isolation]
 recommends: []
 profiles: [core, full]
@@ -53,11 +53,10 @@ extra directory. The rest of this skill assumes a worktree; the branch path is t
 
 Run this in order. Each check prevents a class of "lost work" you can't easily undo.
 
-1. **Read the accompaniment dial.** Open `02-DOCS/wiki/harness/user-profile.md` for the technical +
-   accompaniment level (L0..L3) — it sets how much you narrate and whether you confirm before acting
-   (see the dial table below). No profile yet → assume non-technical, explain what a worktree is in
-   one plain sentence before making one. No `02-DOCS/` at all (a worktree can be created in any git
-   repo with no rsc harness present) → skip the dial, assume non-technical, and proceed.
+1. **Read the accompaniment dial** — `02-DOCS/wiki/harness/user-profile.md` gives the technical +
+   accompaniment level (L0..L3); set your volume from the table below. No profile yet → assume
+   non-technical, explain what a worktree is in one plain sentence before making one. No `02-DOCS/` at all (a worktree can be created in any git repo
+   with no rsc harness present) → skip the dial, assume non-technical, and proceed.
 2. **Confirm you're in a git repo.** `git rev-parse --is-inside-work-tree`. If not, there's nothing
    to isolate with git — tell the user; don't fabricate a worktree.
 3. **Check the current branch.** `git rev-parse --abbrev-ref HEAD`. On `main`/`master` with work
@@ -70,6 +69,8 @@ Run this in order. Each check prevents a class of "lost work" you can't easily u
      carry them over. Never silently leave a user's WIP behind.
    - Unrelated WIP → that's the textbook reason to use a worktree (isolate the new work, leave the
      WIP exactly where it sits).
+   - A dirty tree you don't understand is a hard stop: surface every modified path and ask before
+     branching or stashing. Lost WIP is the one unrecoverable failure in this step.
 5. **Pick the base ref.** Branch from an up-to-date default branch unless the user wants to build on
    local HEAD. Stale base = predictable merge pain later. Default: fresh from `origin/<default>`.
 6. **Choose a name** tied to the feature slug — the same `<slug>` the spec and plan use
@@ -83,15 +84,17 @@ Only once the tree state is understood and the user's WIP is accounted for do yo
 **Prefer the native worktree tool when it's available in your environment.** An `EnterWorktree`-style
 tool typically creates an isolated worktree (often under something like `.claude/worktrees/`, though
 the exact location is tool-dependent), switches the session into it, and tracks it for clean exit —
-which is exactly the lifecycle this skill wants, with no manual path management.
+which is exactly the lifecycle this skill wants, with no manual path management. The git path is the
+universal fallback and is exactly what the native tool does under the hood.
 
-- **Enter:** create/enter the worktree (e.g. an `EnterWorktree`-style native tool, named for the
-  feature slug). The session's working directory moves into the isolated checkout.
-- **Exit:** on the native tool, `keep` to leave the worktree and branch on disk for later, `remove`
-  to delete both when the work is done or abandoned. Removal of a worktree holding uncommitted or
-  unmerged work must be an explicit, confirmed choice — never a silent cleanup.
+| You have… | Create | Leave intact | Discard |
+| --- | --- | --- | --- |
+| A native worktree tool (`EnterWorktree`-style) | enter, named for the feature slug; the session's working directory moves into the isolated checkout | exit with `keep` — worktree and branch stay on disk for later | exit with `remove` — deletes both when the work is done or abandoned |
+| Plain git only | `git worktree add -b feat/<slug> …` | leave the dir; it persists | `git worktree remove` + `git branch -d` |
 
-If no native worktree tool is present, fall back to plain git. The mechanics:
+Removing a worktree that holds uncommitted or unmerged work must be an explicit, confirmed choice,
+never a silent cleanup: refuse the silent path and confirm the discard with the user, quoting what
+would be lost.
 
 ```bash
 # from the repo root, default branch up to date
@@ -140,24 +143,13 @@ git worktree prune                                # self-heal stale administrati
 - **`git worktree prune`** after a remove clears stale metadata when a directory vanished out from
   under git — cheap self-healing, safe to run.
 
-## Native vs. git fallback — which you're using
-
-| You have… | Create | Leave intact | Discard |
-| --- | --- | --- | --- |
-| A native worktree tool (`EnterWorktree`-style) | enter, named for the slug | exit with `keep` | exit with `remove` (confirm if dirty/unmerged) |
-| Plain git only | `git worktree add -b feat/<slug> …` | leave the dir; it persists | `git worktree remove` + `git branch -d` |
-
-The native tool is preferred because it owns the session-switch and the exit lifecycle for you. The
-git path is the universal fallback and is exactly what the native tool does under the hood.
-
 ## Model tier — `light` (opt-in routing)
 
 This phase's default model tier is **`light`** — isolating the workspace is mechanical git work. Routing is **off** unless `models.enabled: true` in `02-DOCS/wiki/sdd/config.yaml`. When on: resolve this phase's tier (`models.overrides` wins over `models.phases`), map it to a model via `models.tiers`, and apply per `../sdd/references/model-routing.md` — announce the switch per the accompaniment dial when it differs from the session model, and dispatch any `Task`/`parallel` subagents on that model. Routing off or no profile → honor the session model silently. Never fake a switch a tool can't make; skip routing on a one-line change.
 
 ## Adapting to the dial
 
-Read `02-DOCS/wiki/harness/user-profile.md` and match your volume — the isolation is identical at
-every level; only the talking changes.
+The isolation is identical at every level; only the talking changes.
 
 | Level | How `worktrees` behaves |
 | --- | --- |
@@ -182,47 +174,10 @@ the dial controls verbosity, never whether you check before risking someone's WI
 | "Already on a feature branch, I'll make a worktree anyway" | Redundant isolation is just clutter. If the current branch is already isolated and clean, say so and proceed. |
 | "I'll record the worktree path into 02-DOCS so it's tracked" | Isolation is plumbing, not knowledge. No artifact; the branch name traces it. Don't pollute the wiki. |
 
-## Red flags — stop and re-route
-
-- **Not a git repo** → nothing to isolate with git. Tell the user; don't invent a workspace.
-- **Dirty tree you don't understand** → don't bulldoze it. Surface every modified path and ask
-  before branching/stashing. Lost WIP is the one unrecoverable failure here.
-- **Asked to merge, open a PR, or delete the branch after the work** → that's `../ship/SKILL.md`, not
-  this one. This skill opens isolation; ship closes it.
-- **Asked to actually write the feature code** → that's `../implement/SKILL.md`. Create the workspace,
-  then hand off; don't start coding in this step.
-- **A native `remove`/`git worktree remove` would drop uncommitted or unmerged work** → refuse the
-  silent path. Confirm the discard explicitly with the user, quoting what would be lost.
-
-## Checklist (copy when isolating)
-
-```text
-- [ ] Read the accompaniment dial (user-profile.md); set verbosity
-- [ ] Confirmed inside a git repo
-- [ ] Checked current branch; on main/master if implement is next
-- [ ] Checked `git status --short`; accounted for any uncommitted WIP (asked, didn't bulldoze)
-- [ ] Picked base ref (fresh origin/<default> unless user chose HEAD)
-- [ ] Named the workspace feat/<slug> to match the spec/plan artifacts
-- [ ] Created isolation: native worktree tool if available, else git worktree (branch = degenerate case)
-- [ ] Confirmed: cwd is the isolated branch; the main checkout is untouched
-- [ ] Wrote NO runtime code and NO 02-DOCS artifact here
-- [ ] Handed off to implement
-```
-
-## What this skill is NOT
-
-- **Not the task breakdown.** Slicing the plan into ordered, verifiable tasks is `../tasks/SKILL.md`.
-- **Not the coding.** Writing the feature test-first, task by task, is `../implement/SKILL.md`.
-- **Not branch cleanup / merge / PR.** Closing the branch — merge, PR, or discard, with Eric-only
-  git authorship — is `../ship/SKILL.md`. This skill only *opens* the isolation.
-- **Not a place for runtime or wiki artifacts.** It touches git state only; nothing under `02-DOCS`.
-
-## Where you are in the chain
-
-`constitution` → `specify` → `clarify` → `plan` → `tasks` → `analyze` → **worktrees** (on-demand) →
-`implement` → `verify` → `review` → `ship`. The **parallel** pattern leans on this skill too: each
-independent stream gets its own worktree so the streams never fight over files.
-
-**Next:** with a clean isolated workspace in hand, hand to **`../implement/SKILL.md`** — walk the
-task list test-first, one commit per task, on this branch. When the feature is built and verified,
-**`../ship/SKILL.md`** closes the branch.
+**Next:** with a clean isolated workspace in hand, hand to `../implement/SKILL.md` — walk the task
+list test-first, one commit per task, on this branch. Neighbours: `../tasks/SKILL.md` slices the plan
+before you get here; `../parallel/SKILL.md` decides *what may run concurrently* inside these
+workspaces — it leans on this skill (each independent stream gets its own worktree, so the streams
+never fight over files) but the partition-then-gather call is its own; `../ship/SKILL.md` closes the
+branch afterwards — merge, PR, or discard, with Eric-only git authorship. This skill only *opens* the
+isolation, and it touches git state only: no runtime code, nothing under `02-DOCS`.


### PR DESCRIPTION
Context-engineering pass on `skills/worktrees/SKILL.md` per `scripts/skill-migration-brief.md`. No substance changed: no command, guard, path, model tier or recommendation was altered.

| Metric | Before | After |
| --- | --- | --- |
| `description` chars | 887 | **339** (target ≤350) |
| Body | 228 lines / 15624 bytes | **183 lines / 12869 bytes** |
| `eval-lint` | — | **PASS** (7 should_trigger / 5 should_not_trigger / 1 capability) |

## Description

Dropped the ten-phrase `Triggers:` list and the chain-position restatement — both are resident in context on every turn the skill is installed, invoked or not, and the model matches by meaning anyway. What is left is the rubric shape: what it does, when, and an explicit `NOT … (that is <sibling>)` boundary.

The boundary now sharpens the nearest sibling, `parallel`: **worktrees provides the isolation, `parallel` decides what may run concurrently inside it.** `ship` covers the other edge (this skill only *opens* isolation).

## What went

- **"What this skill is NOT"** — four bullets restating the description. Every route survives in the closing handoff paragraph: `tasks`, `implement`, `ship` (with the Eric-only git authorship note) and the no-`02-DOCS` rule.
- **"Red flags — stop and re-route"** — all five entries were third copies. Not-a-git-repo and the dirty-tree stop are pre-flight steps 2 and 4; the ship/implement routes live in the closing paragraph and the anti-patterns table; the destructive-remove refusal moved next to the create/keep/discard table it governs, carrying the "quoting what would be lost" detail with it. A rule in context is followed; a rule in a tail is skimmed.
- **The copy-when-isolating checklist** — every line restated a numbered pre-flight step or the contract sentence verbatim, and the numbered gate is already an ordered checklist that carries the reasoning the copy did not.
- **The standalone "Native vs. git fallback" table** — merged into the creation section, dropping the enter/exit bullets it duplicated. The table now carries both paths end to end.
- **"Where you are in the chain"** — folded into the closing handoff; the chain diagram is already at the top.

## What stayed, deliberately

- The **anti-patterns table** (rubric requires one; these are concrete failure modes, not restated rules).
- The **branch-vs-worktree decision table** — the call genuinely branches five ways.
- The **dial table** — phase-specific behaviour for `worktrees`, not the generic accompaniment dial (which belongs to `init` and is only *read* here).
- The **provenance-aware cleanup guards** and all three bash fences, verbatim.
- The **model-tier routing block** and the chain diagram.

No `references/` directory exists for this skill, so the every-reference-is-linked invariant is vacuous. `manifest.json` untouched, as instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)