### PR TITLE
refactor(react): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/react/SKILL.md
+++ b/skills/react/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react
-description: "Use when building or reviewing a client-side React SPA on Vite (React 19.2 — components, where state lives, hooks, client routing, server data fetching) and NOT server-rendered React. Triggers: 'React + Vite app', 'I'm fetching in useEffect and it fires twice', 'where should this filter state live', 'my list flickers and the wrong row updates', 'set up React Router', 'cómo hago data fetching en React sin useEffect', 'per què es re-renderitza tot l'arbre'. NOT App Router / server components / SSR (that is nextjs); NOT mobile screens (that is react-native)."
+description: "Use when building or reviewing a client-side React SPA bundled by Vite (React 19.2): components, where state lives, hooks, server data fetching, client routing, re-render and effect bugs. NOT App Router / server components / SSR (that is `nextjs`); NOT native screens (that is `react-native`)."
 tags: [react, vite, spa, frontend, hooks, tanstack-query]
 recommends: [typescript, design, testing-web]
 origin: risco
@@ -10,42 +10,23 @@ origin: risco
 
 > Build or review a fast, typed, correctly-architected **client-side** React single-page app bundled by Vite. No server runtime, no RSC tree, no framework router. Server-rendered React (App Router, server actions, SSR/SSG) is not this skill — that is `../nextjs/SKILL.md`.
 
-## When to use
-
-> **⚠️ SDD new-feature gate — read this first.** If this skill fired on a **new, non-trivial feature or behaviour change** and there is **no approved spec + plan** under `02-DOCS/wiki/sdd/`, STOP — do **not** write feature code yet. Hand off to `../specify/SKILL.md` first: it runs brainstorm → spec → plan → tasks before any code, then routes back here once the plan is approved. Build here directly only for a genuinely one-line / low-risk change. Method: `../sdd/SKILL.md`.
-
-- A repo with `vite.config.{ts,js}` + `react` + `react-dom` and **no** `next` and **no** `@react-router/dev` framework mode — i.e. an SPA.
-- Creating components and deciding **where state lives** (local / lifted / URL / context / store).
-- Wiring **server data**: queries, mutations, caching, optimistic UI.
-- Client routing (React Router v7 *library mode* or TanStack Router).
-- Fixing re-render storms, stale closures, effect misuse, `key` bugs.
-- Setting up the Vite project (aliases, env vars, code-splitting, `dist/` build).
-
-## When NOT to use — route it
-
-- Server Components, server actions, App Router, SSR/SSG, `app/` dir → `../nextjs/SKILL.md`.
-- React Native / Expo / native screens → `../react-native/SKILL.md`.
-- The type system itself (generics, discriminated unions, `tsconfig` theory) with no React shape → `../typescript/SKILL.md`.
-- Visual design, tokens, spacing, button states → `../design/SKILL.md`.
-- Writing the Vitest/RTL or E2E suite as the task → `../testing-web/SKILL.md`.
-- Hosting the built `dist/` → `../deployment/SKILL.md`.
+**SDD gate — before writing feature code.** If this skill fired on a **new, non-trivial feature or behaviour change** and there is **no approved spec + plan** under `02-DOCS/wiki/sdd/`, stop and hand off to `../specify/SKILL.md`: it runs brainstorm → spec → plan → tasks, then routes back here once the plan is approved. Build directly only for a genuinely one-line / low-risk change. Method: `../sdd/SKILL.md`.
 
 ## First: confirm it's a Vite SPA, not a framework
 
-Do this before giving any advice — it stops you applying SSR/RSC patterns to a client SPA.
-
-1. Read `package.json`. `vite` + `react` present? Good.
-2. Is `next` present? → stop, use `../nextjs/SKILL.md`.
-3. Is `@react-router/dev` present (React Router **framework mode** = SSR, Remix successor)? → that is out of scope, closer to nextjs-shape. Library mode (`react-router` / `react-router-dom` alone) stays here.
-4. Pick the data layer (**TanStack Query**, always — see §6) and the router (React Router v7 library mode *or* TanStack Router).
+Read `package.json` before giving any advice — it stops you applying SSR/RSC patterns to a client SPA.
 
 | Signal in package.json                | Read it as            | Where                  |
 | ------------------------------------- | --------------------- | ---------------------- |
 | `vite` + `react`, no `next`           | Vite SPA              | here                   |
 | `next`                                | metaframework / RSC   | `../nextjs/SKILL.md`   |
