### PR TITLE
fix(release): unwedge the pipeline and stop it stranding a tag without its commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,23 @@ jobs:
         run: |
           git config user.name "Eric Risco"
           git config user.email "erisco@icloud.com"
+      # The registry is the source of truth for "what is already released". If a previous run
+      # published and tagged but failed to push the bump commit back (main advanced under it),
+      # package.json is left behind and every later run recomputes the SAME version, hits
+      # "tag already exists" and dies — wedging releases permanently. Reconciling first makes
+      # the pipeline self-healing instead.
+      - name: Reconcile version with the registry
+        run: |
+          PUBLISHED="$(npm view @ericrisco/rsc version 2>/dev/null || echo 0.0.0)"
+          LOCAL="$(node -p "require('./package.json').version")"
+          HIGHEST="$(printf '%s\n%s\n' "$PUBLISHED" "$LOCAL" | sort -V | tail -1)"
+          echo "published=$PUBLISHED local=$LOCAL highest=$HIGHEST"
+          if [ "$HIGHEST" != "$LOCAL" ]; then
+            npm version "$HIGHEST" --no-git-tag-version --allow-same-version
+            git add package.json package-lock.json manifest.json
+            git commit -m "chore: realign version with the registry ($LOCAL -> $HIGHEST) [skip ci]"
+          fi
+
       - name: Bump version
         run: |
           npm version "${{ github.event.inputs.bump || 'patch' }}" -m "chore(release): %s [skip ci]"
@@ -70,8 +87,23 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # main can advance while this job runs (a PR merging behind it), which rejects the push
+      # as non-fast-forward. `--follow-tags` still lands the tag, so a bare push leaves the tag
+      # published without its commit — the state that wedged this pipeline. Rebase and retry.
       - name: Push version commit + tag
-        run: git push --follow-tags origin main
+        run: |
+          for attempt in 1 2 3; do
+            git fetch origin main
+            git rebase origin/main || { git rebase --abort; exit 1; }
+            if git push --follow-tags origin HEAD:main; then
+              echo "pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "push rejected, retrying ($attempt/3)"
+            sleep 5
+          done
+          echo "::error::could not push the version commit after 3 attempts"
+          exit 1
 
       # --- cut a GitHub Release for the new tag --------------------------------
       - name: Create GitHub Release

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.43",
+  "version": "0.1.44",
   "counts": {
     "skills": 258
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ericrisco/rsc",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "Eric Risco's agent-skills catalog as a granular, self-recommending CLI installer.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Releases have been failing since **25 Jul**. The error was `fatal: tag 'v0.1.44' already exists`, and the underlying state is worse than the message suggests:

| | |
|---|---|
| npm `latest` | **0.1.44** (published) |
| `package.json` on main | **0.1.43** |
| git tag `v0.1.44` | exists on the remote |

Git and the registry have been disagreeing for four days, and nothing surfaced it because the job dies at the bump step — before any gate runs.

## What happened

A run bumped, published to npm, created the tag, then reached `git push --follow-tags origin main`. `main` had advanced underneath it (a PR merging behind the release), so the branch update was rejected as non-fast-forward — **but the tag ref went through anyway**. That leaves a published tag with no commit behind it, so every later run recomputes the same `0.1.44`, collides with the tag, and dies. Permanently wedged, and it stays wedged without manual intervention.

`concurrency: group: release` was already in place — it serialises releases against each other, but it never protected against an ordinary merge racing one.

## Fixes

**State:** `package.json` realigned to `0.1.44` to match the registry. The next release cuts `0.1.45`.

**Cause, so it cannot recur:**

- **Reconcile before bumping.** The job now takes the highest of `package.json` and `npm view @ericrisco/rsc version`. A stranded bump self-heals on the next run instead of jamming forever.
- **Rebase and retry the push.** Up to three attempts against `origin/main`, so a merge landing mid-release no longer strands the tag.

## Verification

`npm run manifest:check` OK (258 skills), `npm test` 194 pass. The reconcile path is exercised by this very merge: main is at 0.1.44 and npm is at 0.1.44, so the step is a no-op and the bump produces 0.1.45.