### PR TITLE
refactor(presentations): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/presentations/SKILL.md
+++ b/skills/presentations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: presentations
-description: "Use when building a presentation deck — a pitch deck, sales deck, product/keynote talk, investor deck, board/QBR review, or a leave-behind one-pager — and you need a stunning, on-brand result exported to PDF and/or an editable PPTX. Covers two production pipelines: design-led Markdown decks (Marp/Slidev themed from the project's design tokens, exported to PDF + PPTX) and native editable PowerPoint via python-pptx (masters, layouts, native charts, tables, speaker notes). Grounds copy in the brand study and visuals in the design tokens; defers the WORDS to `marketing` and the visual system to `design`. Triggers: 'make a deck', 'build a pitch/sales/investor deck', 'slides for my talk', 'turn this doc into slides', 'export to PowerPoint/PPTX', 'Marp', 'Slidev', 'python-pptx', 'keynote deck', 'one-pager'. NOT a video skill (motion is used with restraint, not as the medium)."
+description: "Use when building, theming, or exporting a presentation deck — pitch, sales, keynote, board/QBR, leave-behind one-pager — from slide structure to a token-based theme to PDF or editable PPTX (Marp, Slidev, python-pptx). NOT the words (that is `marketing`), NOT the visual tokens (that is `design`), NOT the investor story arc (that is `pitch-deck`)."
 tags: [presentations, pptx, slides, deck]
 recommends: [marketing]
 origin: risco
@@ -14,82 +14,56 @@ origin: risco
 > The deck owns *structure, visual system, and export*. The **words** are `marketing`'s job; the
 > **visual tokens** are `design`'s. This skill orchestrates all three into a finished deck.
 
-## When to use / When NOT to use
+Also out of scope: a web-native, scroll/animation-heavy **landing page** (that is
+`../design/SKILL.md` + `../nextjs/SKILL.md`); a **video / motion explainer** as the deliverable — this
+skill uses motion only as restrained slide transitions and builds, never as the medium; and the live
+financial *model* behind an investor deck — this skill renders the slides and cites the model as the
+source of truth.
 
-**Use when:**
+## Brand grounding (gate — clears before the first headline)
 
-- Building any deck: pitch, sales, product launch, keynote/conference talk, investor raise, board/QBR review, training/workshop, internal all-hands.
-- Turning an existing doc, memo, or notes into a slide-by-slide deck.
-- Producing a leave-behind one-pager or executive summary alongside a deck.
-- Exporting a deck to PDF (vector, fonts embedded, 16:9) or to an editable `.pptx`.
-- Re-skinning / restructuring an existing deck to be on-brand and less generic.
+**Never produce deck copy or a deck narrative without a complete brand study.** A deck is the brand on
+stage: generic slides read as "another AI deck" the moment they hit the projector, and the only cure is
+grounding every headline, claim, and tone choice in a real, persisted brand profile. This is the same
+gate `marketing` and `design` enforce — decks share the study, they do not fork it.
 
