### PR TITLE
refactor(django): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/django/SKILL.md
+++ b/skills/django/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: django
-description: "Use when building, reviewing, securing, testing or shipping a Django web app — models, migrations, QuerySets, managers, FBV/CBV views, forms, the admin, settings split, and Django REST Framework (serializers, ModelViewSet, routers, permissions, throttling). Triggers: 'add a filter and fix the N+1 in this ListView', 'build a DRF ModelViewSet with owner-only permission', 'this template loops over books and queries book.author each iteration' (N+1 without the word Django), 'why does manage.py check --deploy warn about SECURE_HSTS_SECONDS', 'revisa este modelo y añade un UniqueConstraint en (tenant, slug)', 'el queryset hace N+1', any file with manage.py, settings.py, models.py, serializers.py or a 0001_initial migration. NOT async-first FastAPI services (that is fastapi)."
+description: "Use when building, reviewing, securing, testing or shipping a Django app — models, migrations, QuerySets/managers, FBV/CBV views, forms, the admin, settings split, and Django REST Framework (serializers, ModelViewSet, permissions). NOT async FastAPI/Pydantic services (that is `fastapi`), NOT Postgres schema/index work (that is `postgresdb`)."
 tags: [python, django, orm, drf, backend, web]
 recommends: [postgresdb, secure-coding, deployment, testing-py, api-design]
 origin: risco
@@ -31,10 +31,7 @@ add a dependency.
 
 **Version rule:** default to 5.2 LTS. Pick 6.0 only for a concrete Tasks/CSP need, and say so.
 
-## When to use vs route elsewhere
-
-The test: if the project has `manage.py` and `INSTALLED_APPS`, it is Django. If it imports
-`fastapi` + `pydantic`, it is not.
+## Route elsewhere
 
 | Situation | Route to |
 |---|---|
@@ -44,8 +41,6 @@ The test: if the project has `manage.py` and `INSTALLED_APPS`, it is Django. If 
 | Container/Compose/CI, gunicorn prod tuning, collectstatic pipeline | `deployment` |
 | REST contract design (cursor vs offset, status codes, versioning) | `api-design` |
 | ruff/uv/general type hints, packaging | `python` |
-
-Everything else Django-shaped — models, QuerySets, migrations, views, DRF, settings — is here.
 
 ## Project shape
 


### PR DESCRIPTION
## Metrics

| | before | after |
|---|---|---|
| `description` chars | 779 | **343** (target ≤350, hard limit 1024) |
| SKILL.md bytes | 13077 | **12398** |
| SKILL.md lines | 268 | **263** (ceiling 400) |
| eval-lint | — | **PASS** (`should_trigger=7, should_not_trigger=4, capability=1`) |

## What went

- **The `Triggers:` phrase list** — seven quoted prompts in English and Spanish plus a
  filename-pattern clause (`any file with manage.py, settings.py, models.py…`). That list was
  paid for on every turn the skill is installed, invoked or not, and the model matches by
  meaning anyway. Every one of those phrases already exists in `evals/cases.yaml`, where it is
  actually scored instead of merely stated.
- **The boundary was widened, not just shortened.** `NOT async-first FastAPI services` became two
  named boundaries: `` `fastapi` `` (async/Pydantic services) and `` `postgresdb` ``
  (schema/index work) — the two siblings this skill is genuinely confused with, and both are the
  `route_to` of a real `should_not_trigger` case.
- **Two body fragments that restated the description**: the `manage.py`-vs-`fastapi` "test"
  paragraph and the `Everything else Django-shaped … is here` catch-all. The section is now
  titled `Route elsewhere`, which is what the table does.

## What stayed, and why

- **Pinned stack** — Django 5.2 LTS (2025-04-02, support to ~April 2028) vs 6.0 (2025-12-03,
  Tasks framework / native CSP), DRF 3.17.1 (2026-03-24). Dated version facts are the heaviest
  rubric dimension; cutting them would be a content change.
- **The six-row routing table** — it delegates to `fastapi`, `postgresdb`, `secure-coding`,
  `deployment`, `api-design` and `python`; four of those are named nowhere else in the skill.
- **The 12-row anti-patterns table** — required by the rubric, and the hybrid case the brief
  calls out: these are concrete failure modes (f-string SQL into `.raw()`, fat serializer
  walking relations, editing an applied migration), not rules already stated above it.
- **Decision tables where the flow branches** — `select_related` vs `prefetch_related` vs
  `Prefetch`, FBV vs generic CBV vs DRF, Tasks vs Celery.
- **Bad/good worked pairs** — logic-in-view vs model method, and the N+1 loop.
- **The `SECURE_*` settings table** and the `check --deploy` gate.
- **The `Verify` block** describing `scripts/verify.sh` — a pre-existing output contract, not
  something added by this pass.

## Invariant checks

- All four `references/` files are still linked inline from the body: `drf.md` (Views & URLs),
  `orm-performance.md` (QuerySet performance), `security.md` (Security), `testing.md` (Testing).
- Frontmatter parses as YAML; `name: django` matches the directory; `origin: risco` intact;
  `recommends` untouched.
- `manifest.json` deliberately **not** touched — the orchestrator regenerates it.
- No recommendation, version, command, figure or claim changed. Diff is 2 insertions,
  7 deletions.
