### PR TITLE
refactor(e2e-testing): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: e2e-testing
-description: "Use when writing or stabilizing browser end-to-end tests with Playwright — driving real navigation, forms, logins, and multi-step user journeys through an actual browser, picking durable locators, or killing tests that pass locally but flake in CI. Covers getByRole/getByTestId locator choice, web-first assertions, storageState auth via setup projects, retries/trace config, sharding, and the 2026 flakiness playbook. Triggers: 'write a Playwright test', 'my e2e tests flake in CI but pass locally', 'set up storageState so I don't log in every test', 'getByRole vs CSS selector', 'shard Playwright across machines', 'trace on retry', 'strict mode resolved to 2 elements', 'els tests d'extrem a extrem fallen aleatòriament al pipeline', 'los tests e2e fallan a veces'. NOT in-process component/unit web tests (that is testing-web), NOT pytest suites (that is testing-py), NOT a11y audits as the goal (that is accessibility), NOT building the CI pipeline itself (that is github-actions)."
+description: "Use when writing or stabilizing Playwright tests that drive a real browser through multi-step journeys — durable locators, web-first assertions, storageState auth, trace/retries, and flakes that only bite in CI. NOT in-process component tests (that is testing-web), NOT WCAG auditing (that is accessibility), NOT the pre-merge gate (that is verify)."
 tags: [playwright, e2e, browser-testing, flakiness, ci]
 recommends: [testing-web, accessibility, performance, github-actions, debug]
 origin: risco
@@ -18,17 +18,6 @@ line is **Playwright v1.60.x** (v1.60.0 shipped 2026-05-11). The `_react` / `_vu
 and the `:light` Shadow-DOM suffix were **removed in v1.58.0** — at any version you should be pinning
 they are long gone, so do not reach for them.
 
-## What good looks like
-
-- **User-facing locators.** Tests find elements the way a user does — by role and accessible name —
-  not by `div.card > button:nth-child(2)`. The test survives a refactor that the user never sees.
-- **Web-first assertions.** Every assertion auto-retries until the DOM settles. You never read a
-  value once and compare it.
-- **Deterministic by design.** No `waitForTimeout`. No test that depends on another test's leftovers.
-  Flakiness is a design defect you prevent, not a rerun you tolerate.
-- **Traces on retry.** CI captures a full trace the first time a test retries, so a CI-only failure
-  is debuggable from the artifact without a local repro.
-
 ## Is this even an e2e test?
 
 E2e is the most expensive layer. Spend it only on journeys that cross pages or services. Route the rest out.
@@ -40,6 +29,7 @@ E2e is the most expensive layer. Spend it only on journeys that cross pages or s
 | "Is this page accessible?" — WCAG/ARIA as the deliverable | `../accessibility/SKILL.md` | E2e may *call* axe inside a test, but auditing a11y is its own skill. |
 | "Is this page fast?" — LCP/CWV budgets | `../performance/SKILL.md` | Perf budgets are a different signal than journey correctness. |
 | The runner matrix, caching, the pipeline itself | `../github-actions/SKILL.md` | E2e contributes a *job*; owning the pipeline is theirs. |
+| "Is the change done?" — run the gate, collect evidence, then merge | `../verify/SKILL.md` | Running an existing suite as a pre-merge gate is not authoring or stabilizing one. |
 
 Rule: if you can prove it without launching a browser, you should. Push logic down to `testing-web`.
 


### PR DESCRIPTION
## What this is

The context-engineering pass on `e2e-testing` per `scripts/skill-migration-brief.md`. Substance is untouched — no changed recommendations, versions, commands, or figures.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 987 | **349** |
| `SKILL.md` bytes | 13,813 | **12,672** |
| `SKILL.md` lines | 243 | **233** |
| `scripts/eval-lint.sh` | — | **PASS** (should_trigger=7, should_not_trigger=4, capability=1) |

Diff: `1 file changed, 2 insertions(+), 12 deletions(-)`. Only `skills/e2e-testing/SKILL.md` is touched; `manifest.json` is left for the orchestrator to regenerate.

## What went

**The `Triggers:` list.** Nine quoted phrases across English, Catalan and Spanish, plus a four-way NOT clause — 987 chars in context on every turn the skill is installed, invoked or not. The model matches by meaning, so a keyword list is pure per-turn cost.

**`## What good looks like`.** Four bullets: user-facing locators, web-first assertions, no sleeps / no order dependence, trace on retry. Every one is taught in full further down, next to the code that implements it — the locator ladder, the web-first assertion pair, the sleep→signal table, `trace: 'on-first-retry'` in the config. A preamble restating the body is the "repeating yourself across layers" pattern the brief names.

## What stayed, and why

- **The anti-patterns table.** Required by the rubric, and it is not a rationalization bank: nine concrete failure modes (`waitForTimeout`, XPath, `page.$`, `expect(await`, committed `storageState`, `trace: 'on'`, order dependence, browser-driven unit logic, `.first()`) each with why-it-bites and do-instead.
- **The flakiness playbook table.** Symptom→cause→fix keyed on what CI actually prints. It overlaps the anti-patterns table on two rows by design — one is diagnostic (you have a red pipeline), the other is authoring (you are writing the test). Cutting either would cut substance, which the brief forbids.
- **The routing table**, the **sleep→real-signal table**, and the three bad/good code pairs. The flow genuinely branches, and the pairs teach judgment by demonstration.
- **Version facts:** Playwright v1.60.x (v1.60.0, 2026-05-11), `_react`/`_vue`/`:light` removed in v1.58.0.
- **The `## Verify` section** — `scripts/verify.sh` exists, so the pointer is load-bearing.

## New description

> Use when writing or stabilizing Playwright tests that drive a real browser through multi-step journeys — durable locators, web-first assertions, storageState auth, trace/retries, and flakes that only bite in CI. NOT in-process component tests (that is testing-web), NOT WCAG auditing (that is accessibility), NOT the pre-merge gate (that is verify).

Discrimination over coverage: the boundary now names the three siblings a reader could plausibly confuse this with. `testing-py` and `github-actions` moved out of the description and are still routed by name in the body's routing table, which also gained a `verify` row so the description's claim is checkable. All named siblings verified present under `skills/`.

## Invariants checked

- `references/config-and-ci.md` and `references/flakiness-playbook.md` both still linked inline (8 and 2 mentions).
- Frontmatter parses as YAML; `name` matches the directory id; `origin: risco` intact; `recommends` unchanged (all real).
- Per the brief, `npm test` / `npm run validate` not run — no `node_modules` in this worktree.