-**Do NOT use when (delegate or decline):**
-
-- Writing the deck's *copy* in isolation (headlines, value prop, narrative voice) → that is `../marketing/SKILL.md`. This skill *consumes* that copy and lays it out.
-- Choosing the brand's *visual tokens* (OKLCH palette, type pairing, spacing scale, motion personality) → that is `../design/SKILL.md`. This skill *consumes* those tokens into a slide theme.
-- A web-native, scroll/animation-heavy **landing page** (not a deck) → `../design/SKILL.md` + `../nextjs/SKILL.md`.
-- A **video / motion explainer** as the deliverable (Manim/Remotion, talking-head, animated short) → that is a video job. This skill uses motion only as restrained slide transitions/builds, never as the medium.
-- A live financial *model* / spreadsheet (the numbers engine behind an investor deck) → that is an investor-materials/modeling job; this skill renders the *slides* and cites the model as the source of truth.
-
-## Brand grounding (read this first)
-
-**Hard rule: never produce deck copy or a deck narrative without a complete brand study.** A deck is the
-brand on stage — generic slides read as "another AI deck" the moment they hit the projector, and the cure
-is grounding every headline, claim, and tone choice in a real, persisted brand profile. This is the same
-hard gate the `marketing` and `design` skills enforce; decks share the study, they do not fork it.
-
-Run this gate before writing a single slide headline:
-
-1. **Locate the brand study.** Read the project's root `CLAUDE.md` for a `## Brand & voice` section linking into `02-DOCS/wiki/brand/` (the `harness` Karpathy-wiki convention: compiled brand articles under `02-DOCS/wiki/brand/`, raw inputs the user pastes under `02-DOCS/raw/brand/`). If `CLAUDE.md` is absent, the link is missing, or it points nowhere, treat the study as ABSENT.
-2. **Check completeness** against the checklist in `references/brand-grounding.md` (it extends the shared brand checklist with **deck-specific** dimensions: deck purpose, audience & setting, length, presenter-vs-leave-behind, and must-include slides). Any empty dimension = INCOMPLETE.
-3. **If ABSENT or INCOMPLETE, STOP and interview the user** — one focused batch at a time (never dump all questions at once). Voice samples are mandatory; never fabricate a voice. Then persist: write/update the brand study under `02-DOCS/wiki/brand/` (raw inputs verbatim under `02-DOCS/raw/brand/`), and add/update the `## Brand & voice` link in root `CLAUDE.md`. Exact format → `references/brand-grounding.md`.
+1. **Locate the brand study.** Read the project's root `CLAUDE.md` for a `## Brand & voice` section linking into `02-DOCS/wiki/brand/` (the `harness` Karpathy-wiki convention: compiled brand articles under `02-DOCS/wiki/brand/`, raw inputs the user pastes under `02-DOCS/raw/brand/`). No `CLAUDE.md`, no link, or a link that points nowhere = ABSENT.
+2. **Check completeness** against the checklist in `references/brand-grounding.md` — it extends the shared brand checklist with **deck-specific** dimensions: deck purpose, audience & setting, length, presenter-vs-leave-behind, and must-include slides. Any empty dimension = INCOMPLETE.
+3. **If ABSENT or INCOMPLETE, STOP and interview the user** — one focused batch at a time, never all questions at once. Voice samples are mandatory; never fabricate a voice. Then persist: write/update the brand study under `02-DOCS/wiki/brand/` (raw inputs verbatim under `02-DOCS/raw/brand/`), and add/update the `## Brand & voice` link in root `CLAUDE.md`. Exact format → `references/brand-grounding.md`.
 4. **Only once the study is complete, proceed** — and cite which articles drove the deck (e.g. "narrative grounded in `02-DOCS/wiki/brand/value-proposition.md`, voice in `voice.md`").
 
-If the user explicitly says "skip it, rough draft", you may produce a clearly-labelled `DRAFT (ungrounded — not brand-checked)` and still recommend running the gate before it ships. That is the only exception, and it must be labelled.
+Single exception: if the user explicitly says "skip it, rough draft", you may produce a clearly-labelled
+`DRAFT (ungrounded — not brand-checked)` and still recommend running the gate before it ships.
 
-## The non-negotiables
+## Design the message before the pixels
 
