### PR TITLE
refactor(domains-dns): cut the trigger list and the tail index

### DIFF
--- a/skills/domains-dns/SKILL.md
+++ b/skills/domains-dns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domains-dns
-description: "Use when pointing a custom domain at a host, fixing broken HTTPS, choosing apex vs www, or publishing DNS rows — registering/delegating a name, writing A/AAAA/CNAME/ALIAS/MX/TXT/CAA/SRV records, standing up auto-renewing TLS, or cutting nameservers over without downtime. Triggers: 'point example.com at Vercel', 'set up DNS for the domain', 'NET::ERR_CERT_AUTHORITY_INVALID', 'CNAME flattening / ALIAS at the apex', 'dig +trace still shows the old IP', 'need a CAA record for Let's Encrypt', 'publish the SPF/DKIM/DMARC/MX rows', 'apuntar el dominio', 'el certificado caducó y no renueva', 'configurar els registres DNS'. NOT inbox placement / warmup / spam-rate tuning (that is email-deliverability), NOT what runs behind the name (that is deployment)."
+description: "Use when pointing a domain at a host or fixing broken HTTPS — delegating nameservers, writing A/AAAA/CNAME/ALIAS/MX/TXT/CAA rows, apex vs www, standing up auto-renewing TLS, and cutting nameservers over without downtime. NOT inbox placement or warmup (that is `email-deliverability`), NOT what runs behind the name (that is `deployment`)."
 tags: [dns, tls, ssl, domains, https, acme, certbot, dig, caa, nameservers]
 recommends: [email-deliverability, deployment, monitoring, cloudflare, vercel]
 origin: risco
@@ -104,13 +104,7 @@ curl -vI https://example.com 2>&1 | grep -Ei 'HTTP/|location|SSL certificate'  #
 
 Propagation is governed by **TTL, not a fixed 48 hours** (RFC 2181). To make a change land fast, lower the record's TTL (e.g. to 300s) *before* you change it, so resolvers re-query sooner. NS/registrar delegation changes can still lag because of registry/TLD TTLs.
 
-Verification checklist before you call it done:
-
-- [ ] `dig +short` returns the intended IP/host from a public resolver (`@1.1.1.1`).
-- [ ] Apex resolves via A/AAAA or ALIAS, **never** a CNAME.
-- [ ] `dig CAA` lists the CA that issued (or is empty — open policy).
-- [ ] `openssl s_client` shows the right subject, a complete chain, and `notAfter` comfortably ahead.
-- [ ] `curl -vI` returns 2xx/3xx with no cert warning; www and apex land on the one canonical host.
+`scripts/verify.sh <domain>` runs the whole done-check read-only: apex-CNAME check, CAA sanity, chain completeness + expiry, HTTPS reachability, www↔apex canonical. The full dig/openssl/curl playbook and an error → cause → fix table are in `references/verify-and-debug.md`.
 
 ## Nameserver cutover (no downtime)
 
@@ -135,12 +129,3 @@ Order matters; each step has a reason.
 | Splitting one zone across two providers | Resolvers answer from whichever NS won; records vanish intermittently | One authoritative provider per zone |
 | TTL left at 86400 during migration | Old answer cached for a day after you flip | Drop to 300s a day ahead |
 | Testing certs against ACME production | Burns the 50-cert/7-day limit; week-long lockout | Use the staging endpoint first |
-
-## References & siblings
-
-- `references/record-cookbook.md` — every record type with edge cases (TXT chunking, MX priority, SPF lookup limit, SRV, DNSSEC).
-- `references/tls-and-acme.md` — certbot/acme.sh, HTTP-01 vs DNS-01, wildcards, platform cert quirks, 2026 lifetimes + ARI.
-- `references/verify-and-debug.md` — full dig/openssl/curl playbook and error → cause → fix.
-- `scripts/verify.sh <domain>` — read-only audit: apex-CNAME check, CAA sanity, chain completeness + expiry, HTTPS reachability, www↔apex canonical.
-
-Route out when the ask isn't the records: inbox placement → ../email-deliverability/SKILL.md; what runs behind the name and how it's released → ../deployment/SKILL.md; platform-specific edge/build config → ../cloudflare/SKILL.md or ../vercel/SKILL.md.


### PR DESCRIPTION
Context-engineering pass on `domains-dns` against `scripts/skill-rubric.md`. Format only — no recommendation, version, command, RFC citation or figure changed.

## Numbers

| | Before | After |
| --- | --- | --- |
| `description` chars | 754 | **338** (≤350 target, 1024 hard limit) |
| Body bytes | 11242 | **9841** |
| Body lines | 146 | **131** (≤400 ceiling) |
| eval-lint | PASS | **PASS** (7 should_trigger, 5 should_not_trigger, 1 capability) |

## Description

Dropped the ten-phrase, three-language `Triggers:` list. It is in context on every turn the skill is installed, invoked or not, and the model matches by meaning. The rewrite keeps what discriminates — the record types, apex vs www, TLS, cutover — and states the boundary against the two siblings it is genuinely confusable with:

> Use when pointing a domain at a host or fixing broken HTTPS — delegating nameservers, writing A/AAAA/CNAME/ALIAS/MX/TXT/CAA rows, apex vs www, standing up auto-renewing TLS, and cutting nameservers over without downtime. NOT inbox placement or warmup (that is `email-deliverability`), NOT what runs behind the name (that is `deployment`).

Both siblings exist under `skills/`.

## What went

- **The `Triggers:` phrase list** (~410 chars of the description).
- **The "Verification checklist before you call it done"** — its five items mapped one-to-one, in order, onto the five commands in the fenced block directly above it. Its two criteria that were not pure restatement (complete chain with `notAfter` ahead; www and apex on one canonical host) are exactly what `scripts/verify.sh` already audits, so the checklist is replaced by a one-line pointer to that script.
- **The trailing "References & siblings" index.** `record-cookbook.md` and `tls-and-acme.md` were already linked inline at point of use; `verify-and-debug.md` and `scripts/verify.sh` now are too, in the Verify section. The route-out paragraph repeated the description's boundary, and its `cloudflare` / `vercel` / `email-deliverability` links already appear inline in the body.

**Reference invariant holds:** all three files under `references/` are linked from the body.

## What stayed, on purpose

- **The anti-patterns table, all nine rows.** The rubric requires one, and this is not a rule bank or a rationalization table — no STOP framing, no excuse/reality columns. Every row names a concrete failure mode, why it bites, and the fix.
- **Resolution order is debug order** (name → delegation → records → TLS) — the core teaching, and the reason the skill routes at all.
- **Two decision tables where the flow genuinely branches**: where to host the zone, and HTTP-01 vs DNS-01.
- **The apex bad/good record pair** — judgment taught by demonstration.
- **The TLS rules block** — each rule already sits at point of use and names the failure it prevents (CAA before issuance, fullchain vs leaf, staging vs the 50-cert limit).
- **The nameserver cutover sequence** and the record cookbook summary table.
- No result-envelope block existed and none was added.

## Verification

- `bash scripts/eval-lint.sh | grep -E '^domains-dns +'` → PASS
- `manifest.json` untouched (derived; orchestrator regenerates).
- `npm test` / `npm run validate` not run — no `node_modules` in the worktree, per the migration brief.
