### PR TITLE
refactor(digitalocean): cut the trigger list and the duplicated tails

### DIFF
--- a/skills/digitalocean/SKILL.md
+++ b/skills/digitalocean/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: digitalocean
-description: "Use when deploying or operating a workload on DigitalOcean and you must decide where it runs and how to ship it — Droplet (raw VPS) vs App Platform (managed PaaS) vs Functions, wiring a Managed Database (Postgres/MySQL/Valkey), Spaces object storage + CDN, doctl auth, App Platform app spec YAML, cloud firewalls, VPC private networking, reserved IPs, snapshots/backups, app logs, scaling. Triggers: 'deploy to DigitalOcean', 'DigitalOcean App Platform app spec', 'DO managed postgres with connection pooling', 'doctl apps create', 'reserved IP failover', 'I need an S3-compatible bucket with a CDN' (that is Spaces — non-obvious), 'subir mi web a DigitalOcean con doctl', 'Droplet o App Platform, qué sale más barato'. NOT host-agnostic CI/CD or rollback strategy (that is deployment), NOT a Hetzner bare VPS (that is hetzner)."
+description: "Use when deploying or operating a workload on DigitalOcean — Droplet vs App Platform vs Functions, doctl, app spec YAML, Managed Postgres/MySQL/Valkey on the VPC, S3-compatible Spaces + CDN. NOT host-agnostic CI/CD or rollback strategy (that is `deployment`), NOT a bare Hetzner VPS (that is `hetzner`), NOT another managed PaaS (that is `railway`)."
 tags: [digitalocean, doctl, app-platform, droplets, spaces, deployment, paas, vps]
 recommends: [deployment, postgresdb, docker, domains-dns, monitoring, scaling, hetzner]
 origin: risco
@@ -8,10 +8,11 @@ origin: risco
 
 # DigitalOcean — Droplet vs App Platform, doctl, Managed DBs, Spaces
 