-These are constraints, not preferences. Violating any one is a defect.
-
-1. **Brand study first, then narrative, then layout, then export.** No deck before the grounding gate passes. Cite the articles you used.
-2. **One idea per slide.** A slide that needs two breaths to explain is two slides. If you can't title it with one assertion, it isn't one slide.
-3. **The headline IS the slide.** Write assertion headlines ("Churn fell 40% after onboarding v2"), not topic labels ("Churn"). The audience reads the headline; the body proves it.
-4. **Legible from the back of the room.** Body text ≥ 24pt (≥ 28–32pt for talks); ~6 words/line, ~6 lines/slide as a ceiling, not a target. Contrast ≥ 4.5:1. If it doesn't read at 3 metres, it doesn't ship.
-5. **16:9, fonts embedded, exports verified.** PDF is vector with fonts embedded; PPTX opens clean in PowerPoint/Keynote/Google Slides. Run `scripts/verify.sh` before claiming done.
-6. **Tokens, not magic numbers.** Colors, type scale, and spacing come from the project's `design` tokens (OKLCH → the deck theme), never hand-picked hex per slide.
-7. **Motion with restraint.** One transition family, fast (≤ 300ms), builds reveal *meaning* (one bullet at a time), not decoration. Honor reduced-motion in HTML pipelines. A deck is not a video.
-8. **No invented numbers.** Every metric on a slide traces to a source (the model, analytics, a citation). Mark gaps `[[NEEDS PROOF]]`; never fabricate to fill a chart.
-
-## Design first (assertion-evidence + cognitive load)
-
-Before a pipeline, a theme, or a single pixel: a deck is a *communication* artifact, and the design that
-matters most is the message design. The one principle everything below descends from is **audience-centered
-design** — every choice serves the audience's understanding, not the presenter's comfort.
+A deck is a *communication* artifact, so the design that matters most is the message design. Everything
+below descends from **audience-centered design** — every choice serves the audience's understanding, not
+the presenter's comfort.
 
 **Plan the message (six questions).** Lock these before storyboarding: (1) who *specifically* is the
 audience and what do they already know; (2) the ONE main message they remember a week later; (3) the 3–5
 supporting points that carry it; (4) the evidence proving each; (5) the single call-to-action; (6) what is
-essential vs. expandable under time pressure. These feed straight into the deck arc — message = thesis,
-points = beats, CTA = closing ask (→ `references/storytelling-and-decks.md`).
+essential vs. expandable under time pressure. These feed the deck arc directly: message = thesis, points =
+beats, CTA = closing ask (→ `references/storytelling-and-decks.md`).
 
 **Assertion-evidence is the slide unit.** Each slide = one assertion (a complete claim, written as the
 title) + the visual evidence that proves it — never a topic label over a bullet list. *"User engagement rose
-43% after the redesign"* + a chart, not *"Engagement"* + three bullets. This is non-negotiable #3 made
-concrete: the body proves the headline, it does not repeat it.
+43% after the redesign"* + a chart, not *"Engagement"* + three bullets. The body proves the headline; it
+never repeats it.
 
-**Manage cognitive load: one concept per slide.** Working memory is small and the audience is also listening
-to you. If a slide needs two breaths to explain, it's two slides. Reveal sequential parts progressively
-(build order *is* the explanation) rather than dumping everything at once.
+**One concept per slide.** Working memory is small and the audience is also listening to you. If a slide
+needs two breaths to explain, it's two slides. Reveal sequential parts progressively — build order *is* the
+explanation — rather than dumping everything at once.
 
-**Spoken vs. shown — never both.** The slide and your mouth are two channels; redundancy wastes both. Show
-the assertion, the visual, the number, the next step; *say* the elaboration, the context, the
-interpretation, the story. Reading slides verbatim is the fastest way to lose a room.
+**Spoken vs. shown — never both.** The slide and your mouth are two channels; redundancy wastes both. *Show*
+the assertion, the visual, the number, the next step; *say* the elaboration, the context, the interpretation,
+the story. Reading slides verbatim is the fastest way to lose a room.
 
 Full frameworks — the planning questions, the spoken/shown table, the **1–5 evaluation rubric**
 (audience-centered / visual clarity / cognitive load / accessibility), the implementation checklist, and the
 communication anti-patterns — live in `references/slide-design.md`. Score any draft against the rubric (≥ 4
-on each axis) before shipping; the Deck QA gate below points back to it.
+on each axis) before shipping.
 
 ## Which pipeline? (decide before building)
 
