### PR TITLE
refactor(drizzle-orm): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/drizzle-orm/SKILL.md
+++ b/skills/drizzle-orm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: drizzle-orm
-description: "Use when modeling data or querying with Drizzle ORM in TypeScript — schema declared in `.ts`, type-safe `select`/`insert`/relational queries, and `drizzle-kit` migrations, or when choosing Drizzle over Prisma for an edge/serverless runtime. Triggers: 'set up Drizzle ORM', 'drizzle-kit generate', 'write a pgTable schema', '$inferSelect type', 'drizzle push vs generate for production', 'my db.query.posts.findMany returns no author relation', 'drizzle-kit conflicting migration', 'switch off Prisma to something lighter for edge', 'definir l esquema amb Drizzle i tipus type-safe', 'migrar de Prisma a Drizzle para algo más ligero', 'migració amb drizzle-kit'. NOT Prisma Client or schema.prisma (that is prisma-orm), NOT a generic zero-downtime migration strategy (that is db-migrations), NOT Postgres engine/indexing/EXPLAIN (that is postgresdb)."
+description: "Use when modeling data or querying with Drizzle ORM in TypeScript — `pgTable` schema in `.ts`, type-safe select/insert/relational queries, `drizzle-kit` migrations. NOT Prisma Client or `schema.prisma` (that is `prisma-orm`), NOT ORM-agnostic migration strategy (that is `db-migrations`), NOT Postgres engine tuning or EXPLAIN (that is `postgresdb`)."
 tags: [drizzle, drizzle-orm, typescript-orm, drizzle-kit, sql, migrations, database, schema]
 recommends: [prisma-orm, postgresdb, db-migrations, neon, sqlite-turso, planetscale, supabase, typescript, sql]
 origin: risco
@@ -229,6 +229,3 @@ It checks a `drizzle()` call exists, the table helper matches the configured `di
 carries `dialect`/`schema`/`out`, that any `db.query` usage has `{ schema }`/`{ relations }` passed
 to `drizzle()`, and bans Prisma-isms (`schema.prisma`, `PrismaClient`, `prisma generate`) that mean
 the wrong ORM leaked in.
-
-For the full driver matrix and the v1↔v2 relations migration, see
-`references/relations-and-drivers.md`.


### PR DESCRIPTION
Migrates `drizzle-orm` to the Claude-5-era authoring rubric (`scripts/skill-rubric.md`,
`scripts/skill-migration-brief.md`). The skill's body already met the rubric, so this is
deliberately a small diff: 1 insertion, 4 deletions.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 849 | **350** |
| body bytes | 11236 | **10627** |
| body lines | 234 | **231** |
| `eval-lint` | — | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

## What went

- **The `Triggers:` phrase list** — eleven quoted phrases across English, Spanish and Catalan,
  499 of the description's 849 characters. The description is in context on every turn the
  skill is installed, invoked or not, so that was a per-turn tax on every user for routing the
  model already does by meaning.
- **The two-line reference pointer at the tail.** Both halves of it were already inline at the
  point of use: the driver matrix is pointed to under "Decide first", the v1↔v2 relations
  walkthrough under "Relations". `references/relations-and-drivers.md` is still linked twice
  from the body, so the reference-must-be-linked invariant holds.

## What stayed, and why

- **All three `NOT … (that is <sibling>)` boundaries** — `prisma-orm`, `db-migrations`,
  `postgresdb`. All three exist under `skills/`. They are what make the description
  discriminative against its nearest neighbours, which is the actual test in dimension 1.
- **The anti-patterns table.** Required by the rubric, and it is the clean `Anti-pattern | Why
  it bites | Do instead` shape already — not the borrowed excuse/rationalization wrapper
  dimension 7 forbids. Its rows name concrete failure modes (`db.query` with no `{ schema }`,
  `dialect` mismatched to the table helper, an un-awaited builder), not rules restated from
  above.
- **The two decision tables.** The flow genuinely branches: 0.45.x vs the 1.0 rc line, and
  driver entrypoint by host. That is exactly where the rubric wants a table.
- **The bad → good pair** teaching `where` in SQL instead of `.filter()` in JS — judgment by
  demonstration.
- **The Verify section** describing the real `scripts/verify.sh`.

No result-envelope block was added; this skill never had one.

## Substance untouched

This was a context-engineering pass, not a content rewrite. Every version, command, API name
and code sample is unchanged — `drizzle-orm@0.45.2` / `drizzle-kit@0.31.x`, the
`1.0.0-rc.3` line with Relations v2, the eight driver entrypoints, the `drizzle.config.ts`
keys, the migration workflow. `manifest.json` was not touched; it is derived.

Content issues noticed and deliberately **not** fixed here (they need their own change):
none for this skill — its five `route_to` targets (`prisma-orm`, `db-migrations`,
`postgresdb`, `neon`, `sql`) all name skills that exist.
