### PR TITLE
feat(catalog): add viral-score, a 0-100 rubric for deciding which clips to publish

### DIFF
--- a/skills/viral-score/SKILL.md
+++ b/skills/viral-score/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: viral-score
+description: "Use to judge whether a short-form clip is worth publishing — scores a reel, short or podcast excerpt 0-100 on ten weighted criteria with automatic penalties, then ranks a batch and says where the cut-off falls. Run it on transcript candidates before rendering. NOT writing the hook or caption (that is `shortform-packaging`), NOT inventing the idea (that is `shortform-ideation`), NOT executing the edit (that is `shortform-editing`)."
+tags: [viral, score, rubric, shortform, reels, shorts, tiktok, ranking, evaluation, retention]
+recommends: [shortform-packaging, shortform-ideation, shortform-editing, shortform-strategy, video-shorts]
+profiles: []
+origin: risco
+---
+
+# viral-score — is this clip worth publishing?
+
+A fixed rubric for scoring a vertical clip's chance of travelling. Its value is that it is
+**fixed**: the same clip scores the same on Monday and Friday, and two clips are comparable
+because they were measured with the same instrument.
+
+So **do not substitute your own judgment for the rubric and do not adjust the weights.** If a clip
+has a quality the rubric does not capture, say so in the reasons — but score it with this.
+
+Score candidates **before rendering** whenever you can. Judging a transcript excerpt costs seconds;
+editing a clip that gets discarded costs an afternoon.
+
+## The ten criteria
+
+Each is scored **0-10**.
+
+| # | Criterion | Weight | What earns the points |
+|---|---|---|---|
+| 1 | **Opening hook** | 20 % | Do the first 3 seconds stop the scroll? Curiosity, surprise, emotion, a strong claim, a striking open |
+| 2 | **Expected retention** | 20 % | Is there a reason to reach the end? Sustained curiosity, pace, resolution, no dead air |
+| 3 | **Emotional impact** | 15 % | Intensity: inspiration, awe, fear, anger, joy, nostalgia, humour, surprise. **Indifference scores very low** |
+| 4 | **Shareability** | 10 % | Would someone send this to a friend? |
+| 5 | **Comment-worthiness** | 10 % | Does it invite debate or a reply? |
+| 6 | **Message clarity** | 5 % | Does the idea fit in one sentence? |
+| 7 | **Value density** | 5 % | Does every second earn its place? |
+| 8 | **Originality** | 5 % | Is it different or unexpected? |
+| 9 | **Context independence** | 5 % | Does it land without having heard the rest of the episode? |
+| 10 | **Storytelling** | 5 % | Is there a story, a lesson, or a transformation? |
+
+## The calculation
+
+```text
+Viral Score = ( Hook×0.20 + Retention×0.20 + Emotion×0.15 + Shareability×0.10
+              + Comments×0.10 + Clarity×0.05 + Density×0.05
+              + Originality×0.05 + Context×0.05 + Storytelling×0.05 ) × 10
+```
+
+## Automatic penalties
+
+Subtracted **after** the formula, and they stack.
+
+| Penalty | Points |
+|---|---|
+| Weak hook | −10 |
+| Slow intro | −8 |
+| Needs too much context | −10 |
+| Long pauses | −5 |
+| Idea too generic | −8 |
+| Provokes no emotion | −10 |
+| Unsatisfying ending | −5 |
+
+Clamp the final result to **[0, 100]**.
+
+## Reading the score
+
+| Range | Verdict |
+|---|---|
+| 95-100 | Exceptional. Publish immediately |
+| 90-94 | Very likely to perform |
+| 80-89 | Good candidate. Worth editing and publishing |
+| 70-79 | Acceptable, but there are better clips |
+| 60-69 | Weak. Publish only if there is no alternative |
+| 0-59 | Discard |
+
+## Required output, per clip
+
+- **Start** and **end timestamp**
+- **Viral Score** (0-100)
+- A **table** with all ten criterion scores
+- **Reasons** behind the scoring
+- **Main strengths**
+- **Main weaknesses**
+- **Verdict**: Publish / Review / Discard
+
+Scoring several clips adds two things: a **ranking from highest to lowest**, and **where the
+cut-off falls** — the point below which publishing stops being worth it.
+
+## Applying it well
+
+**Score the clip, not the topic.** A fascinating episode routinely yields a clip that scores 45.
+
+**Judge the hook on the actual first three seconds**, not on the idea in the abstract. A clip that
+opens with a filler word or halfway through a sentence has a weak hook: −10. That is also why the
+excerpt should start on a sentence boundary — where you cut decides the hook.
+
+**Be strict about context independence.** If the viewer needs to know who the guest is, or what the
+previous question was, that is −10.
+
+**Do not inflate the mean.** If twenty clips all come out above 80, the rubric is not being applied.
+A healthy batch spreads widely, with few above 85.
+
+**Justify every low score with what happens in the clip**, at a timestamp — not with a generality.
+
+## Anti-patterns
+
+| Anti-pattern | Do instead |
+|---|---|
+| Scoring how interesting the subject is | Score this clip's execution; the topic is not the artifact |
+| Grading the hook from the full idea | Read only the first three seconds as the viewer receives them |
+| Compressing a batch into 78-85 | Use the range; a flat distribution means the instrument is not being used |
+| "Weak hook" with no evidence | Quote the opening words and the timestamp |
+| Adjusting weights for a clip you like | The weights are the instrument. Argue in the reasons, score with the rubric |
+| Rendering first, scoring after | Score transcript candidates, then edit only what survives |
+| Skipping the penalties because the total looks low | They are automatic and they stack; a 72 with three penalties is a 49 |
+
+## See Also
+
+- `../shortform-packaging/SKILL.md` — the hook line, caption, hashtags and cover for a clip that
+  passed this bar.
+- `../shortform-ideation/SKILL.md` — inventing the angle, upstream of anything scoreable.
+- `../shortform-editing/SKILL.md` — executing the edit once a clip is chosen.
+- `../shortform-strategy/SKILL.md` — what the channel should publish over time, which this feeds
+  with per-clip evidence.

