### PR TITLE
refactor(verify): cut the trigger list and fold the when-to-use and red-flag banks into the gate

### DIFF
--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: "Use when implementation is finished and someone is about to say it's done, shipped, working, or ready to merge in the rsc-sdd flow — the post-implementation GATE that demands evidence before any 'done' claim. Triggers: 'verify this feature', 'is it done?', 'run the checks', 'lint/type/test before merge', 'did the acceptance criteria pass', 'confirm the tasks are complete', 'gate before review', 'audit the change', 'are we green', 'prove it works'. Runs the relevant stack skill's scripts/verify.sh (lint, type-check, tests, coverage, dependency/vuln audit), then walks every task done-check and every spec acceptance criterion, attaching the actual command output as evidence. Writes the verification record under 02-DOCS/wiki/sdd/ and points to the review phase. NOT writing tests or features (that is implement), NOT adversarial code reading (that is review), NOT root-cause diagnosis of a failing test (that is debug). Honors the harness accompaniment dial."
+description: "Use when implementation is finished and about to be called done or merged — the rsc-sdd evidence gate: runs the stack's scripts/verify.sh (lint, type, test, audit), walks every task done-check and acceptance criterion, records a dated verdict. NOT judging the diff by eye (that is `review`, spec-less `code-review`), NOT diagnosis (that is `debug`)."
 tags: [sdd, verify, test]
 recommends: [review]
 profiles: [core, full]
@@ -15,21 +15,7 @@ The one rule everything else serves: **a claim of done is a claim about evidence
 
 This is a process skill. It does not own the lint/type/test tooling — the **stack skills do** (`../fastapi/SKILL.md`, `../go/SKILL.md`, `../nextjs/SKILL.md`, `../flutter/SKILL.md`, each shipping `scripts/verify.sh`; data-layer checks come from `../postgresdb/SKILL.md`, security from `../secure-coding/SKILL.md`). `verify` orchestrates them and judges the whole against the spec.
 
-## When to use / when not to
-
-Use when:
-
-- Implementation of a task or feature is complete and you (or the user) are about to say so.
-- A fix has been applied and you need to confirm it actually resolves the issue, with the app's own checks.
-- You're at the gate before the `review` phase, or before a merge / PR.
-- Someone asks "is it done?", "are we green?", "did it pass?", "can I merge?".
-
-Do NOT use when:
-
-- You're still writing tests or production code → that's the `implement` phase (TDD lives there).
-- A check is failing and you need to find out *why* → that's `debug` (reproduce → isolate → fix). `verify` reports the failure and hands off; it does not diagnose.
-- You're reading the diff adversarially for design/correctness smells a test can't catch → that's `review`.
-- There is no spec or task list to verify against → you're earlier in the chain; go to `specify`/`plan`/`tasks` first.
+Not this phase: still writing tests or production code → `../implement/SKILL.md` (TDD lives there); a check is failing and you need to know *why* → `../debug/SKILL.md` (`verify` reports the failure and hands off, it does not diagnose); reading the diff adversarially for design/correctness smells a test can't catch → `../review/SKILL.md`, or `../code-review/SKILL.md` when there is no spec/plan chain to key off; nothing to verify *against* → you're earlier in the chain, go to `../specify/SKILL.md` / `../plan/SKILL.md` / `../tasks/SKILL.md` first.
 
 ## Model tier — `balanced` (opt-in routing)
 
@@ -37,14 +23,12 @@ This phase's default model tier is **`balanced`** — it runs the checks and int
 
 ## Read the room first (accompaniment dial)
 
-Before running anything, read `02-DOCS/wiki/harness/user-profile.md` for the technical + accompaniment level and adapt:
+Before running anything, read `02-DOCS/wiki/harness/user-profile.md` for the technical + accompaniment level; no profile yet → default to non-technical framing. The verdict itself (pass / fail per item) never changes with the dial — only how much you explain around it.
 
 - **L0** — run the gate, show pass/fail and the one-line failing summary. Minimal words.
 - **L1** — add one line of *why* per failing check.
 - **L2** — narrate each gate (what lint/type/test/audit checks and why it matters here).
 - **L3** — explain every result, what each acceptance criterion means in plain language, and what the user should decide next.
-
-If no profile exists yet, default to non-technical framing and keep the verdict legible. The verdict itself (pass / fail per item) never changes with the dial — only how much you explain around it.
 
 ## The gate (run in this order)
 
