### PR TITLE
refactor(duckdb): cut the trigger list and the duplicate reference index

### DIFF
--- a/skills/duckdb/SKILL.md
+++ b/skills/duckdb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duckdb
-description: "Use when you need fast analytical SQL over local files (Parquet/CSV/JSON/Arrow) with no server to run, when embedding OLAP in an app or notebook, when a pandas groupby/merge on multi-GB data is too slow, or when reading data straight from S3/HTTP/a lakehouse. Triggers: 'query a folder of parquet files in place', 'aggregate a 5GB CSV on my laptop', 'replace this slow pandas groupby', 'run SQL over a dataframe in Jupyter', 'read these parquet files from S3 without downloading', 'out-of-core aggregate', 'analizar un CSV enorme sin montar un servidor', 'consultar parquet en local sense base de dades'. NOT a multi-user production analytics server (that is clickhouse-analytics), NOT your app's transactional CRUD database (that is postgresdb)."
+description: "Use when analytical SQL must run in-process with no server: Parquet/CSV/JSON/Arrow queried in place, OLAP embedded in an app or notebook, a slow pandas groupby on multi-GB data, or S3/lakehouse data read without downloading. NOT a multi-user analytics server (that is clickhouse-analytics), NOT an app's transactional CRUD store (that is postgresdb)."
 tags: [duckdb, olap, analytics, parquet, embedded-database, sql, columnar]
 recommends: [clickhouse-analytics, postgresdb, sql, sqlite-turso, data-cleaning, business-intelligence]
 origin: risco
@@ -34,8 +34,7 @@ for greenfield exploration.
 The two you will confuse most: DuckDB vs ClickHouse is **embedded-single-node vs server-distributed** —
 under ~10GB on one box DuckDB usually wins; pick ClickHouse when many people query concurrently. DuckDB vs
 SQLite is **same niche, opposite workload** — both embedded single-file, but SQLite is row-store OLTP and
-DuckDB is column-store OLAP. Don't run your app's writes through DuckDB. (Some recommended siblings above
-may not be built in this collection yet; the routing decision still holds.)
+DuckDB is column-store OLAP. Don't run your app's writes through DuckDB.
 
 ## Install & version
 
@@ -175,22 +174,17 @@ escape hatch, not the default.
 
 ## Anti-patterns
 
-| Rationalization | Reality → STOP |
+| Anti-pattern | Do instead |
 | --- | --- |
-| "Load the file into pandas, then query it" | You just paged the whole file through RAM. `FROM 'file.parquet' SELECT ...` scans only needed columns. |
-| "DuckDB can be our app's database" | One writer, single process — concurrent CRUD writers corrupt the workflow. App OLTP is `postgresdb`. |
-| "Spin up DuckDB behind our dashboard API for 200 users" | It's embedded, not a server; concurrent users serialize on the writer. That's `clickhouse-analytics`. |
-| "Just use the latest version in prod" | Pin the **LTS** (1.4.x; v1.4.4 shipped 2026-01-26) so a future upgrade doesn't break the on-disk format / extension ABI. |
-| "Download the S3 files, then read them" | `INSTALL httpfs` + `CREATE SECRET` reads `s3://...` in place with row-group pushdown. No download. |
-| "`SELECT *` over this 200-column Parquet" | Columnar engine — list the columns you need so it skips the rest. `SELECT *` reads everything. |
-| "GROUP BY a, b, c (restate every column)" | Drift bait. `GROUP BY ALL` tracks the SELECT automatically. |
-| "It's embedded so I don't need to think about RAM" | Set `memory_limit` / `threads`; without a cap a runaway aggregate can thrash before it spills. |
-| "Use DuckDB as our embeddings/vector store" | VSS exists but vector search is `vector-db`'s workflow, not DuckDB's home turf. |
-
-## References
-
-- [references/python-and-interop.md](references/python-and-interop.md) — full Python client: connect/cursor, `?`/`$name` parameters, relational operators, register/unregister frames, pandas/Polars/Arrow/NumPy round-trips, transactions, threading caveat.
-- [references/remote-and-lakehouse.md](references/remote-and-lakehouse.md) — httpfs, `CREATE SECRET` for S3/GCS/Azure, hive globs, Iceberg/Delta/DuckLake reads, partitioned writes, MotherDuck `ATTACH 'md:'`.
+| Loading a file into pandas, then querying the frame | Pages the whole file through RAM. `FROM 'file.parquet' SELECT ...` scans only needed columns. |
+| Making DuckDB the app's database | One writer, single process — concurrent CRUD writers corrupt the workflow. App OLTP is `postgresdb`. |
+| Serving a dashboard API for 200 users from DuckDB | It's embedded, not a server; concurrent users serialize on the writer. That's `clickhouse-analytics`. |
+| Running the latest version in prod | Pin the **LTS** (1.4.x; v1.4.4 shipped 2026-01-26) so a future upgrade doesn't break the on-disk format / extension ABI. |
+| Downloading the S3 files, then reading them | `INSTALL httpfs` + `CREATE SECRET` reads `s3://...` in place with row-group pushdown. No download. |
+| `SELECT *` over a 200-column Parquet | Columnar engine — list the columns you need so it skips the rest. `SELECT *` reads everything. |
+| `GROUP BY a, b, c` — restating every column | Drift bait. `GROUP BY ALL` tracks the SELECT automatically. |
+| Treating "embedded" as "no need to think about RAM" | Set `memory_limit` / `threads`; without a cap a runaway aggregate can thrash before it spills. |
+| Using DuckDB as the embeddings/vector store | VSS exists but vector search is `vector-db`'s workflow, not DuckDB's home turf. |
 
 ## Verify
 