-| `@react-router/dev`                   | RR framework mode/SSR | `../nextjs/SKILL.md`-shape |
-| `react-router` only                   | RR library mode       | here (§7)              |
-| `expo` / `react-native`               | native               | `../react-native/SKILL.md` |
+| `@react-router/dev`                   | RR framework mode/SSR (Remix successor) | `../nextjs/SKILL.md`-shape |
+| `react-router` only                   | RR library mode       | here (Routing)         |
+| `expo` / `react-native`               | native                | `../react-native/SKILL.md` |
+
+Then pick the data layer (**TanStack Query**, always) and the router (React Router v7 library mode *or* TanStack Router).
+
+Adjacent jobs route out: the type system itself (generics, discriminated unions, `tsconfig` theory) with no React shape → `../typescript/SKILL.md`; visual design, tokens, spacing, button states → `../design/SKILL.md`; writing the Vitest/RTL or E2E suite as the task → `../testing-web/SKILL.md`; hosting the built `dist/` → `../deployment/SKILL.md`.
 
 ## Component & state architecture
 
@@ -62,7 +43,7 @@ Do this before giving any advice — it stops you applying SSR/RSC patterns to a
 | URL search params                       | it should be shareable / bookmarkable / survive reload         |
 | Context                                 | wide read, **low** write frequency (theme, auth user)          |
 | External store (Zustand) + selectors    | wide read, **high** write frequency, or deep prop-drilling     |
-| TanStack Query cache                    | it's **server** data (anything fetched) — see §6               |
+| TanStack Query cache                    | it's **server** data (anything fetched)                        |
 
 ```tsx
 // Bad: syncing a derived value into state with an effect → stale + extra render
@@ -76,7 +57,7 @@ const fullName = `${first} ${last}`;
 ## Hooks discipline (React 19.2)
 
 - `useState` for one or two independent values; `useReducer` when the next state depends on the previous one or several fields move together.
-- **The `useEffect` rule:** effects exist to *synchronize with a non-React external system* (a subscription, a DOM node, a non-React widget). They are **not** for transforming data and **not** for fetching server data (§6). If you can compute it in render or in an event handler, do that instead.
+- **The `useEffect` rule:** effects exist to *synchronize with a non-React external system* (a subscription, a DOM node, a non-React widget). They are **not** for transforming data and **not** for fetching server data. If you can compute it in render or in an event handler, do that instead.
 - **`useEffectEvent`** (stable in 19.2): extract the non-reactive part of an effect so it reads the latest props/state without being a dependency. Fixes the stale-closure / over-firing class of effect bug.
 
 ```tsx
