### PR TITLE
fix(release): tag after the push, so the tag can never point at an orphan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,24 +78,32 @@ jobs:
             git commit -m "chore: realign version with the registry ($LOCAL -> $HIGHEST) [skip ci]"
           fi
 
+      # No tag here on purpose. The tag is created after the commit is pushed (see below), so
+      # it can only ever point at something that actually landed on main.
       - name: Bump version
+        id: bump
         run: |
-          npm version "${{ github.event.inputs.bump || 'patch' }}" -m "chore(release): %s [skip ci]"
+          npm version "${{ github.event.inputs.bump || 'patch' }}" --no-git-tag-version
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          git add package.json package-lock.json manifest.json
+          git commit -m "chore(release): $VERSION [skip ci]"
 
       # --- publish + push the bump back ----------------------------------------
       - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      # main can advance while this job runs (a PR merging behind it), which rejects the push
-      # as non-fast-forward. `--follow-tags` still lands the tag, so a bare push leaves the tag
-      # published without its commit — the state that wedged this pipeline. Rebase and retry.
-      - name: Push version commit + tag
+      # main can advance while this job runs (a PR merging behind it), which rejects the push as
+      # non-fast-forward — so rebase and retry. Tagging is deliberately NOT part of this step:
+      # a rebase rewrites the commit's sha, and a tag made beforehand would be left pointing at
+      # an orphan. Push the commit, then tag whatever landed.
+      - name: Push version commit
         run: |
           for attempt in 1 2 3; do
             git fetch origin main
             git rebase origin/main || { git rebase --abort; exit 1; }
-            if git push --follow-tags origin HEAD:main; then
+            if git push origin HEAD:main; then
               echo "pushed on attempt $attempt"
               exit 0
             fi
@@ -104,6 +112,14 @@ jobs:
           done
           echo "::error::could not push the version commit after 3 attempts"
           exit 1
+
+      # The invariant this pipeline lost for four days: a tag never exists without its commit.
+      # Tagging only after a successful push is what guarantees it, in both directions.
+      - name: Tag the released commit
+        run: |
+          V="v${{ steps.bump.outputs.version }}"
+          git tag -a "$V" -m "chore(release): ${{ steps.bump.outputs.version }}"
+          git push origin "$V"
 
       # --- cut a GitHub Release for the new tag --------------------------------
       - name: Create GitHub Release


### PR DESCRIPTION
My previous fix (#120) solved *"tag pushed without its commit"* and created the exact mirror image of it.

The push step rebases onto `origin/main`, which **rewrites the version commit's sha** — but `npm version` had already created the tag against the pre-rebase commit. `--follow-tags` only pushes tags reachable from what it pushes, so the tag stayed local and the run died at:

```
tag v0.1.46 exists locally but has not been pushed to ericrisco/rsc-harness
```

npm got 0.1.45 and 0.1.46, `main` got both commits, and neither got a tag or a GitHub Release.

## Reordered so the invariant holds both ways

1. Bump with `--no-git-tag-version` and commit by hand — **no tag yet**
2. Publish to npm
3. Rebase and push the commit, with retries
4. **Only then** tag the commit that actually landed, and push the tag
5. Cut the GitHub Release

A tag now exists if and only if its commit is on `main`. Neither half can be stranded.

## Backfilled

`v0.1.45` (61e3df3) and `v0.1.46` (d0d2552) were published to npm but never tagged. Both now have tags and GitHub Releases, so git, npm and the releases page agree again for the first time since 25 Jul.

## Sequence of the three bugs, for the record

| | State | Cause |
|---|---|---|
| 25 Jul | tag without commit → pipeline wedged 4 days | plain push rejected by a racing merge, tag went through anyway |
| #120 | commit without tag | rebase rewrote the sha the tag pointed at |
| this PR | neither can strand | tag is created from what landed, after it landed |