@@ -186,10 +160,8 @@ Always pin/verify the version in the target project before generating (`marp --v
 The deck's words are conversion copy on a stage. Defer the *craft* to `../marketing/SKILL.md`; this skill
 enforces the deck-specific shape:
 
-- **Assertion headline per slide.** Not "Market", but "TAM is $12B and growing 24%/yr". The headline carries the point; the body is evidence.
 - **Benefit-led, climbing feature → benefit → proof**, stopping at the rung the audience cares about. Specificity (a number, a mechanism, a receipt) beats adjectives — "2× faster" not "blazing fast".
-- **Minimal text.** Presenter decks: a headline + one visual + 0–3 support points; the argument lives in the speaker notes / your mouth. Leave-behinds may carry more, because no one's narrating.
-- **Two variants when both are needed:** *presenter* (sparse, you narrate) vs *leave-behind* (self-contained, sent as PDF). Same narrative, different text density — never ship a wall-of-text presenter slide.
+- **Two text densities, chosen deliberately:** *presenter* slides carry a headline + one visual + 0–3 support points, with the argument in the speaker notes / your mouth; *leave-behind* slides are self-contained because no one is narrating. Never ship a wall-of-text presenter slide.
 - **Voice from the brand study.** Headlines obey the do/don't word lists and tone samples. Ban-list words ("revolutionary", "seamless", "game-changer", "supercharge") are defects.
 
 ## Visual system for slides (with `design`)
@@ -199,11 +171,11 @@ The deck's pixels are the brand's design system projected at 3 metres. Defer the
 `references/slide-design.md`):
 
 - **Layout grid** built for 16:9: a 12-column grid, generous margins, one focal point per slide, consistent safe-area so nothing clips on a projector.
-- **Type scale for projection**, not for a laptop reading distance: display/headline/body/caption steps, body ≥ 24pt, line length ~6 words, never below the legibility floor to cram text.
-- **Color from tokens, allocated for a room:** dark deck themes read better in dark rooms / on big screens; light themes for printed handouts and bright rooms. High contrast always; never rely on color alone to encode meaning.
-- **Data viz that makes one point:** one chart = one takeaway named in the headline; remove gridlines/clutter; label directly; pre-attentive emphasis (one highlighted bar/line) over rainbow palettes; never a 3-D pie.
+- **Type scale for projection**, not laptop reading distance: display/headline/body/caption steps, body ≥ 24pt (≥ 28–32pt for talks), ~6 words/line and ~6 lines/slide as a ceiling, contrast ≥ 4.5:1. Never drop below the legibility floor to cram text — split the slide instead. If it doesn't read at 3 metres, it doesn't ship.
+- **Color from tokens, allocated for a room:** dark themes read better in dark rooms / on big screens, light themes for printed handouts and bright rooms. High contrast always; never rely on color alone to encode meaning.
+- **Data viz that makes one point:** one chart = one takeaway named in the headline; remove gridlines/clutter; label directly; pre-attentive emphasis (one highlighted bar/line) over rainbow palettes; never a 3-D pie. Every number traces to a source — mark gaps `[[NEEDS PROOF]]`, never fabricate one to fill a chart.
 - **Imagery** full-bleed and intentional (with a legibility scrim behind text), not stocky decoration; respect resolution so it doesn't pixelate on a 4K projector.
-- **Motion with restraint:** one transition family, builds that reveal one idea at a time, ≤ 300ms; reduced-motion honored in HTML pipelines. Animation explains sequence/state change, never just fills time.
+- **Motion with restraint:** one transition family, ≤ 300ms, builds that reveal one idea at a time; reduced-motion honored in HTML pipelines. Animation explains sequence/state change, never just fills time.
 
 ## Anti-patterns
 
@@ -253,7 +225,8 @@ npx decktape reveal http://localhost:8000 deck.pdf
 
 ## Deck QA gate
 
-Run before claiming done. `scripts/verify.sh` automates the mechanical subset.
+Run before claiming done — each line is a defect if unchecked. `scripts/verify.sh` automates the
+mechanical subset.
 
 - [ ] Brand study located, complete, and cited (which articles grounded the deck).
 - [ ] One idea per slide; every slide titled with an assertion headline, not a topic label.
@@ -269,28 +242,17 @@ Run before claiming done. `scripts/verify.sh` automates the mechanical subset.
 - [ ] File size sane (compressed images, subsetted fonts); ban-list words absent from copy.
 - [ ] Scored ≥ 4/5 on each axis of the design rubric — audience-centered, visual clarity, cognitive load, accessibility (→ `references/slide-design.md`, "Diagnostic rubric").
 
-## Project grounding (02-DOCS + CLAUDE.md)
+## Project grounding (02-DOCS)
 
-When this skill runs in a project with a `02-DOCS/` layer (the
-[`harness`](../harness/SKILL.md) Karpathy wiki), record this project's deck
-conventions there and index them from the root `CLAUDE.md`, so the next agent inherits them instead of
-re-deriving them.
+In a project with a `02-DOCS/` layer (the [`harness`](../harness/SKILL.md) Karpathy wiki), read
+`02-DOCS/wiki/stack/presentations.md` first and stay consistent with it; create or refresh it when
+missing or stale, and index it in `02-DOCS/wiki/index.md`. It records this project's real choices: the
+chosen pipeline (Marp / Slidev / python-pptx) and why, the theme file path and how it maps the design
+tokens, the standard deck arc(s), export commands and the canonical output, the presenter-vs-leave-behind
+convention, and font-embedding / asset-location notes.
 
-1. **Find the article** `02-DOCS/wiki/stack/presentations.md`, indexed in `02-DOCS/wiki/index.md` (the Knowledge map index; root `CLAUDE.md` points to it).
-2. **If missing or stale**, create/update it with this project's real choices — the chosen pipeline (Marp / Slidev / python-pptx) and why; the theme file path and how it maps the design tokens (`02-DOCS/wiki/stack/design.md`); the standard deck arc(s); export commands and the canonical output (PDF / PPTX); presenter-vs-leave-behind convention; font-embedding and asset-location notes — then index it in `02-DOCS/wiki/index.md` (the Knowledge map; root `CLAUDE.md` keeps only a short pointer to it).
-3. **Read it first on every use** and stay consistent; when a convention changes, update the article (bump its `Updated` date) in the same change.
+The deck theme is downstream of the design tokens: always reconcile that article with
+`02-DOCS/wiki/stack/design.md` so the deck and the product share one palette and type system.
 
-The deck theme is downstream of the design tokens: always reconcile `02-DOCS/wiki/stack/presentations.md`
-with `02-DOCS/wiki/stack/design.md` so the deck and the product share one palette and type system.
-
-No `02-DOCS/` layer? Skip silently (optionally suggest `harness`). Like the other technical
-conventions and unlike the brand study, deck conventions are *recorded, not gated* — never block the task
-on this.
-
-## See Also
-
-- `../marketing/SKILL.md` — **the copy**: headlines, value prop, benefit-led claims, the deck's voice. This skill consumes that copy and lays it out.
-- `../design/SKILL.md` — **the visuals**: OKLCH tokens, type pairing, spacing, motion personality. This skill maps those tokens into the slide theme and reads `02-DOCS/wiki/stack/design.md`.
-- `../nextjs/SKILL.md` — when a "deck" is actually a web-native landing/microsite, the build belongs there.
-- `../harness/SKILL.md` — the `02-DOCS` Karpathy-wiki convention the brand study and deck conventions persist into.
-- References: `references/storytelling-and-decks.md` (arcs + slide-by-slide skeletons), `references/markdown-decks.md` (Marp + Slidev theming & export), `references/pptx-python.md` (python-pptx recipes), `references/slide-design.md` (visual system + data viz + motion), `references/brand-grounding.md` (checklist + question script).
+No `02-DOCS/` layer? Skip silently (optionally suggest `harness`). Unlike the brand study, deck
+conventions are *recorded, not gated* — never block the task on this.


### PR DESCRIPTION
Context-engineering pass on `skills/presentations/` against `scripts/skill-rubric.md`. Format only — no recommendation, version, command, figure or claim was changed.

## Numbers

| | Before | After | Δ |
| --- | --- | --- | --- |
| `description` chars | 881 | **348** | −533 (−61%) |
| SKILL.md bytes | 25934 | **21063** | −4871 (−19%) |
| SKILL.md lines | 296 | **258** | −38 |
| `scripts/eval-lint.sh` | PASS | **PASS** | 7 / 6 / 2 |

The description is the expensive half: it sits in context on every turn the skill is installed, invoked or not.

## Description

Before it opened with a correct "Use when…" and then spent ~450 chars on a pipeline inventory and a 10-item `Triggers: 'make a deck', 'Marp', 'Slidev', …` keyword list, closing on one soft boundary ("NOT a video skill").

After:

> Use when building, theming, or exporting a presentation deck — pitch, sales, keynote, board/QBR, leave-behind one-pager — from slide structure to a token-based theme to PDF or editable PPTX (Marp, Slidev, python-pptx). NOT the words (that is `marketing`), NOT the visual tokens (that is `design`), NOT the investor story arc (that is `pitch-deck`).

The trigger list went — the model matches by meaning, and the body already instructs semantic routing. The boundary now names three real siblings that this skill is genuinely confusable with. `pitch-deck` is the important one: its own description already says *"NOT rendering/exporting/theming the slides into a designed PDF or PPTX (that is presentations)"*, so the pair is now reciprocal and a reader can pick correctly from either side.

## What went

- **"When to use / When NOT to use"** (17 lines) — restated the description. The two exclusions the description cannot carry (a video/motion explainer as the deliverable; the financial *model* behind an investor deck) survive as a four-line out-of-scope note that also keeps the `nextjs` and `design` pointers alive.
- **"The non-negotiables"** (8 numbered rules, 13 lines) — a rule bank restating the flow. All eight were already stated where they are enforced: the brand gate, the message-design section, the visual-system constraints, the anti-patterns table, the Deck QA gate. A rule in an appendix is skimmed; a rule in context is followed. The four figures that lived *only* there — ≥ 28–32pt for talks, contrast ≥ 4.5:1, the ~6-lines/slide ceiling, `[[NEEDS PROOF]]` — moved next to the step they govern rather than being dropped.
- **The trailing "See Also" index** — all five `references/` files and all four `../<sibling>/SKILL.md` links already appear inline at their point of use, so nothing became unreachable.
- **"Project grounding"** condensed 17 → 6 lines. It was re-teaching the `harness` 02-DOCS convention instead of pointing at it; the article path, the contents it must record, and the `design.md` reconciliation rule are intact.
- Tightened "Design first" and "Slide copy": merged the duplicate presenter-vs-leave-behind bullets, dropped the assertion-headline bullet that repeated the section directly above it.

## What stayed, and why

- **The full anti-patterns table (11 rows).** The rubric requires one, and it is a different animal from a rationalization bank — concrete failure modes ("exporting PPTX from Marp/Slidev and calling it editable", "fonts not embedded in the PDF"), not rules already stated above.
- **The pipeline decision table.** The flow genuinely branches here and picking wrong is expensive to undo mid-build — this is the skill's central decision.
- **The end-to-end worked example** (storyboard → Marp theme → PDF/PPTX export). Teaches judgment by demonstration and saves a round-trip into the references for the common case.
- **"Tooling & current versions (verified 2026-06)"** verbatim. Freshness is the heaviest rubric dimension (0.25); nothing there was touched.
- **The 13-item Deck QA gate.** With the rule bank gone, this is where the constraints are actually checked.

## Verification

- `bash scripts/eval-lint.sh` → `presentations  PASS (should_trigger=7, should_not_trigger=6, capability=2)`
- Description parses as single-line quoted YAML, 348 chars (target ≤ 350, hard limit 1024).
- All five `references/` files still linked from the body: `brand-grounding.md`, `markdown-decks.md`, `pptx-python.md`, `slide-design.md`, `storytelling-and-decks.md`.
- All four sibling links resolve: `../marketing/`, `../design/`, `../nextjs/`, `../harness/`.
- Only `skills/presentations/SKILL.md` is touched. `manifest.json` deliberately untouched — the orchestrator regenerates it.