@@ -96,7 +77,7 @@ useEffect(() => {
 function Profile({ id }: { id: string }) {
   const user = use(fetch(`/api/users/${id}`).then(r => r.json())); // ❌
 }
-// Good: the promise is owned by a cache (see §6 useSuspenseQuery)
+// Good: the promise is owned by a cache (useSuspenseQuery, below)
 ```
 
 - **`useTransition` / `useDeferredValue`** keep the UI responsive: mark a slow state update non-urgent so typing/clicks stay live.
@@ -132,7 +113,8 @@ const remove = useMutation({
 ```
 
 - **`useSuspenseQuery`** + `<Suspense fallback>` + an error boundary moves loading/error out of the component body and is the correct source for `use()`-style reads.
-- **Optimistic delete**: `onMutate` snapshots + writes the expected state, `onError` rolls back, `onSettled` invalidates. Full pattern (infinite, prefetch, query-key factory, optimistic) → `references/data-and-state.md`.
+- **Optimistic delete**: `onMutate` snapshots + writes the expected state, `onError` rolls back, `onSettled` invalidates.
+- Query-key factory, `invalidateQueries` vs `setQueryData`, infinite queries, prefetch, Zustand store + selectors, the full Bad→Good set → `references/data-and-state.md`.
 
 ## Routing (client-side)
 
@@ -151,7 +133,7 @@ const router = createBrowserRouter([
 - Use **lazy routes** so each route is its own chunk.
 - **TanStack Router** is the type-safe alternative — fully typed params/search, first-class loaders. Pick it when route/search typing matters.
 - `@react-router/dev` **framework mode** is SSR → treat like nextjs, out of scope.
-- Protected routes, `useSearchParams`-as-state, nested loaders → `references/routing.md`.
+- Nested/lazy routes, client loaders, protected-route wrapper, `useSearchParams`-as-state → `references/routing.md`.
 
 ## Performance
 
@@ -162,7 +144,7 @@ const router = createBrowserRouter([
 - **Code-split** routes and heavy components with `lazy()` + `<Suspense>`; Vite splits automatically on dynamic `import()`.
 - **React Compiler on** ⇒ delete manual `useMemo`/`useCallback`/`React.memo` — it auto-memoizes; leaving them in is dead noise.
 - **Narrow store selectors** so a slice change doesn't re-render the whole subtree.
-- Targets: LCP < 2.5s, INP < 200ms, CLS < 0.1. Deep dive → `references/performance.md`.
+- Targets: LCP < 2.5s, INP < 200ms, CLS < 0.1. Profiler workflow, React Compiler Vite setup, bundle analysis, re-render map → `references/performance.md`.
 
 ## TypeScript + Vite project setup
 
@@ -174,7 +156,7 @@ const router = createBrowserRouter([
 
 ## Anti-patterns → STOP
 
-| Rationalization                                       | Reality                                                                 | Do instead                                          |
+| Anti-pattern                                          | Reality                                                                 | Do instead                                          |
 | ----------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------- |
 | "Fetch in `useEffect`, it's simpler"                  | Waterfalls, races, double-fire, no cache/dedupe                          | `useQuery` / `useSuspenseQuery`                     |
 | "Create the promise inline for `use()`"               | New promise every render → suspends forever                              | Promise owned by a cache (TanStack Query)           |
@@ -185,40 +167,10 @@ const router = createBrowserRouter([
 | "`VITE_API_SECRET` is fine, it's an env var"          | It ships in the browser bundle — fully public                            | Proxy the secret through a backend                  |
 | "`useEffect` to compute a derived value"              | Extra render + a stale window                                            | Recompute in render                                 |
 
-## Quick reference
-
-| Task                                | API / tool                                  | Note                                  |
-| ----------------------------------- | ------------------------------------------- | ------------------------------------- |
-| Server data                         | `useQuery`                                  | `queryKey` + `queryFn` + `staleTime`  |
-| Mutation                            | `useMutation` + `invalidateQueries`         | or optimistic `onMutate/onError/onSettled` |
-| Read a promise in render            | `use()` + `<Suspense>` + error boundary     | promise from a cache, never inline    |
-| High-frequency global state         | Zustand + selector                          | narrow the selector                   |
-| Wide, low-write state               | `<Context value>`                           | theme/auth, not server data           |
-| Keep UI responsive                  | `useTransition` / `useDeferredValue`        | mark slow update non-urgent           |
-| Non-reactive logic inside an effect | `useEffectEvent`                            | reads latest, not a dependency        |
-| Client route                        | `createBrowserRouter` + `RouterProvider`    | lazy routes for splitting             |
-| Code-split                          | `lazy()` + `<Suspense>`                      | Vite splits on dynamic `import()`     |
-| Build                               | `vite build`                                | emits `dist/`                         |
-
 ## Verify
 
-`scripts/verify.sh` runs from the project root: **ESLint → `tsc --noEmit` → Vitest → `vite build`**, in that order. Each tool is detected and **skipped with a warning (never a failure) if absent** — a repo without a tool can't fail a command it doesn't have. The final `vite build` writes `dist/`; the lint/type/test steps are read-only. No installs, no network mutations, safe to re-run. It exits non-zero only on a real tool failure, and exits 0 on a clean/empty target.
-
-## References
-
-- `references/data-and-state.md` — TanStack Query v5 in depth (query-key factory, mutations, `invalidateQueries` vs `setQueryData`, optimistic with `onMutate/onError/onSettled`, `useSuspenseQuery`, infinite, prefetch), Zustand store + selectors, context patterns, full Bad→Good set.
-- `references/routing.md` — React Router v7 library mode (nested/lazy routes, client loaders, protected-route wrapper, `useSearchParams` as state) and the TanStack Router type-safe alternative; framework mode → defer.
-- `references/performance.md` — Profiler workflow, `key` bugs, `react-virtual`, code-splitting, React Compiler Vite setup, bundle analysis, narrow-selector re-render map.
+`scripts/verify.sh` runs from the project root: **ESLint → `tsc --noEmit` → Vitest → `vite build`**, in that order. Each tool is detected and **skipped with a warning (never a failure) if absent**. The final `vite build` writes `dist/`; the lint/type/test steps are read-only. No installs, no network mutations, safe to re-run. It exits non-zero only on a real tool failure, and exits 0 on a clean/empty target.
 
 ## Project grounding (02-DOCS)
 
 If the workspace has `02-DOCS/`, record stack-specific React conventions (chosen router, store, query defaults) in `02-DOCS/wiki/stack/react.md` and index it from `CLAUDE.md`. Recorded, not gated — skip silently if there is no `02-DOCS/`.
-
-## See also
-
-- `../nextjs/SKILL.md` — the SSR / RSC / App Router sibling (server-rendered React).
-- `../react-native/SKILL.md` — native mobile React.
-- `../typescript/SKILL.md` — the type system itself.
-- `../design/SKILL.md` — visual design, tokens, component states.
-- `../testing-web/SKILL.md` — Vitest/RTL test authoring.
-- `../deployment/SKILL.md` — hosting the built `dist/`.


### PR DESCRIPTION
Context-engineering pass on `skills/react/` per `scripts/skill-migration-brief.md`. No content rewrite: no recommendation, version, command, figure or claim changed.

## Numbers

| Metric | Before | After |
| --- | --- | --- |
| `description` chars | 561 | 293 |
| Body bytes | 16485 | 12569 |
| Body lines | 224 | 176 |
| eval-lint | PASS | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

Diff is 19 insertions / 67 deletions in one file.

## Description

Dropped the seven-phrase multilingual `Triggers:` list. It is in context on every turn the skill is installed, invoked or not, and the model matches by meaning without it. Kept the subject (client-side React SPA on Vite, React 19.2) and sharpened the boundary so the description still discriminates on its own against its nearest sibling `nextjs` — and against `react-native`.

Before: `Use when building or reviewing a client-side React SPA on Vite (React 19.2 — …) and NOT server-rendered React. Triggers: 'React + Vite app', 'I'm fetching in useEffect and it fires twice', … 'per què es re-renderitza tot l'arbre'. NOT App Router …`

After: `Use when building or reviewing a client-side React SPA bundled by Vite (React 19.2): components, where state lives, hooks, server data fetching, client routing, re-render and effect bugs. NOT App Router / server components / SSR (that is \`nextjs\`); NOT native screens (that is \`react-native\`).`

## What went

- **"When to use" / "When NOT to use — route it"** — the first restated the description; the second duplicated both the `package.json` detection table and the `See also` tail. The four non-obvious routes (`typescript`, `design`, `testing-web`, `deployment`) survive as one inline sentence beside the detection table, so every sibling link is still reachable where it is needed.
- **Numbered 1–4 detection prose** — restated the detection table row for row. The "Remix successor" note folded into the table cell.
- **"Quick reference"** — a ten-row index of APIs already taught above it (`useQuery`, `useMutation`, `use()`, Zustand selectors, `useEffectEvent`, `createBrowserRouter`, `lazy()`, `vite build`). Restatement, not a decision table.
- **"References" and "See also" tails** — link indexes whose links all already appear inline. The descriptive detail from the reference index moved into those inline mentions.
- **Dangling `§6`/`§7` cross-references** to sections that were never numbered.

## What stayed, and why

- **The anti-patterns table.** Required by the rubric and a different animal from a rule bank: each row names a concrete failure mode with a Reality column. Header renamed `Rationalization` → `Anti-pattern` to match the rubric's wording; rows untouched.
- **The `package.json` detection table and the state-location table** — the flow genuinely branches on both.
- **Both Bad/Good pairs** (derived-state-via-effect, effect-as-fetch) — they teach judgment by demonstration.
- **The `verify.sh` contract**, the 02-DOCS grounding note, and the **SDD gate** — the gate is compressed to one paragraph but still points at `../specify/SKILL.md` / `../sdd/SKILL.md` rather than restating the method.

## Invariants checked

- All three `references/` files linked inline from the body: `data-and-state.md` (data fetching), `routing.md` (routing), `performance.md` (performance).
- All eight `../<sibling>/SKILL.md` links resolve: deployment, design, nextjs, react-native, sdd, specify, testing-web, typescript.
- Frontmatter parses as YAML; `name` matches the directory; `origin: risco`; description 293 ≤ 1024.
- `manifest.json` untouched (orchestrator regenerates); `npm test` / `npm run validate` not run (no `node_modules` in the worktree).

Substance verified verbatim: React 19.2, `useEffectEvent` stable in 19.2, TanStack Query v5, React Router v7 library mode, ~50–100 rows for virtualization, LCP < 2.5s / INP < 200ms / CLS < 0.1, and the `VITE_`-ships-to-the-browser secret warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
