### PR TITLE
refactor(decision-records): drop the trigger-phrase description, de-duplicate three body lines

### DIFF
--- a/skills/decision-records/SKILL.md
+++ b/skills/decision-records/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decision-records
-description: "Use when a consequential, hard-to-reverse choice was just made or is about to be — database, framework, auth model, vendor, API style, deployment target — and future-you will ask why, with the answer buried in chat; capture it as a numbered, immutable ADR with the context that forced the choice, the real options weighed with their trade-offs, the decision, and consequences both ways. Also when a prior decision is being reversed and must be superseded without erasing history, or when onboarding keeps re-litigating a settled choice. Triggers: 'write up why we picked Postgres over DynamoDB so we stop arguing', 'record the switch to tRPC but keep the old REST decision in history', 'documenta por qué elegimos Hetzner y qué alternativas descartamos con pros y contras', 'registra la decisió i les alternatives que vam descartar'. NOT the meeting recap with action items and owners (that is meeting-notes), NOT the project-wide standing principles and stack canon (that is constitution)."
+description: "Use when a hard-to-reverse choice (database, framework, vendor, auth model) must be frozen as an immutable numbered ADR — the context that forced it, the options weighed, the decision, consequences both ways — or superseded without erasing history. NOT a meeting recap (that is meeting-notes), NOT standing project principles (that is constitution)."
 tags: [decision-records, adr, architecture-decisions, rationale, decision-log, madr, knowledge-ops]
 recommends: [meeting-notes, constitution, sop-builder, knowledge-ops, codebase-onboarding, plan, specify]
 origin: risco
@@ -182,7 +182,7 @@ A decision log is only useful if it stays navigable.
 - **Index every ADR at creation.** One row: `| 0007 | Choose Postgres | accepted | 2026-06-02 |`. No orphans.
 - **Keep supersession links live** in both directions.
 - **Review cadence.** Periodically sweep `accepted` ADRs — anything reality has overtaken gets a superseding record, not a silent edit.
-- **Index the log from the entry point** — `02-DOCS/wiki/index.md` (the Knowledge map; root `CLAUDE.md` keeps only a short pointer) — so onboarding finds it. The broader wiki and onboarding doc are owned by `knowledge-ops` and `codebase-onboarding`; this skill owns only the ADRs the wiki links to. The meeting that spawned a decision routes to [`meeting-notes`](../meeting-notes/SKILL.md); the repeatable how-to it implies routes to [`sop-builder`](../sop-builder/SKILL.md).
+- **Index the log from the entry point** — `02-DOCS/wiki/index.md` — so onboarding finds it. The broader wiki and onboarding doc belong to [`knowledge-ops`](../knowledge-ops/SKILL.md) and [`codebase-onboarding`](../codebase-onboarding/SKILL.md); this skill owns only the ADRs the wiki links to. The meeting that spawned a decision routes to [`meeting-notes`](../meeting-notes/SKILL.md); the repeatable how-to it implies routes to [`sop-builder`](../sop-builder/SKILL.md).
 
 ## Anti-patterns
 
@@ -199,4 +199,4 @@ A decision log is only useful if it stays navigable.
 
 ## Verify
 
-Lint a produced ADR (or a whole decisions dir) with `scripts/verify.sh <path>`: it checks for a recognized status, a date, the required sections, ≥2 options, and a valid filename — read-only, no network. See [`references/templates.md`](references/templates.md) for the skeletons it expects.
+Lint a produced ADR (or a whole decisions dir) with `scripts/verify.sh <path>`: it checks for a recognized status, a date, the required sections, ≥2 options, and a valid filename — read-only, no network. It expects the skeletons above.


### PR DESCRIPTION
Context-engineering pass on `decision-records` against `scripts/skill-rubric.md`. This skill was
already close to the rubric, so the honest diff is small: the description carried all the weight,
and the body needed three de-duplications, not a rewrite.

## Numbers

| | Before | After |
|---|---|---|
| `description` | 990 chars | **349 chars** (-65%) |
| `SKILL.md` | 12564 B / 203 lines | **11861 B / 202 lines** |
| eval-lint | — | **PASS** (6 should_trigger / 5 should_not_trigger / 1 capability) |

## What went

- **The `Triggers:` list.** Four quoted example prompts in English, Spanish and Catalan, plus a
  second sentence restating the ADR spine (context / options / decision / consequences) that the
  body teaches in full. The model matches by meaning; a keyword list in three languages is paid for
  on every turn the skill is installed, whether or not it fires.
- **A repeated parenthetical.** "Maintain the log" re-stated the "(the Knowledge map; root
  `CLAUDE.md` keeps only a short pointer)" gloss verbatim from "Decide home + naming once" — the
  same fact at two layers is what drifts.
- **A third pointer to the same reference.** The Verify section sent the reader to
  `references/templates.md` for "the skeletons it expects" with the skeleton printed above it.

## What stayed, on purpose

- **The anti-patterns table (8 rows)** — the rubric requires one, and rows that name a concrete
  failure mode plus a "do instead" are a different animal from a rationalization bank, even where a
  row echoes a rule stated earlier in the flow.
- **The ADR-worthy / skip gate table** and the **naming-school** and **status-lifecycle** tables:
  the flow genuinely branches at each.
- The **bad/good context pair** and the **options comparison matrix** — judgment taught by
  demonstration.
- The **supersession ritual**, the **OKF `type: decision` frontmatter** rules for ADRs inside a
  harness wiki bundle, and the **MADR 4.0.0 (2024-09-17)** / Fowler / AWS Architecture Blog
  grounding.

## Also fixed

The bare `knowledge-ops` and `codebase-onboarding` mentions in "Maintain the log" are now real
`../<sibling>/SKILL.md` links, matching how `meeting-notes`, `sop-builder` and `constitution` are
already referenced in the same body.

## Substance untouched

Every path, command, status name, figure and version is verbatim. Frontmatter parses as YAML,
`name`/`origin` unchanged, all six `../<sibling>/SKILL.md` links resolve, `references/templates.md`
is still linked inline (twice, at its points of use), and `manifest.json` is untouched — the
orchestrator regenerates it after merge. `npm test` / `npm run validate` not run: no
`node_modules` in this worktree, per the brief.
