### PR TITLE
refactor(fable-operator): halve the always-on description, cut two cross-layer restatements

### DIFF
--- a/skills/fable-operator/SKILL.md
+++ b/skills/fable-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fable-operator
-description: "Use when a task needs reliable, verified, well-communicated reasoning: analysis, debugging, review, advice, decisions, explanations, technical questions, or drafting anything the user will act on — any substantive request, even when rigor isn't asked for. Especially when stakes are high or irreversible, when a wrong answer is expensive, when diagnosing why something fails, or when the user pushes back on a prior answer. NOT for casual low-stakes chat (applying it there is rigor theater); NOT a replacement for the SDD phase skills — verify, debug and review own their gates, this is the reasoning discipline beneath them. Invoke on demand with /fable-operator."
+description: "Use when a substantive request needs verified, calibrated reasoning — analysis, diagnosis, review, advice, or a draft the user will act on — even when rigor is not asked for, and most of all when being wrong is expensive or irreversible. NOT casual chat (rigor theater), NOT the SDD gates `verify`, `debug`, `review`; this is the discipline beneath them."
 tags: [reasoning, verification, rigor, debugging, review, decision-making, epistemics]
 recommends: [sdd, verify, debug, review]
 profiles: [core, full]
@@ -12,8 +12,6 @@ origin: risco
 This is a way of working, not a checklist. Section 0 decides how much of it applies. Afterward, the five-question self-test at the end is the working summary.
 
 > **Provenance.** Adapted from [Migueldgq/fable-operator](https://github.com/Migueldgq/fable-operator) (MIT). The method was originated by Eric Risco — extracted from a model's own reasoning patterns and preserved as a portable operating manual. Ported into rsc house format (frontmatter, evals) with the method kept intact.
->
-> **Invoke on demand** with `/fable-operator`, or let it fire automatically on substantive reasoning, diagnosis, review, and high-stakes decisions.
 
 ## 0. Triage first — two seconds, before anything else
 
@@ -133,7 +131,6 @@ The risk at the end must never contradict the confidence at the top. If the cave
 
 These produce *polished output*, and polish is camouflage. None will feel like a mistake while it's happening.
 
-- **Answering the wrong question brilliantly.** Accurate, thorough, orthogonal to the need. Tell: no picture was ever formed of what the person does next.
 - **Helpful invention.** The request has a gap — missing parameter, ambiguous referent, unattached file — and it gets filled smoothly with the most plausible value. Fix is mechanical: every filled gap gets one clause — "I've assumed X" — every time.
 - **Deference dressed as respect.** Folding to pushback that contains displeasure but no argument; or building carefully on a confidently stated false premise because correcting feels rude. If right, say so again, kindly, with reasons. If the premise is wrong, the correction IS the help. When genuinely wrong: own it in one sentence, fix it, don't perform contrition.
 - **Confidence inherited from format.** Tables look measured; code looks tested; numbered procedures look validated. None of these formats confer any of those properties. Watch for the moment when structuring an answer nicely quietly upgrades belief in it.


### PR DESCRIPTION
## What

`fable-operator` migrated to the Claude-5-era authoring rubric. The description was the whole
problem; the body was already close, so the diff is deliberately small — 1 insertion, 4 deletions.

| | before | after |
|---|---|---|
| `description` | 665 chars | **354 chars** (−47%) |
| `SKILL.md` | 20 078 B / 170 lines | **19 462 B / 167 lines** |
| eval-lint | — | **PASS** (6 should_trigger / 5 should_not_trigger / 1 capability) |

## Description

This skill is in the `core` profile, so its description is in context on **every turn it is
installed**, invoked or not. It spent 665 characters enumerating trigger surfaces — analysis,
debugging, review, advice, decisions, explanations, technical questions, drafting — and then
advertising its own slash command. Enumeration is not discrimination: none of that list helps a
reader choose this skill over `verify` or `debug`.

Before:

> Use when a task needs reliable, verified, well-communicated reasoning: analysis, debugging,
> review, advice, decisions, explanations, technical questions, or drafting anything the user will
> act on — any substantive request, even when rigor isn't asked for. Especially when stakes are high
> or irreversible, when a wrong answer is expensive, when diagnosing why something fails, or when the
> user pushes back on a prior answer. NOT for casual low-stakes chat (applying it there is rigor
> theater); NOT a replacement for the SDD phase skills — verify, debug and review own their gates,
> this is the reasoning discipline beneath them. Invoke on demand with /fable-operator.

After:

> Use when a substantive request needs verified, calibrated reasoning — analysis, diagnosis, review,
> advice, or a draft the user will act on — even when rigor is not asked for, and most of all when
> being wrong is expensive or irreversible. NOT casual chat (rigor theater), NOT the SDD gates
> `verify`, `debug`, `review`; this is the discipline beneath them.

Both `NOT` boundaries name real siblings (`skills/verify/`, `skills/debug/`, `skills/review/`, all
also in `recommends`). The `even when rigor is not asked for` clause is kept: it is a real
triggering instruction, not filler — the skill is meant to fire on substantive work unprompted.
`/fable-operator` was dropped; no other skill in the catalog advertises its own slash command and
the harness already exposes it.

## Body — what went (3 lines)

- **The provenance block's second paragraph** — "Invoke on demand with `/fable-operator`, or let it
  fire automatically on substantive reasoning, diagnosis, review, and high-stakes decisions."
  A when-to-use line sitting one line below the frontmatter that already carried it. Two layers
  saying the same thing drift apart; the description wins.
- **§10's first anti-pattern**, "Answering the wrong question brilliantly", and its tell ("no
  picture was ever formed of what the person does next"). Both were already in §1 — the claim in
  its `*Prevents:*` line, the tell in its opening paragraph — in context, at the step they govern.
  §10 earns its place by naming failure modes stated nowhere else; that one was not.

## Body — what stayed, and why

- **The rest of §10.** This is the anti-patterns register the rubric requires, and it is not a
  rationalization table: the seven remaining entries (helpful invention, deference dressed as
  respect, confidence inherited from format, scope creep as generosity, consistency loyalty,
  complexity as competence signaling, rigor theater) name concrete failure modes that appear
  nowhere else in the body.
- **The per-section `*Prevents:*` lines.** Each states the failure its section exists to avert, at
  the point of use. A rule next to the step it governs is followed; the same rule in an appendix is
  skimmed — so the inline copy is the one that survived the dedup above.
- **§0's triage ladder** (casual / standard / consequential / irreversible) and **the five-question
  self-test.** These are the two interfaces that make the method scale to stakes rather than fire at
  full weight on a pasta question — an expressive interface, not an example list.
- **§11 Voice** and the worked examples in §2, §4 and §5, which teach judgment by demonstration.

The method is untouched: no recommendation, figure, command or claim changed. This was a
context-engineering pass, not a content rewrite.

## Verification

- `bash scripts/eval-lint.sh` → `fable-operator PASS (should_trigger=6, should_not_trigger=5,
  capability=1)`; suite-wide `RESULT: PASS`, 0 failures across 257 skills.
- Frontmatter parses as YAML; `name` matches the directory; `origin: risco`; all four `recommends`
  ids (`sdd`, `verify`, `debug`, `review`) resolve to real skills.
- `description` 354 chars, well under the 1024 hard limit.
- No `references/` directory exists, so the "every reference is linked" invariant holds vacuously.
  No `../<sibling>/SKILL.md` links to resolve; every fence is language-tagged (there are none).
- `manifest.json` intentionally untouched — the orchestrator regenerates it.

Only `skills/fable-operator/SKILL.md` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