--- a/skills/viral-score/evals/README.md
+++ b/skills/viral-score/evals/README.md
@@ -1,0 +1,16 @@
+# Evals — viral-score
+
+These are routing and capability checks, not an automated harness. Run them by hand:
+read each `should_trigger` prompt and confirm the skill fires on it — including the two
+non-obvious ones ("this clip feels flat but I can't say why" and the retrospective "why
+did this short underperform"), which carry no scoring keyword, and the Spanish prompt;
+read each `should_not_trigger` prompt and confirm the description's NOT-boundary sends it
+to the named `route_to` sibling instead. The neighbours are close together, so the
+packaging / ideation / editing / strategy split is the part most worth checking.
+
+For the `capability` cases, score the described clip for real and check the answer hits
+every `must_include` line. The first case exists because penalties are the step most often
+skipped: an opener mid-sentence, a 4s pause and an unresolved ending must each subtract,
+and the total must be clamped after they do. The second checks that batch mode produces
+what a single-clip run does not — a ranking and an explicit cut-off. No network, no
+fixtures.

--- a/skills/viral-score/evals/cases.yaml
+++ b/skills/viral-score/evals/cases.yaml
@@ -1,0 +1,50 @@
+skill: viral-score
+
+should_trigger:
+  - prompt: "Score this reel — is it worth publishing?"
+    why: Core ask — a single clip judged against the rubric, verdict required.
+  - prompt: "I cut 20 clips from yesterday's episode. Rank them and tell me which ones to post."
+    why: Batch mode — ranking plus the cut-off line, which only this skill produces.
+  - prompt: "Order these shorts from best to worst."
+    why: Comparison with no scoring keyword; ordering clips requires a shared instrument.
+  - prompt: "Here's the transcript of a 2h podcast. Which passages would make good shorts?"
+    why: The pre-render case the skill exists for — score candidates before anything is edited.
+  - prompt: "Valora este reel y dime si lo publico o lo descarto."
+    why: Spanish — same core ask, publish/discard verdict.
+  - prompt: "This clip feels flat to me but I can't say why. Is it me?"
+    why: Non-obvious — a vague quality doubt resolves into criterion scores and named weaknesses.
+  - prompt: "Why did this short underperform? It seemed strong when I made it."
+    why: Non-obvious — retrospective diagnosis against the same criteria, especially hook and context independence.
+
+should_not_trigger:
+  - prompt: "Write the caption and hashtags for this Reel."
+    route_to: shortform-packaging
+    why: Upload-form copy for a clip already chosen, not the decision to choose it.
+  - prompt: "Give me ten ideas for shorts about discipline."
+    route_to: shortform-ideation
+    why: Inventing angles, upstream of anything that can be scored.
+  - prompt: "Burn in the subtitles and add B-roll to this clip."
+    route_to: shortform-editing
+    why: Executing the edit; scoring is what decides whether the edit is worth doing.
+  - prompt: "How often should I post on this channel, and at what times?"
+    route_to: shortform-strategy
+    why: Channel cadence over time, not the merit of one artifact.
+  - prompt: "Design a thumbnail for my YouTube video."
+    route_to: youtube-thumbnails
+    why: A different surface and a different artifact; this rubric scores the clip itself.
+
+capability:
+  - prompt: "Score this 18s clip: it opens mid-sentence with 'o sea, entonces lo que pasa es que…', has a 4s pause in the middle, and ends without resolving the point."
+    must_include:
+      - "a score for all ten criteria"
+      - "the weak-hook penalty applied for opening mid-sentence"
+      - "the long-pause penalty"
+      - "the unsatisfying-ending penalty"
+      - "a final score clamped to 0-100 after penalties"
+      - "a Publish / Review / Discard verdict"
+  - prompt: "Here are 6 clips from one episode with their transcripts. Rank them."
+    must_include:
+      - "a Viral Score for every clip"
+      - "a ranking from highest to lowest"
+      - "an explicit cut-off point below which publishing is not worth it"
+      - "strengths and weaknesses per clip, tied to what happens in it"


### PR DESCRIPTION
Adds `viral-score`: ten weighted criteria, seven stacking penalties, a clamped 0-100 result and a Publish/Review/Discard verdict, plus ranking and an explicit cut-off when scoring a batch.

**The rubric is reproduced exactly** — same weights, same penalty values, same bands, same required output fields. Its value is that it is fixed: two clips are comparable, and the same clip scores the same twice. The body instructs the agent not to substitute its own judgment or retune the weights.

## Two deliberate departures from the text as supplied

Both easy to revert if you disagree:

**1. The description was in the pre-Claude-5 style.** It carried a `Dispara con: "valora este reel", "puntúa estos clips"…` trigger list — exactly what the rubric change in #23 removes, and what ~85 skills have been migrated away from today. Adding it as written would have shipped a regression on the same day. Rewritten to what/when/NOT-boundary: **712 → 434 chars**.

**2. The channel-context section named a handle and two workspace-local paths.** This package is public on npm and the number cannot be recycled, so `@niundiaazero`, `03-REELS/_research/…` and `01-TOOLS/CLIPS/…` are out. The substance they carried is kept, generalised: *the excerpt must start on a sentence boundary, because where you cut decides the hook* now sits in "Applying it well", where it applies to anyone.

If this was meant as a personal skill rather than a catalog one, that changes both calls — say so and I will restore the original framing and keep it out of the public catalog.

Body is in English to match the other 257 skills. Rubric semantics unchanged.

## Verification

- `eval-lint` **PASS** — 7 should_trigger / 5 should_not_trigger / 2 capability
- `npm run validate` OK; description 434 chars, well inside the 1024 hard limit
- All five `route_to` siblings verified to exist (`shortform-packaging`, `shortform-ideation`, `shortform-editing`, `shortform-strategy`, `youtube-thumbnails`)
- Anti-patterns table present, as the rubric requires

The two capability cases target the failure this rubric actually suffers in practice: penalties silently skipped, and batch mode not producing a cut-off.

Note: `manifest.json` is not regenerated here — it is derived, and the ~80 open migration PRs would all collide on it. Regenerate once centrally after merging.