### PR TITLE
refactor(finetuning): cut the description 63% and fold the tail index inline

### DIFF
--- a/skills/finetuning/SKILL.md
+++ b/skills/finetuning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finetuning
-description: "Use when adapting an open-weight model to a target FORM or BEHAVIOR — tone, output format, domain style, a reasoning/tool-calling pattern — via LoRA/QLoRA or full fine-tuning with TRL SFTTrainer and then preference optimization (DPO/ORPO/KTO/GRPO); when choosing fine-tune vs prompt vs RAG vs longer context; when setting LoRA r/alpha/target_modules; when eval loss climbs while train loss keeps falling; when the adapter seems to have learned nothing; when inference outputs garbage after a run. Triggers: 'fine-tune Llama/Qwen on our data', 'LoRA vs QLoRA vs full fine-tune', 'SFT then DPO/ORPO/KTO/GRPO', 'set target_modules / rank / alpha', 'my fine-tune overfits', 'the model forgot everything after training', 'write a GRPO reward function', 'ajustar un modelo amb LoRA amb les nostres dades'. NOT adding facts or fresh knowledge to a model (that is rag); NOT the fast single-GPU Unsloth backend or GGUF export (that is unsloth); NOT serving the trained model (that is vllm)."
+description: "Use when adapting an open-weight model to a target form or behavior — tone, output format, reasoning pattern — via LoRA/QLoRA or full fine-tuning with TRL SFTTrainer, then preference optimization (DPO/ORPO/KTO/GRPO), and for fine-tune vs prompt vs RAG. NOT adding facts to a model (that is rag); NOT the single-GPU Unsloth backend or GGUF export (that is unsloth)."
 tags: [finetuning, lora, qlora, sft, dpo, grpo, peft, trl, preference-optimization]
 recommends: [training-data, unsloth, open-weights, huggingface, vllm, rag]
 origin: risco
@@ -33,8 +33,10 @@ row below is a real off-ramp.
 
 Route out explicitly. Facts / freshness / citations → `../rag/SKILL.md`. Squeezing a prompt before
 spending money → `prompt-engineering`. Picking *which* base model (size/license/task) → `open-weights`.
-Building the JSONL/preference corpus → `training-data`. A fast single-GPU run + GGUF export →
-`../unsloth/SKILL.md`. Serving the result → `../vllm/SKILL.md`.
+Building the JSONL/preference corpus → `training-data` (LLM corpora, NOT tabular cleaning — that is
+`data-cleaning`). A fast single-GPU run + GGUF export → `../unsloth/SKILL.md` (same LoRA/QLoRA
+concepts, one optimized implementation; this skill stays backend-agnostic). Downloading the base or
+pushing the adapter/merged model → `huggingface`. Serving the result → `../vllm/SKILL.md`.
 
 > The cheapest fine-tune is the one you didn't need. Prompt + RAG solves most "make it behave"
 > asks at zero training cost and updates instantly. Fine-tune when that ceiling is real, measured,
@@ -201,6 +203,8 @@ score). Judge the run on that, plus **eval loss**.
   eval; keep the held-out set quarantined. (Corpus-side hygiene is `training-data`.)
 - General LLM/agent eval harness and judging → `agent-eval`. Bring your task metric here.
 
+The full tuning + forgetting + evaluation playbook is in `references/hyperparameters-and-eval.md`.
+
 ## When NOT to fine-tune (anti-patterns)
 
 | Anti-pattern | Why it breaks | Do instead |
@@ -214,19 +218,6 @@ score). Judge the run on that, plus **eval loss**.
 | A few dozen examples for full FT | Not enough signal; unstable | Curate ~hundreds–thousands (LIMA) or use LoRA |
 | Fine-tune a model you can't legally deploy | License blocks your use case | Check the model card first → `open-weights` |
 
-## Related skills
-
-- **`../rag/SKILL.md`** — the fork of the decision gate: facts/freshness/citations live there;
-  form/behavior lives here. Most "make it behave" asks are RAG or prompting, not training.
-- **`prompt-engineering`** — the cheaper lever to exhaust before spending a GPU.
-- **`training-data`** — builds/validates the JSONL `messages` and preference-pair corpus you feed
-  here (LLM corpora, NOT tabular cleaning — that is `data-cleaning`).
-- **`open-weights`** — chooses *which* base model by task/size/license; you consume that choice.
-- **`../unsloth/SKILL.md`** — a fast single-GPU training backend + GGUF export; same LoRA/QLoRA
-  concepts, one optimized implementation. This skill stays backend-agnostic.
-- **`huggingface`** — download the base, push the adapter/merged model, host inference (NOT training).
-- **`../vllm/SKILL.md`** — serves the trained/merged model (adapter hot-swap, throughput flags).
-
 ## Checklist
 
 - [ ] Ran the decision gate: confirmed this is a form/behavior need, not a facts need (else → rag).