-You own one decision: **where on DO does this run, and how do I ship it.** Everything
-else (CI/CD shape, Dockerfile, DB schema, DNS) belongs to a sibling — see the boundary at
-the bottom. Pick the compute model first, then wire data and storage, then the ops that
-bite in production.
+You own one decision: **where on DO does this run, and how do I ship it.** Host-agnostic
+CI/CD, release gating and rollback strategy are `../deployment/SKILL.md`; authoring the
+Dockerfile is `docker`; DNS records and the registrar are `domains-dns`; a bare Hetzner box
+and its economics are `hetzner`. Pick the compute model first, then wire data and storage,
+then the ops that bite in production.
 
 ```text
 workload → [Droplet | App Platform | Functions] → Managed DB (VPC private host) → Spaces (S3 + CDN)
@@ -34,11 +35,9 @@ Droplet only when you need the box itself.
 Rules of thumb:
 
 - **Stateless web service or API from a Git repo → App Platform.** It builds, deploys, gives
-  you TLS and a URL, and re-deploys on push. No box to patch.
+  you TLS and a URL, and re-deploys on push. No box to patch. **Static frontend → App
+  Platform static site (free, up to 3)**; don't run a Droplet to serve HTML.
 - **You need root, a long-lived stateful daemon, custom ports, or a cron host → Droplet.**
-  App Platform components are not meant to be a persistent pet process.
-- **Static frontend → App Platform static site (free, up to 3).** Don't run a Droplet to
-  serve HTML.
 - **A managed Postgres/MySQL/Valkey → always the Managed Database product**, never a DB you
   hand-install on a Droplet, unless you have a hard reason.
 
@@ -156,8 +155,8 @@ doctl compute droplet create web-1 \
   to spin up and destroy, but a powered-off Droplet still bills for storage — destroy, don't
   just power off, to stop charges.
 
-Cloud-init recipes, firewall inbound/outbound rule sets, snapshot cadence, and reserved-IP
-failover live in `references/droplet-ops.md`.
+Cloud-init recipes, firewall inbound/outbound rule sets, snapshot cadence + restore,
+reserved-IP failover, and the VPC + private-DB layout live in `references/droplet-ops.md`.
 
 ## Managed Databases
 
@@ -206,11 +205,6 @@ browser fetches it cross-origin, and a **lifecycle** rule to expire/transition o
 
 ## Basic ops + cost gotchas
 
-```bash
-doctl apps logs <app-id> --type run --follow   # app logs
-doctl apps update <app-id> --spec .do/app.yaml # change instance_count/size by editing the spec
-```
-
 - Set **alerts** on the app/DB (deploy failures, CPU, restart count) so you hear about
   trouble before users do. App-level dashboards/alerting *strategy* is `../monitoring`.
 - **Scale** by editing `instance_count`/`instance_size_slug` in the spec and re-applying;
@@ -231,21 +225,3 @@ doctl apps update <app-id> --spec .do/app.yaml # change instance_count/size by e
 | Hand-installing Postgres on a Droplet "to save money" | You now own patching, backups, failover | Managed Database unless you have a hard reason |
 | Powering off a Droplet to stop billing | Powered-off Droplets still bill for storage | Snapshot then destroy |
 | Leaving a reserved IP unassigned | It's billed when not attached | Release it |
-
-## References
-
-- `references/app-spec.md` — full multi-component app spec (web + worker + static_site + job
-  + database), health checks, ingress routes, instance-size slug table, env/SECRET scoping,
-  autoscaling and alerts.
-- `references/droplet-ops.md` — cloud-init examples, cloud firewall inbound/outbound rule
-  recipes, snapshot/backup cadence + restore, reserved IP failover, VPC + private DB layout.
-
-## Boundary
-
-This skill is DigitalOcean-specific deployment. For neighbors:
-
-- Host-agnostic CI/CD pipelines, release gating, rollback strategy → `../deployment/SKILL.md`.
-- Postgres schema/query/index work (not "provision a DO cluster") → `../postgresdb/SKILL.md`.
-- Authoring the Dockerfile itself → `docker`. DNS records/registrar → `domains-dns`.
-- Uptime/metrics dashboards + alerting strategy → `monitoring`. Host-agnostic capacity →
-  `scaling`. A Hetzner bare VPS and its economics → `hetzner`.


### PR DESCRIPTION
Context-engineering pass on `skills/digitalocean/SKILL.md` against `scripts/skill-rubric.md`. No content rewrite: every recommendation, command, price and date is unchanged.

| | before | after |
| --- | --- | --- |
| description | 828 chars | 349 chars |
| body | 12,908 bytes / 251 lines | 11,403 bytes / 227 lines |
| eval-lint | — | **PASS** (should_trigger=5, should_not_trigger=4, capability=1) |

## Description

Was a keyword bank: eight quoted trigger phrases in three languages plus a feature inventory, in context on every turn the skill is installed whether or not it fires. Now what it does / when / an explicit NOT boundary against the three siblings a reader genuinely confuses this with:

- `deployment` — host-agnostic CI/CD and rollback strategy
- `hetzner` — a bare VPS you harden yourself
- `railway` — someone else's managed PaaS

The non-obvious "S3-compatible bucket with a CDN → Spaces" route is preserved as `S3-compatible Spaces + CDN` in the description and stays covered by its `should_trigger` eval case.

## Removed

- **`## References` tail index** — both files were already linked at point of use (`references/app-spec.md` in the App Platform section, `references/droplet-ops.md` in the Droplets section), so the index was a second copy of the same two links. Its one unique detail (VPC + private-DB layout) folded into the inline mention, so both links survive.
- **`## Boundary` section** — restated the description's NOT clause plus the `postgresdb` / `monitoring` / `scaling` delegations that already sit inline in the sections that need them. The routing it uniquely carried (`docker`, `domains-dns`) moved to the opening paragraph, where a reader decides whether they are in the right skill at all. This also resolved the dangling "see the boundary at the bottom" pointer.
- **A duplicated `bash` fence** under "Basic ops + cost gotchas" — both commands in it (`doctl apps logs`, `doctl apps update --spec`) appear verbatim in the App Platform section above. The cost bullets, which carry the real numbers, stayed.
- **Two rules-of-thumb bullets** collapsed into the ones beside them; the "App Platform components are not meant to be a persistent pet process" why is already the second column of the matching anti-patterns row.

## Kept

- **The anti-patterns table** — the rubric requires one, and this is not a rationalization bank: eight concrete failure modes with real slugs and prices (`apps-d-2vcpu-4gb` ~$78/mo, plaintext `dop_v1_…` in a spec, powering off a Droplet to stop billing).
- **The Droplet vs App Platform vs Functions decision table** — this is where the flow actually branches, and it is the skill's whole job.
- **Every load-bearing figure and date**: per-second billing since 2026-01-01 (min 60s / $0.01), 3 free static sites, $5/mo basic, ~$15/mo single-node managed PG and ~$30/mo HA, ~21 pools / ~1,000 connections, $5/mo Spaces with 250 GiB + 1 TiB egress, $0.02/GiB App Platform overage.
- **The app spec YAML, the `${db.DATABASE_URL}` injection and `type: SECRET` scoping notes, the boto3 Spaces snippet, and the "rollback = re-apply the prior spec" mechanism.**

No result envelope or chain-position block existed, so none was added. `manifest.json` untouched; `evals/`, `scripts/verify.sh` and both `references/` files untouched.