### PR DESCRIPTION
Context-engineering pass on `duckdb` per `scripts/skill-migration-brief.md` + `scripts/skill-rubric.md`. Format only — no recommendation, version, figure or command changed.

## Numbers

| | before | after |
|---|---|---|
| description | 746 chars | **350 chars** (-53%) |
| SKILL.md | 11771 bytes / 208 lines | **10768 bytes / 202 lines** |
| eval-lint | — | **PASS** (`should_trigger=6, should_not_trigger=5, capability=1`) |

## Description

Dropped the eight-phrase `Triggers:` list (English/Spanish/Catalan) — pure per-turn cost for every install, invoked or not. What remains is what discriminates: in-process analytical SQL over files, plus the two `NOT` boundaries.

> Use when analytical SQL must run in-process with no server: Parquet/CSV/JSON/Arrow queried in place, OLAP embedded in an app or notebook, a slow pandas groupby on multi-GB data, or S3/lakehouse data read without downloading. NOT a multi-user analytics server (that is clickhouse-analytics), NOT an app's transactional CRUD store (that is postgresdb).

Both named siblings verified present under `skills/`.

## What went

- **Trailing `## References` index.** Both files it listed are already linked inline at their point of use (`references/python-and-interop.md` in the Python interop section, `references/remote-and-lakehouse.md` in the remote/lakehouse section), so the tail block paid twice for the same two links. Invariant holds: every file under `references/` is still reachable from the body.
- **A stale hedge** — "(Some recommended siblings above may not be built in this collection yet; the routing decision still holds.)" Checked the catalog: `clickhouse-analytics`, `postgresdb`, `sqlite-turso`, `sql` and `vector-db` all exist, so the caveat was simply wrong.

## What was reframed, not cut

The anti-patterns table was the hybrid case the brief describes. **All nine rows kept**, re-columned `Rationalization | Reality → STOP` → `Anti-pattern | Do instead`, urgency wrapper dropped. The rows name concrete failure modes (pandas-then-query, DuckDB behind a 200-user dashboard, unpinned prod version, `SELECT *` over 200 columns) — that is the anti-patterns table dimension 3 requires, not a rule bank.

## What was deliberately kept

- **"Is DuckDB the tool?" routing table** — the flow genuinely branches six ways, and routing is this skill's primary job.
- Version guidance (v1.5.3 stable, v1.4.4 LTS), install block, friendly-SQL dialect block, remote/lakehouse and export snippets, the "Outgrowing DuckDB" handoff to `clickhouse-analytics`/MotherDuck, the `Verify` section describing `scripts/verify.sh`, and the 02-DOCS grounding pointer (a pointer to `harness`, not a restatement of it).
- No result-envelope block existed and none was added.

## Checks

- `bash scripts/eval-lint.sh` → `duckdb PASS`
- Frontmatter parses as YAML; `name` matches the dir id; `origin: risco`
- All five `../<sibling>/SKILL.md` links resolve; all five `route_to` values in `evals/cases.yaml` name real skills
- `manifest.json` untouched (derived — orchestrator regenerates)
- Only `skills/duckdb/` touched