@@ -239,6 +230,3 @@ score). Judge the run on that, plus **eval loss**.
 - [ ] Trained 1–3 epochs; watched **eval** loss (not train) for the overfitting turn.
 - [ ] Preference stage only if needed; correct method for the data (pairs→DPO/ORPO, votes→KTO, verifier→GRPO); tiny LR.
 - [ ] Verified `trl`/`peft`/`transformers` current majors and import paths at author time.
-
-See `references/methods.md` for full SFT→DPO/GRPO/ORPO/KTO scripts, dataset schemas, and adapter
-merging; `references/hyperparameters-and-eval.md` for the tuning + forgetting + evaluation playbook.


### PR DESCRIPTION
Migrates `finetuning` to the Claude-5-era authoring rubric. Context pass only — no recommendation, version, hyperparameter or citation was changed.

## Numbers

| | Before | After |
|---|---|---|
| `description` | 981 chars | **364 chars** (−63%) |
| body | 16,615 bytes / 245 lines | **15,188 bytes / 233 lines** |
| eval-lint | — | **PASS** (should_trigger=7, should_not_trigger=6, capability=1) |

The description was the real cost: it is in context on every turn this skill is installed, invoked or not, and it was sitting at 981 of the 1024-char budget.

## What went

- **The `Triggers: '…'` phrase list** — 8 quoted phrases across English and Catalan. The model matches by meaning; a keyword list is pure per-turn cost.
- **The symptom enumeration** in the description ("when eval loss climbs while train loss keeps falling", "when the adapter seems to have learned nothing", "when inference outputs garbage after a run"). Each is already an anti-patterns row where it can be acted on. In the description it was coverage, not discrimination.
- **The `NOT … (that is vllm)` boundary.** Training vs serving is not a near-miss. The two boundaries that do real work are kept: `rag` (facts vs form — the fork that routes half of all "should I fine-tune?" questions) and `unsloth` (same job, one specific backend). `vllm` is still routed inline in the body and still has its own `should_not_trigger` eval case.
- **The `## Related skills` tail index** (12 lines). Every link in it already appeared at the point of use in the decision gate's route-out paragraph — except `huggingface` and the `data-cleaning` boundary. Those two, plus the "same LoRA/QLoRA concepts, one optimized implementation; this skill stays backend-agnostic" note that distinguishes this skill from `unsloth`, were folded into that paragraph. Nothing was lost, and a reader deciding where to go now reads it where they are deciding rather than 190 lines later.
- **The trailing `See references/…` line.** `methods.md` was already linked inline right after the GRPO example; `hyperparameters-and-eval.md` is now linked from the evaluation section it actually documents.

## What stayed, deliberately

- **Every substantive detail, verbatim.** QLoRA NF4 + double quantization, `alpha ≈ 2·r`, LoRA LR 1e-4–2e-4, DPO 5e-7, GRPO 1e-6, `target_modules="all-linear"`, `num_generations=8`, the trl v1.x / transformers v5.x version-reality notes and the `trl.experimental.*` import warning, LIMA's ~1,000 examples, all arXiv citations, and the model-license caveat. Nothing was reworded, re-recommended or re-versioned.
- **The anti-patterns table, unchanged.** It already had the correct shape (`Anti-pattern | Why it breaks | Do instead`) and names concrete failure modes rather than restating rules above it — there was no STOP / excuse framing to strip.
- **The decision gate and the method-selection tables.** The flow genuinely branches (fine-tune vs prompt vs RAG vs longer context; LoRA vs QLoRA vs full FT; DPO vs ORPO vs KTO vs GRPO by data shape).
- **The pre-flight checklist.** It guards an expensive, irreversible GPU run — operational, not a recap of prose.

## Invariants checked

- Both files under `references/` are linked from the body (`methods.md` line 160, `hyperparameters-and-eval.md` line 206).
- All three `../<sibling>/SKILL.md` links resolve (`rag`, `unsloth`, `vllm`).
- Every `recommends` id is still named in the body: `training-data`, `unsloth`, `open-weights`, `huggingface`, `vllm`, `rag`.
- `name` matches the directory id; `origin: risco` intact; description parses as single-line quoted YAML.
- Evals untouched and already healthy — all six `route_to` values name real skills in the catalog.
- `manifest.json` not touched.