@@ -105,11 +89,9 @@ Rules for RUN:
 The stack gate proves the code is *clean and tested*. It does **not** prove the feature does what the spec asked. Walk both lists explicitly:
 
 - **Task done-checks** — for each task in the plan, confirm its done-check is satisfiable from evidence (a passing test, a file that exists, an endpoint that returns the documented shape). Mark each ✅ with the evidence or ❌ with what's missing.
-- **Acceptance criteria** — for each criterion in the spec, point at the concrete evidence that satisfies it. A criterion with no test and no observable proof is **unverified** — treat it as a FAIL item, not a pass, until there is evidence.
+- **Acceptance criteria** — for each criterion in the spec, point at the concrete evidence that satisfies it. A criterion with no test and no observable proof is **unverified** — treat it as a FAIL item, not a pass, until there is evidence. A criterion you "reviewed by reading the code" is not verified either: reading is `review`; verifying needs an observable result.
 
 Where a criterion needs runtime proof (a page renders, a command produces output), drive it through the relevant tool — defer browser/app runtime to the stack skill's own runtime guidance rather than inventing a check here.
-
-A criterion you "reviewed by reading the code" is not verified. Reading is `review`; verifying needs an observable result.
 
 ### 4 — RECORD
 
@@ -151,9 +133,9 @@ Append-only spirit: don't overwrite a prior run's record; a new run is a new dat
 - **FAIL** the moment any item lacks passing evidence. List the open items precisely (which check, which criterion, what's missing). Do not soften it. A single unverified acceptance criterion fails the whole gate.
 - Hand each failing kind to the right place: a failing test/type error → `debug`; a missing test for a criterion → back to `implement`; a spec ambiguity that surfaced → `clarify`.
 
-## Anti-patterns → STOP
+## Anti-patterns
 
-| Rationalization | Reality |
+| Anti-pattern | Why it fails / fix |
 | --- | --- |
 | "The tests passed last run, I'll trust that." | Re-run now. Code changed since; stale green is not green. Evidence is current, or it isn't evidence. |
 | "verify.sh printed SKIP for the tests — close enough." | A SKIP is *unverified*, not passing. The criterion it covers is still open until a real run passes. |
@@ -163,13 +145,7 @@ Append-only spirit: don't overwrite a prior run's record; a new run is a new dat
 | "One acceptance criterion is unproven; ship the rest." | The gate is all-or-nothing. One unverified criterion fails the whole verdict. |
 | "A test is failing — let me just fix it real quick." | That's `debug`, a different discipline. `verify` reports the failure and hands off; it does not patch mid-gate. |
 | "I'll write the verdict, then run the checks to confirm." | Backwards. RUN and WALK first; the verdict is the *consequence* of output you already read. |
-
-## Red flags — abort the verdict
-
-- You're about to type "done"/"passing"/"works" and you cannot point to a specific line of command output that proves it. Stop; go run it.
-- The stack `verify.sh` for a touched stack doesn't exist or didn't run — the gate is incomplete; say so instead of declaring PASS.
-- An acceptance criterion has no test and no observable proof — it's unverified; the verdict is FAIL.
-- A failing check tempts you to fix it inline — that's scope drift into `debug`; record the failure and hand off.
+| "The gate is mostly green, I'll call it done." | If you cannot point at the line of command output that proves a claim, you have no claim. Go run it. |
 
 ## Result envelope
 
@@ -194,7 +170,7 @@ End with:
 
 ## Next in the chain
 
-A **PASS** record is the entry ticket to the next phase: **`review`** (adversarial read of the diff for what the gate can't catch), then **`ship`** (PR/merge with Eric-only authorship). A **FAIL** routes back: failing checks to **`debug`**, missing coverage to **`implement`**, surfaced ambiguity to **`clarify`**. Either way the verification record under `02-DOCS/wiki/sdd/verifications/` travels with the work as its proof.
+A **PASS** record is the entry ticket to the next phase: **`../review/SKILL.md`** (adversarial read of the diff for what the gate can't catch), then **`../ship/SKILL.md`** (PR/merge). A **FAIL** routes back per the VERDICT step. Either way the verification record under `02-DOCS/wiki/sdd/verifications/` travels with the work as its proof.
 
 ## Orientación (siempre)
 


### PR DESCRIPTION
Context-engineering pass on `skills/verify/SKILL.md` against `scripts/skill-rubric.md`, per `scripts/skill-migration-brief.md`. One file touched.

## Numbers

| Metric | Before | After | Δ |
|---|---|---|---|
| `description` chars | 964 | **349** | −615 (−64%) |
| SKILL.md bytes | 14737 | **13264** | −1473 (−10%) |
| SKILL.md lines | 202 | **178** | −24 |
| `eval-lint.sh` | PASS | **PASS** | 8 should_trigger / 5 should_not_trigger / 1 capability |

## Description

Before, it opened with the phase, then spent ~380 chars on a 10-phrase `Triggers:` keyword list, then restated the whole body flow, then closed on a boundary naming `implement`/`review`/`debug` but **not** `code-review`.

After:

> Use when implementation is finished and about to be called done or merged — the rsc-sdd evidence gate: runs the stack's scripts/verify.sh (lint, type, test, audit), walks every task done-check and acceptance criterion, records a dated verdict. NOT judging the diff by eye (that is `review`, spec-less `code-review`), NOT diagnosis (that is `debug`).

The boundary is rebuilt around the real mis-route — **verify vs review vs code-review**. `verify` runs machinery and reads its output; `review` reads the diff against the sdd spec/plan chain; `code-review` reads a diff with no spec chain to key off. `implement` is no longer named in the description because "Use when implementation is finished" already excludes it, and the body still routes there by name. "Honors the harness accompaniment dial" was dropped: every rsc-sdd phase does, so it carries zero routing signal.

## What was removed

- **"When to use / when not to"** (14 lines). The four "Use when" bullets restated the description; the four routing bullets survive as one line after the intro, upgraded from bare names to resolvable `../<sibling>/SKILL.md` links and now including `../code-review/SKILL.md`, which the section never mentioned.
- **"Red flags — abort the verdict"** (4 bullets). Three were verbatim duplicates of rules stated at the step they govern: RUN rule 4, the WALK acceptance bullet, anti-pattern row 7. The fourth — *you cannot point at the line of output that proves the claim* — was the only one carrying its own substance, so it survives as an anti-patterns row rather than being lost.
- The dial section's trailing paragraph, folded into its lead sentence. `init` owns the dial; this skill points at it.
- One duplicated WALK sentence ("a criterion you reviewed by reading the code is not verified"), merged into the acceptance-criteria bullet it qualifies — where the `review` boundary is actually applied.
- The FAIL-routing list in "Next in the chain", which restated the VERDICT step three lines above it, and "with Eric-only authorship" (that is `ship`'s rule to teach; re-teaching it here is how the two drift apart).
- `Rationalization | Reality` table header, reworded to `Anti-pattern | Why it fails / fix`.

## What was deliberately kept

- **All 8 anti-pattern rows, plus the rescued red flag (9 total).** The rubric requires the table, and each row prevents a distinct real failure: stale green, SKIP-as-pass, read-the-code-as-proof, lint-green-as-done, coverage below floor, partial verdict, fix-mid-gate, verdict-before-output.
- **The five gate steps in full** — SKIP-is-not-a-pass, monorepo multi-stack detection, `config.yaml` precedence over an invented command.
- **The stack gate table** — the flow genuinely branches on which stack changed, and it names the six skills that own the tooling `verify` only orchestrates.
- **The verification-record template** with its OKF frontmatter and the worked PASS/FAIL example: it teaches the output contract by demonstration.
- **The result-envelope block, the model-tier block, and the chain position.** The envelope already existed; none was added.
- The dial's L0–L3 rows (what to show at each level of a *verdict* — phase-specific, not a dial tutorial) and the invariant that the verdict itself never changes with the dial.

Phase semantics untouched: same chain position (after `implement`, before `review`/`ship`), same `balanced` tier with opt-in routing, same LOCATE → RUN → WALK → RECORD → VERDICT, same artifact path. No recommendation, path, command or figure changed.

## Verification

- `bash scripts/eval-lint.sh` → `verify PASS (should_trigger=8, should_not_trigger=5, capability=1)`
- `description` = 349 chars, parses as single-line quoted YAML, third person, `Use when` lead, explicit `NOT … (that is <sibling>)` boundary, no `Triggers:` list.
- No `references/` directory in this skill, so the link invariant is vacuous.
- All 14 `../<sibling>/SKILL.md` links resolve under `skills/`; `recommends: [review]` resolves.
- All opening code fences language-tagged.
- `manifest.json` untouched (derived; the orchestrator regenerates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
