### PR TITLE
feat(catalog): Claude-5 migration wave 3 — 18 skills

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1332,7 +1332,7 @@
     },
     {
       "id": "domains-dns",
-      "description": "Use when pointing a custom domain at a host, fixing broken HTTPS, choosing apex vs www, or publishing DNS rows — registering/delegating a name, writing A/AAAA/CNAME/ALIAS/MX/TXT/CAA/SRV records, standing up auto-renewing TLS, or cutting nameservers over without downtime. Triggers: 'point example.com at Vercel', 'set up DNS for the domain', 'NET::ERR_CERT_AUTHORITY_INVALID', 'CNAME flattening / ALIAS at the apex', 'dig +trace still shows the old IP', 'need a CAA record for Let's Encrypt', 'publish the SPF/DKIM/DMARC/MX rows', 'apuntar el dominio', 'el certificado caducó y no renueva', 'configurar els registres DNS'. NOT inbox placement / warmup / spam-rate tuning (that is email-deliverability), NOT what runs behind the name (that is deployment).",
+      "description": "Use when pointing a domain at a host or fixing broken HTTPS — delegating nameservers, writing A/AAAA/CNAME/ALIAS/MX/TXT/CAA rows, apex vs www, standing up auto-renewing TLS, and cutting nameservers over without downtime. NOT inbox placement or warmup (that is `email-deliverability`), NOT what runs behind the name (that is `deployment`).",
       "tags": [
         "dns",
         "tls",
@@ -1356,7 +1356,7 @@
     },
     {
       "id": "drizzle-orm",
-      "description": "Use when modeling data or querying with Drizzle ORM in TypeScript — schema declared in `.ts`, type-safe `select`/`insert`/relational queries, and `drizzle-kit` migrations, or when choosing Drizzle over Prisma for an edge/serverless runtime. Triggers: 'set up Drizzle ORM', 'drizzle-kit generate', 'write a pgTable schema', '$inferSelect type', 'drizzle push vs generate for production', 'my db.query.posts.findMany returns no author relation', 'drizzle-kit conflicting migration', 'switch off Prisma to something lighter for edge', 'definir l esquema amb Drizzle i tipus type-safe', 'migrar de Prisma a Drizzle para algo más ligero', 'migració amb drizzle-kit'. NOT Prisma Client or schema.prisma (that is prisma-orm), NOT a generic zero-downtime migration strategy (that is db-migrations), NOT Postgres engine/indexing/EXPLAIN (that is postgresdb).",
+      "description": "Use when modeling data or querying with Drizzle ORM in TypeScript — `pgTable` schema in `.ts`, type-safe select/insert/relational queries, `drizzle-kit` migrations. NOT Prisma Client or `schema.prisma` (that is `prisma-orm`), NOT ORM-agnostic migration strategy (that is `db-migrations`), NOT Postgres engine tuning or EXPLAIN (that is `postgresdb`).",
       "tags": [
         "drizzle",
         "drizzle-orm",
@@ -1382,7 +1382,7 @@
     },
     {
       "id": "duckdb",
-      "description": "Use when you need fast analytical SQL over local files (Parquet/CSV/JSON/Arrow) with no server to run, when embedding OLAP in an app or notebook, when a pandas groupby/merge on multi-GB data is too slow, or when reading data straight from S3/HTTP/a lakehouse. Triggers: 'query a folder of parquet files in place', 'aggregate a 5GB CSV on my laptop', 'replace this slow pandas groupby', 'run SQL over a dataframe in Jupyter', 'read these parquet files from S3 without downloading', 'out-of-core aggregate', 'analizar un CSV enorme sin montar un servidor', 'consultar parquet en local sense base de dades'. NOT a multi-user production analytics server (that is clickhouse-analytics), NOT your app's transactional CRUD database (that is postgresdb).",
+      "description": "Use when analytical SQL must run in-process with no server: Parquet/CSV/JSON/Arrow queried in place, OLAP embedded in an app or notebook, a slow pandas groupby on multi-GB data, or S3/lakehouse data read without downloading. NOT a multi-user analytics server (that is clickhouse-analytics), NOT an app's transactional CRUD store (that is postgresdb).",
       "tags": [
         "duckdb",
         "olap",
@@ -1404,7 +1404,7 @@
     },
     {
       "id": "dynamodb",
-      "description": "Use when designing or operating an Amazon DynamoDB table - modeling entities and relationships without joins, choosing partition/sort keys, deciding single-table vs table-per-entity, adding a GSI/LSI, picking on-demand vs provisioned capacity, or diagnosing throttling. Triggers: 'design a DynamoDB table', 'model one-to-many / many-to-many without joins', 'single-table design worth it?', 'query the same data by two different keys' (inverted GSI), 'writes throttled even though I'm under my provisioned capacity' (hot partition), 'on-demand or provisioned?', 'why does my Query only return some rows?' (1 MB page), 'diseña la tabla DynamoDB para estos patrones de acceso', 'modela aquesta relació amb clau composta a DynamoDB'. NOT relational schema / SQL / EXPLAIN / B-tree indexing (that is postgresdb), and NOT document modeling with aggregation pipelines (that is mongodb).",
+      "description": "Use when modeling or operating a DynamoDB table: deriving partition/sort keys from access patterns, single-table vs table-per-entity, adding a GSI/LSI, on-demand vs provisioned capacity, or diagnosing hot-partition throttling. NOT relational schema/SQL/EXPLAIN (that is `postgresdb`), NOT aggregation-pipeline document modeling (that is `mongodb`).",
       "tags": [
         "dynamodb",
         "nosql",
@@ -1425,7 +1425,7 @@
     },
     {
       "id": "e-signature",
-      "description": "Use when adding legally-valid electronic-signature flows to documents — sending a PDF or template for signature, embedding signing in your own app, tracking status, verifying signing webhooks, and retrieving the signed PDF plus its audit trail via DocuSign or Dropbox Sign. Triggers: 'send this contract for signature', 'create a DocuSign envelope', 'signature_request/send', 'embed signing in our app', 'notify us when it's signed', 'set up DocuSign JWT auth', 'is a typed-name signature legally binding?', 'do we need QES for EU customers?', 'enviar a firmar', 'firma electrònica amb validesa legal'. NOT drafting the contract text itself (that is contracts) and NOT OCR/parsing/extracting fields from documents (that is document-processing).",
+      "description": "Use when wiring an e-signature flow with DocuSign or Dropbox Sign — picking the SES/AES/QES legal tier, sending a PDF or template for signature, embedded signing, verifying signing webhooks, retrieving the signed PDF plus audit trail. NOT drafting contract text (that is `contracts`), NOT extracting fields from PDFs (that is `document-processing`).",
       "tags": [
         "e-signature",
         "docusign",
@@ -1467,7 +1467,7 @@
     },
     {
       "id": "electron",
-      "description": "Use when building, hardening, or shipping a cross-platform desktop app with Electron — wiring the main/renderer/preload process model, exposing OS capabilities to a web UI over typed IPC, locking down an insecure shell, or packaging with code signing and auto-update. Triggers: 'build a desktop app for Mac/Windows/Linux from my web app', 'let my renderer read a file safely', 'audit my Electron security (nodeIntegration, sandbox, CSP)', 'my preload exposes ipcRenderer and the renderer can require(\\\"fs\\\")', 'Squirrel.Mac won\\\\'t auto-update my app', 'migrate off @electron/remote and BrowserView', 'empaquetar mi app de escritorio para Windows y Mac con firma de código y auto-actualización', 'empaquetar app d\\\\'escriptori amb auto-actualització'. NOT a smaller Rust-backed shell on the OS native webview (that is tauri).",
+      "description": "Use when building, hardening, or shipping a cross-platform Electron desktop app — main/renderer/preload process model, typed contextBridge IPC, locking down nodeIntegration/contextIsolation/sandbox/CSP, or packaging with signing and auto-update. NOT a Rust-backed shell on the native webview (that is tauri), nor the web UI inside it (that is react).",
       "tags": [
         "electron",
         "desktop",
@@ -1488,7 +1488,7 @@
     },
     {
       "id": "elixir",
-      "description": "Use when writing or refactoring Elixir/OTP code — GenServers, supervision trees, processes, pattern matching, mix projects and releases — or when BEAM behaviour misbehaves (restart loops, mailbox growth, timeouts). Triggers: 'write a GenServer', 'design a supervision tree', 'restart strategy one_for_one', 'let it crash instead of try/rescue', 'mix release for production', non-obvious 'my process mailbox keeps growing', 'GenServer call timeout / restart loop', Catalan 'arbre de supervisio en Elixir / processos que peten', Spanish 'arbol de supervision / procesos en Elixir / que es let it crash'. NOT building a Phoenix web app, LiveView, Ecto schemas, controllers or channels (that is phoenix).",
+      "description": "Use when writing or refactoring Elixir/OTP on the BEAM — GenServers, supervision trees and restart strategies, pattern matching, mix projects and releases — or when processes misbehave (restart loops, mailbox growth, call timeouts). NOT a Phoenix web app, LiveView, Ecto or channels (that is `phoenix`).",
       "tags": [
         "elixir",
         "otp",
@@ -1530,7 +1530,7 @@
     },
     {
       "id": "email-deliverability",
-      "description": "Use when mail you send lands in spam, gets rejected, or fails the Gmail/Yahoo bulk-sender checks, and you must fix authentication and reputation rather than the sending code — setting SPF/DKIM/DMARC DNS records so they align, raising a cold domain through warmup, keeping the spam-complaint rate under threshold, adding one-click unsubscribe, getting the brand logo and verified checkmark to show via BIMI, and reading why 'soft' rejections and Postmaster Tools say you are throttled. Triggers: 'our emails go to spam since the Gmail update', 'DMARC fails even though SPF passes', 'how do I warm up a new sending domain', 'do I need one-click unsubscribe to send to gmail', '550 5.7.26 unauthenticated', 'how do I get our logo and the blue checkmark to show in Gmail with BIMI', 'los correos caen en spam y el SPF está bien', 'configurar BIMI i el logo verificat al correu'. NOT putting transactional/bulk email on the wire through a provider API (that is email-connector).",
+      "description": "Use when mail already sent lands in spam, is rejected, or fails the Gmail/Yahoo bulk-sender checks and the fix is authentication and reputation, not the sending code: SPF/DKIM/DMARC alignment, domain warmup, spam-complaint rate, one-click unsubscribe, BIMI. NOT putting mail on the wire through a provider API (that is `email-connector`).",
       "tags": [
         "email",
         "deliverability",
@@ -1552,7 +1552,7 @@
     },
     {
       "id": "embeddings-search",
-      "description": "Use when results from a semantic search feel irrelevant, when you don't know which embedding model or chunk size to use, when you need to add a reranker or hybrid scoring, or when you have no way to tell whether a retrieval change actually helped. Symptoms: search returns garbage, exact-match queries miss, paraphrases work but keywords don't, recall looks fine but the top result is wrong, every chunking idea is a guess. Triggers: 'which embedding model and chunk size should I use', 'my semantic search returns irrelevant results', 'how do I measure if retrieval is good — recall@k, nDCG', 'add a reranker and hybrid BM25+vector', 'exact product codes return nothing but paraphrases work fine', 'recall@k is fine but the top answer is wrong', 'quin model d'embeddings i quina mida de chunk faig servir per a aquests documents', 'la cerca semàntica retorna resultats irrellevants'. NOT operating the vector store (that is vector-db).",
+      "description": "Use when choosing an embedding model, chunk size, or query form, when semantic search returns irrelevant results, when adding hybrid BM25+vector or a reranker, or when a retrieval change needs a number (recall@k, nDCG, MRR). NOT operating the store — index tuning, quantization (that is `vector-db`) — nor the retrieve-to-answer loop (that is `rag`).",
       "tags": [
         "embeddings",
         "semantic-search",
@@ -1598,7 +1598,7 @@
     },
     {
       "id": "expo",
-      "description": "Use when building, shipping, or hot-patching a React Native app with Expo — EAS Build/Submit/Update, eas.json build profiles, config plugins, prebuild/CNG, the managed workflow, confirming you are on the New Architecture (mandatory since SDK 55). Triggers: 'eas build', 'eas.json', 'config plugin', 'expo prebuild', 'my OTA update isn't showing up on devices', 'runtime version mismatch', 'how do I add a permission without editing Xcode/Gradle', 'newArchEnabled is gone from app.json', 'com publico una actualització OTA sense passar per la store', 'subir la app a la Play Store con EAS'. NOT generic React Native components/navigation/native-module authoring (that is react-native), NOT a Dart mobile app (that is flutter).",
+      "description": "Use when shipping a React Native app with Expo — EAS Build/Submit/Update, eas.json profiles and channels, config plugins, prebuild/CNG, runtime-version policy, OTA updates that never land, SDK upgrades, the New Architecture. NOT RN UI, navigation or native-module authoring (that is `react-native`), NOT a Dart app (that is `flutter`).",
       "tags": [
         "expo",
         "eas",
@@ -1641,7 +1641,7 @@
     },
     {
       "id": "fal",
-      "description": "Use when calling a fal.ai model endpoint by id to generate an image, audio, or video from JS/Python/curl, wiring the queue (subscribe vs submit), receiving results by webhook and verifying the ED25519 signature, estimating per-call cost, or migrating off the deprecated @fal-ai/serverless-client. Use when a fal request is stuck IN_QUEUE, a webhook never arrives or its signature won't verify, or a long video gen drops mid-call. Triggers: 'generate an image with fal-ai/flux/dev', 'subscribe vs submit on fal', 'my fal webhook signature won't verify', 'fal request stuck IN_QUEUE', 'how much will 500 Seedream images cost on fal', 'migrate off @fal-ai/serverless-client', 'genera esta imagen con fal y guarda la URL', 'munta el webhook de fal i verifica la firma'. NOT picking the model or art direction (that is ai-media).",
+      "description": "Use when calling a fal.ai endpoint by id to generate image, audio, or video from JS/Python/curl: subscribe vs submit, queue states, ED25519 webhook signature verification, per-call cost, or migrating off @fal-ai/serverless-client. NOT which model or art direction (that is ai-media); NOT the same models on another platform (that is replicate).",
       "tags": [
         "fal",
         "fal-ai",
@@ -1680,7 +1680,7 @@
     },
     {
       "id": "finance-ops",
-      "description": "Use when running the money side of a small company on a cash basis — building a rolling cash-flow forecast, reconciling the bank against the books, fixing a messy expense-category map, or driving a month-end close. Triggers: 'are we going to run out of cash', 'what's our runway', '13-week cash flow forecast', 'reconcile the bank statement', 'these two numbers don't match', 'the ending balance doesn't roll into next week', 'everything landed in Other expenses', 'close the books for May', 'what's our burn this month', 'tancar el mes', 'conciliar el banc amb els llibres', 'cuánto runway nos queda al ritmo actual'. NOT recording journal entries or payroll/depreciation postings (that is bookkeeping).",
+      "description": "Use when running the money side of a small company on a cash basis: a 13-week rolling cash-flow forecast and runway, bank-vs-books reconciliation, mapping spend to tax-return expense categories, or a month-end close. NOT posting journal entries, payroll or depreciation (that is `bookkeeping`); NOT multi-year projections (that is `financial-model`).",
       "tags": [
         "cash-flow",
         "reconciliation",
@@ -1702,7 +1702,7 @@
     },
     {
       "id": "financial-model",
-      "description": "Use when a founder needs the multi-period, driver-based projection that raises a round and steers the company — build 3-year projections, model revenue + costs + headcount + runway, size the raise, or stress-test scenarios. Triggers: 'build a financial model for our seed', 'model our revenue costs and runway', 'when do we run out of cash', 'how much should we raise to get 24 months', 'what runway does $2M buy us', 'model the hiring plan's effect on burn', 'add a downside scenario if we miss plan by 30%', 'modelo financiero a 3 años', 'cuánto runway nos da la ronda', 'model financer i projeccions', 'quant de pista de despegament'. The engine is assumptions → revenue/cost/headcount builds → cash/burn/runway/scenarios, 18–36 months forward, every output a formula. NOT the next-13-weeks liquidity reconciled to the actual bank balance (that is finance-ops), NOT the isolated LTV/CAC math (that is unit-economics, which this model consumes as drivers), NOT the slide story (that is pitch-deck).",
+      "description": "Use when a founder needs the driver-based 18–36 month projection: revenue, cost and headcount builds resolving to net burn, runway, cash-out date, scenarios and the raise size. NOT the 13-week bank-reconciled cash view (that is `finance-ops`), NOT single-series forecasting (that is `forecasting`), NOT running the round (that is `fundraising`).",
       "tags": [
         "financial-model",
         "projections",
@@ -1725,7 +1725,7 @@
     },
     {
       "id": "finetuning",
-      "description": "Use when adapting an open-weight model to a target FORM or BEHAVIOR — tone, output format, domain style, a reasoning/tool-calling pattern — via LoRA/QLoRA or full fine-tuning with TRL SFTTrainer and then preference optimization (DPO/ORPO/KTO/GRPO); when choosing fine-tune vs prompt vs RAG vs longer context; when setting LoRA r/alpha/target_modules; when eval loss climbs while train loss keeps falling; when the adapter seems to have learned nothing; when inference outputs garbage after a run. Triggers: 'fine-tune Llama/Qwen on our data', 'LoRA vs QLoRA vs full fine-tune', 'SFT then DPO/ORPO/KTO/GRPO', 'set target_modules / rank / alpha', 'my fine-tune overfits', 'the model forgot everything after training', 'write a GRPO reward function', 'ajustar un modelo amb LoRA amb les nostres dades'. NOT adding facts or fresh knowledge to a model (that is rag); NOT the fast single-GPU Unsloth backend or GGUF export (that is unsloth); NOT serving the trained model (that is vllm).",
+      "description": "Use when adapting an open-weight model to a target form or behavior — tone, output format, reasoning pattern — via LoRA/QLoRA or full fine-tuning with TRL SFTTrainer, then preference optimization (DPO/ORPO/KTO/GRPO), and for fine-tune vs prompt vs RAG. NOT adding facts to a model (that is rag); NOT the single-GPU Unsloth backend or GGUF export (that is unsloth).",
       "tags": [
         "finetuning",
         "lora",
@@ -1749,7 +1749,7 @@
     },
     {
       "id": "firebase",
-      "description": "Use when building on Firebase — modeling Firestore data, writing or auditing Security Rules, wiring Auth, shipping Cloud Functions, storing files in Cloud Storage, or choosing modular Web/Admin SDK imports — and when symptoms appear like 'my database is open to the internet', 'rules reject my query', a counter stuck at 1 write/sec, custom-claim RBAC, or a callable function. Triggers: 'firestore.rules audit', 'denormalize for read paths', 'collection vs subcollection', 'my query works in the emulator but fails in prod with requires-an-index', 'set a custom admin claim', 'regles de seguretat de Firestore', 'mi base de datos está abierta a internet'. NOT managed-Postgres BaaS with SQL and RLS (that is supabase).",
+      "description": "Use when building on Firebase — Firestore data modeling, Security Rules, Auth and custom claims, Cloud Functions, Storage, modular Web/Admin SDK imports — including symptoms like a database open to the internet, a query rejected by rules, or a doc stuck at ~1 write/sec. NOT managed-Postgres BaaS with SQL and RLS (that is supabase).",
       "tags": [
         "firebase",
         "firestore",
@@ -1783,7 +1783,7 @@
     },
     {
       "id": "fly-io",
-      "description": "Use when deploying or operating an app on Fly.io — writing fly.toml, running Machines across regions near users, attaching Volumes, managing secrets, or scaling (autostop/autostart, scale count, fly-replay). Triggers: 'fly deploy', 'fly launch', 'desplega a Fly.io a prop dels usuaris', 'users in Sydney see high latency but my app only runs in iad', 'scale my Fly app to zero overnight', 'attach a persistent disk to my Fly machine', 'forward writes to the primary region'. NOT a generic git-push PaaS (that is railway), NOT frontend edge hosting (that is vercel).",
+      "description": "Use when deploying or operating an app on Fly.io — writing fly.toml, placing Machines in regions near users, attaching Volumes, managing secrets, or picking a scaling lever (autostop/autostart, scale count, fly-replay). NOT choosing which host to deploy on (that is `deployment`), NOT a git-push PaaS with no regions model (that is `railway`).",
       "tags": [
         "fly-io",
         "deployment",
@@ -1822,7 +1822,7 @@
     },
     {
       "id": "fundraising",
-      "description": "Use when planning or running an equity fundraising round and you need the STRATEGY and PROCESS, not a single document — sizing the raise to a milestone, choosing post-money SAFE vs priced round, building and tiering the investor target list around intro paths, sequencing outreach to manufacture momentum, managing the diligence pipeline, or reading a term sheet to know what to push on before you sign. Triggers: 'plan our seed raise', 'how much should we raise and on what terms', 'SAFE or priced round, what cap', 'build my investor target list', 'how many investors do I actually need to contact', 'we have meetings but no term sheet — the raise stalled', 'got a term sheet, what do I push back on', 'planifica la ronda seed', 'cuántos inversores tengo que contactar', '¿SAFE o ronda con precio?', 'planifiquem la ronda d'inversió'. NOT the slide-deck narrative (that is pitch-deck) and NOT the cap-table/valuation math (that is financial-model).",
+      "description": "Use when planning or running an equity round as a process: sizing the raise to a milestone, choosing post-money SAFE vs priced round, tiering investors by intro path, sequencing outreach for momentum, or reading a term sheet before signing. NOT the slide narrative (that is `pitch-deck`), NOT the cap-table or valuation math (that is `financial-model`).",
       "tags": [
         "fundraising",
         "seed",
@@ -1845,7 +1845,7 @@
     },
     {
       "id": "game-design",
-      "description": "Use when designing or repairing the design of a game — inventing mechanics and systems, shaping the core loop, layering moment-to-moment / session / meta loops, planning progression, economy, currencies and sinks/faucets, tuning difficulty curves and balance, killing dominant strategies, adding 'juice'/game feel as design intent, prototyping and playtesting, or controlling scope, and especially when the ask is 'why isn't my game fun'. Triggers: 'design the core loop', 'my game isn't fun / doesn't hook', 'balance the economy', 'the difficulty curve feels off', 'players found a dominant strategy', 'how do I scope this', 'reward / progression loop', 'diseñar la mecánica', 'el juego no engancha', 'com equilibro l'economia'. NOT writing engine code, scripts or shaders (route to godot/unity/unreal), NOT narrative, dialogue or story beats (route to game-storytelling), NOT level layout or encounter placement (route to level-design).",
+      "description": "Use when designing or repairing what makes a game fun — verbs and mechanics, moment-to-moment/session/meta loops, progression, economy faucets and sinks, difficulty curves, dominant strategies, juice, prototyping and scope. NOT engine code (that is `godot`), NOT story (that is `game-storytelling`), NOT level layout (that is `level-design`).",
       "tags": [
         "game-design",
         "mechanics",

--- a/skills/domains-dns/SKILL.md
+++ b/skills/domains-dns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domains-dns
-description: "Use when pointing a custom domain at a host, fixing broken HTTPS, choosing apex vs www, or publishing DNS rows — registering/delegating a name, writing A/AAAA/CNAME/ALIAS/MX/TXT/CAA/SRV records, standing up auto-renewing TLS, or cutting nameservers over without downtime. Triggers: 'point example.com at Vercel', 'set up DNS for the domain', 'NET::ERR_CERT_AUTHORITY_INVALID', 'CNAME flattening / ALIAS at the apex', 'dig +trace still shows the old IP', 'need a CAA record for Let's Encrypt', 'publish the SPF/DKIM/DMARC/MX rows', 'apuntar el dominio', 'el certificado caducó y no renueva', 'configurar els registres DNS'. NOT inbox placement / warmup / spam-rate tuning (that is email-deliverability), NOT what runs behind the name (that is deployment)."
+description: "Use when pointing a domain at a host or fixing broken HTTPS — delegating nameservers, writing A/AAAA/CNAME/ALIAS/MX/TXT/CAA rows, apex vs www, standing up auto-renewing TLS, and cutting nameservers over without downtime. NOT inbox placement or warmup (that is `email-deliverability`), NOT what runs behind the name (that is `deployment`)."
 tags: [dns, tls, ssl, domains, https, acme, certbot, dig, caa, nameservers]
 recommends: [email-deliverability, deployment, monitoring, cloudflare, vercel]
 origin: risco
@@ -104,13 +104,7 @@ curl -vI https://example.com 2>&1 | grep -Ei 'HTTP/|location|SSL certificate'  #
 
 Propagation is governed by **TTL, not a fixed 48 hours** (RFC 2181). To make a change land fast, lower the record's TTL (e.g. to 300s) *before* you change it, so resolvers re-query sooner. NS/registrar delegation changes can still lag because of registry/TLD TTLs.
 
-Verification checklist before you call it done:
-
-- [ ] `dig +short` returns the intended IP/host from a public resolver (`@1.1.1.1`).
-- [ ] Apex resolves via A/AAAA or ALIAS, **never** a CNAME.
-- [ ] `dig CAA` lists the CA that issued (or is empty — open policy).
-- [ ] `openssl s_client` shows the right subject, a complete chain, and `notAfter` comfortably ahead.
-- [ ] `curl -vI` returns 2xx/3xx with no cert warning; www and apex land on the one canonical host.
+`scripts/verify.sh <domain>` runs the whole done-check read-only: apex-CNAME check, CAA sanity, chain completeness + expiry, HTTPS reachability, www↔apex canonical. The full dig/openssl/curl playbook and an error → cause → fix table are in `references/verify-and-debug.md`.
 
 ## Nameserver cutover (no downtime)
 
@@ -135,12 +129,3 @@ Order matters; each step has a reason.
 | Splitting one zone across two providers | Resolvers answer from whichever NS won; records vanish intermittently | One authoritative provider per zone |
 | TTL left at 86400 during migration | Old answer cached for a day after you flip | Drop to 300s a day ahead |
 | Testing certs against ACME production | Burns the 50-cert/7-day limit; week-long lockout | Use the staging endpoint first |
-
-## References & siblings
-
-- `references/record-cookbook.md` — every record type with edge cases (TXT chunking, MX priority, SPF lookup limit, SRV, DNSSEC).
-- `references/tls-and-acme.md` — certbot/acme.sh, HTTP-01 vs DNS-01, wildcards, platform cert quirks, 2026 lifetimes + ARI.
-- `references/verify-and-debug.md` — full dig/openssl/curl playbook and error → cause → fix.
-- `scripts/verify.sh <domain>` — read-only audit: apex-CNAME check, CAA sanity, chain completeness + expiry, HTTPS reachability, www↔apex canonical.
-
-Route out when the ask isn't the records: inbox placement → ../email-deliverability/SKILL.md; what runs behind the name and how it's released → ../deployment/SKILL.md; platform-specific edge/build config → ../cloudflare/SKILL.md or ../vercel/SKILL.md.

--- a/skills/drizzle-orm/SKILL.md
+++ b/skills/drizzle-orm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: drizzle-orm
-description: "Use when modeling data or querying with Drizzle ORM in TypeScript — schema declared in `.ts`, type-safe `select`/`insert`/relational queries, and `drizzle-kit` migrations, or when choosing Drizzle over Prisma for an edge/serverless runtime. Triggers: 'set up Drizzle ORM', 'drizzle-kit generate', 'write a pgTable schema', '$inferSelect type', 'drizzle push vs generate for production', 'my db.query.posts.findMany returns no author relation', 'drizzle-kit conflicting migration', 'switch off Prisma to something lighter for edge', 'definir l esquema amb Drizzle i tipus type-safe', 'migrar de Prisma a Drizzle para algo más ligero', 'migració amb drizzle-kit'. NOT Prisma Client or schema.prisma (that is prisma-orm), NOT a generic zero-downtime migration strategy (that is db-migrations), NOT Postgres engine/indexing/EXPLAIN (that is postgresdb)."
+description: "Use when modeling data or querying with Drizzle ORM in TypeScript — `pgTable` schema in `.ts`, type-safe select/insert/relational queries, `drizzle-kit` migrations. NOT Prisma Client or `schema.prisma` (that is `prisma-orm`), NOT ORM-agnostic migration strategy (that is `db-migrations`), NOT Postgres engine tuning or EXPLAIN (that is `postgresdb`)."
 tags: [drizzle, drizzle-orm, typescript-orm, drizzle-kit, sql, migrations, database, schema]
 recommends: [prisma-orm, postgresdb, db-migrations, neon, sqlite-turso, planetscale, supabase, typescript, sql]
 origin: risco
@@ -229,6 +229,3 @@ It checks a `drizzle()` call exists, the table helper matches the configured `di
 carries `dialect`/`schema`/`out`, that any `db.query` usage has `{ schema }`/`{ relations }` passed
 to `drizzle()`, and bans Prisma-isms (`schema.prisma`, `PrismaClient`, `prisma generate`) that mean
 the wrong ORM leaked in.
-
-For the full driver matrix and the v1↔v2 relations migration, see
-`references/relations-and-drivers.md`.

--- a/skills/duckdb/SKILL.md
+++ b/skills/duckdb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duckdb
-description: "Use when you need fast analytical SQL over local files (Parquet/CSV/JSON/Arrow) with no server to run, when embedding OLAP in an app or notebook, when a pandas groupby/merge on multi-GB data is too slow, or when reading data straight from S3/HTTP/a lakehouse. Triggers: 'query a folder of parquet files in place', 'aggregate a 5GB CSV on my laptop', 'replace this slow pandas groupby', 'run SQL over a dataframe in Jupyter', 'read these parquet files from S3 without downloading', 'out-of-core aggregate', 'analizar un CSV enorme sin montar un servidor', 'consultar parquet en local sense base de dades'. NOT a multi-user production analytics server (that is clickhouse-analytics), NOT your app's transactional CRUD database (that is postgresdb)."
+description: "Use when analytical SQL must run in-process with no server: Parquet/CSV/JSON/Arrow queried in place, OLAP embedded in an app or notebook, a slow pandas groupby on multi-GB data, or S3/lakehouse data read without downloading. NOT a multi-user analytics server (that is clickhouse-analytics), NOT an app's transactional CRUD store (that is postgresdb)."
 tags: [duckdb, olap, analytics, parquet, embedded-database, sql, columnar]
 recommends: [clickhouse-analytics, postgresdb, sql, sqlite-turso, data-cleaning, business-intelligence]
 origin: risco
@@ -34,8 +34,7 @@ for greenfield exploration.
 The two you will confuse most: DuckDB vs ClickHouse is **embedded-single-node vs server-distributed** —
 under ~10GB on one box DuckDB usually wins; pick ClickHouse when many people query concurrently. DuckDB vs
 SQLite is **same niche, opposite workload** — both embedded single-file, but SQLite is row-store OLTP and
-DuckDB is column-store OLAP. Don't run your app's writes through DuckDB. (Some recommended siblings above
-may not be built in this collection yet; the routing decision still holds.)
+DuckDB is column-store OLAP. Don't run your app's writes through DuckDB.
 
 ## Install & version
 
@@ -175,22 +174,17 @@ escape hatch, not the default.
 
 ## Anti-patterns
 
-| Rationalization | Reality → STOP |
+| Anti-pattern | Do instead |
 | --- | --- |
-| "Load the file into pandas, then query it" | You just paged the whole file through RAM. `FROM 'file.parquet' SELECT ...` scans only needed columns. |
-| "DuckDB can be our app's database" | One writer, single process — concurrent CRUD writers corrupt the workflow. App OLTP is `postgresdb`. |
-| "Spin up DuckDB behind our dashboard API for 200 users" | It's embedded, not a server; concurrent users serialize on the writer. That's `clickhouse-analytics`. |
-| "Just use the latest version in prod" | Pin the **LTS** (1.4.x; v1.4.4 shipped 2026-01-26) so a future upgrade doesn't break the on-disk format / extension ABI. |
-| "Download the S3 files, then read them" | `INSTALL httpfs` + `CREATE SECRET` reads `s3://...` in place with row-group pushdown. No download. |
-| "`SELECT *` over this 200-column Parquet" | Columnar engine — list the columns you need so it skips the rest. `SELECT *` reads everything. |
-| "GROUP BY a, b, c (restate every column)" | Drift bait. `GROUP BY ALL` tracks the SELECT automatically. |
-| "It's embedded so I don't need to think about RAM" | Set `memory_limit` / `threads`; without a cap a runaway aggregate can thrash before it spills. |
-| "Use DuckDB as our embeddings/vector store" | VSS exists but vector search is `vector-db`'s workflow, not DuckDB's home turf. |
-
-## References
-
-- [references/python-and-interop.md](references/python-and-interop.md) — full Python client: connect/cursor, `?`/`$name` parameters, relational operators, register/unregister frames, pandas/Polars/Arrow/NumPy round-trips, transactions, threading caveat.
-- [references/remote-and-lakehouse.md](references/remote-and-lakehouse.md) — httpfs, `CREATE SECRET` for S3/GCS/Azure, hive globs, Iceberg/Delta/DuckLake reads, partitioned writes, MotherDuck `ATTACH 'md:'`.
+| Loading a file into pandas, then querying the frame | Pages the whole file through RAM. `FROM 'file.parquet' SELECT ...` scans only needed columns. |
+| Making DuckDB the app's database | One writer, single process — concurrent CRUD writers corrupt the workflow. App OLTP is `postgresdb`. |
+| Serving a dashboard API for 200 users from DuckDB | It's embedded, not a server; concurrent users serialize on the writer. That's `clickhouse-analytics`. |
+| Running the latest version in prod | Pin the **LTS** (1.4.x; v1.4.4 shipped 2026-01-26) so a future upgrade doesn't break the on-disk format / extension ABI. |
+| Downloading the S3 files, then reading them | `INSTALL httpfs` + `CREATE SECRET` reads `s3://...` in place with row-group pushdown. No download. |
+| `SELECT *` over a 200-column Parquet | Columnar engine — list the columns you need so it skips the rest. `SELECT *` reads everything. |
+| `GROUP BY a, b, c` — restating every column | Drift bait. `GROUP BY ALL` tracks the SELECT automatically. |
+| Treating "embedded" as "no need to think about RAM" | Set `memory_limit` / `threads`; without a cap a runaway aggregate can thrash before it spills. |
+| Using DuckDB as the embeddings/vector store | VSS exists but vector search is `vector-db`'s workflow, not DuckDB's home turf. |
 
 ## Verify
 

--- a/skills/dynamodb/SKILL.md
+++ b/skills/dynamodb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dynamodb
-description: "Use when designing or operating an Amazon DynamoDB table - modeling entities and relationships without joins, choosing partition/sort keys, deciding single-table vs table-per-entity, adding a GSI/LSI, picking on-demand vs provisioned capacity, or diagnosing throttling. Triggers: 'design a DynamoDB table', 'model one-to-many / many-to-many without joins', 'single-table design worth it?', 'query the same data by two different keys' (inverted GSI), 'writes throttled even though I'm under my provisioned capacity' (hot partition), 'on-demand or provisioned?', 'why does my Query only return some rows?' (1 MB page), 'diseña la tabla DynamoDB para estos patrones de acceso', 'modela aquesta relació amb clau composta a DynamoDB'. NOT relational schema / SQL / EXPLAIN / B-tree indexing (that is postgresdb), and NOT document modeling with aggregation pipelines (that is mongodb)."
+description: "Use when modeling or operating a DynamoDB table: deriving partition/sort keys from access patterns, single-table vs table-per-entity, adding a GSI/LSI, on-demand vs provisioned capacity, or diagnosing hot-partition throttling. NOT relational schema/SQL/EXPLAIN (that is `postgresdb`), NOT aggregation-pipeline document modeling (that is `mongodb`)."
 tags: [dynamodb, nosql, single-table-design, aws, data-modeling]
 recommends: [postgresdb, mongodb, redis, vector-db, aws-essentials, deployment, secure-coding]
 origin: risco
@@ -29,24 +29,16 @@ You **refuse** to: click through the AWS console, wire the IaC/CI provisioning p
 `../deployment/SKILL.md`), or model the data as normalized tables you then "join" in application code.
 You emit DDL, IaC snippets, and example SDK calls — you do not provision the infrastructure.
 
-## The non-negotiable order
-
-Do these in sequence. Reordering them is the single most common DynamoDB mistake.
-
-1. **Access patterns first.** You cannot query what your keys do not express, and there is no `WHERE`
-   over arbitrary columns. List the patterns before you name a single attribute.
-2. **Keys second.** Co-locate items that are read together so one `Query` returns them.
-3. **Indexes last.** A GSI is a cost and a consistency compromise; reach for it only when the base
-   table cannot answer a pattern.
-4. **Capacity last.** Capacity mode is a billing decision, not a modeling one — it changes nothing about
-   the keys. Pick it after the model is stable.
-
-Why the order matters: changing a table's key schema after launch means a full migration (new table +
-backfill + dual-write). Get the keys wrong and you pay for it forever.
+The steps below run in sequence — access patterns, then keys, then indexes, then capacity. Reordering
+them is the single most common DynamoDB mistake.
 
 ## Step 1 — Enumerate access patterns
 
-Produce this table before touching keys. It is also exactly what `scripts/verify.sh` checks.
+You cannot query what your keys do not express, and there is no `WHERE` over arbitrary columns, so
+produce this table before you name a single attribute. It is also exactly what `scripts/verify.sh`
+checks: run `scripts/verify.sh <path-to-key-design.{md,json}>` and every row must carry a key target
+(`pk`/`sk` or a named `gsi`) and a `query_type`. It FAILS on any pattern served by `Scan`, WARNS on
+`FilterExpression`, and asserts ≤20 GSIs / ≤5 LSIs. Read-only; exits 0 on an empty or clean target.
 
 | pattern | entity | key condition | read/write | est. freq | served by |
 |---|---|---|---|---|---|
@@ -65,8 +57,12 @@ modeling smell — redesign the key, do not patch it with a filter.
 
 ## Step 2 — Key design + single-table decision
 
+Get this wrong and you pay for it forever: changing a table's key schema after launch means a full
+migration (new table + backfill + dual-write).
+
 **Composite-key encoding.** Use prefixed, sortable strings so one partition holds an entity and its
-children, and so a sort-key range query slices them:
+children — items read together are co-located, so one `Query` returns them — and so a sort-key range
+query slices them:
 
 ```text
 PK = USER#123
@@ -84,8 +80,10 @@ One `Query` with `PK = USER#123 AND SK begins_with("ORDER#")` returns all of tha
 already sorted. That is a **one-to-many** relationship with no join.
 
 **Many-to-many** uses an adjacency list: store the edge twice (or use an inverted GSI, see Step 3) so
-you can traverse it from either side. Full worked example in
-[references/access-patterns.md](references/access-patterns.md).
+you can traverse it from either side. Worked end-to-end in
+[references/access-patterns.md](references/access-patterns.md) — a multi-tenant SaaS / e-commerce model
+(pattern table → PK/SK map → GSI map → AWS SDK v3 `@aws-sdk/lib-dynamodb` calls), adjacency-list
+many-to-many, time-series and leaderboard patterns.
 
 **Single-table vs table-per-entity** — decide honestly, do not cargo-cult:
 
@@ -130,7 +128,8 @@ under one partition key). GSI-only tables have no such cap — a real reason to 
 
 ## Step 4 — Capacity & cost
 
-Pick the mode after the model is stable. Decision table:
+Capacity mode is a billing decision, not a modeling one — it changes nothing about the keys, so pick it
+after the model is stable. Decision table:
 
 | traffic shape | recommendation | why |
 |---|---|---|
@@ -156,7 +155,8 @@ PK = METRIC#daily_total
 PK = METRIC#daily_total#<0..9>
 ```
 
-Capacity math, full pricing detail, and the sharding recipe live in
+Capacity math, full pricing detail (including the Nov-2024 cut), warm throughput, the full quota table,
+and hot-partition diagnosis + the sharding recipe live in
 [references/capacity-and-limits.md](references/capacity-and-limits.md).
 
 ## Step 5 — Operational guardrails
@@ -195,23 +195,10 @@ aws dynamodb query --table-name App \
 | Storing > 400 KB inline (images, docs, logs) | Hits the 400 KB item cap; bloats every read | Put the blob in S3, store the pointer in the item |
 | Picking capacity mode before the model is done | Mode is billing, not modeling — premature and often wrong | Stabilize keys/GSIs first, then choose on-demand vs provisioned |
 
-## References & siblings
+## Route elsewhere when the engine is different
 
-- [references/access-patterns.md](references/access-patterns.md) — full multi-tenant SaaS / e-commerce
-  model end-to-end: pattern table → PK/SK map → GSI map → example AWS SDK v3 (`@aws-sdk/lib-dynamodb`)
-  calls; adjacency-list many-to-many; time-series and leaderboard patterns.
-- [references/capacity-and-limits.md](references/capacity-and-limits.md) — capacity-mode detail, current
-  pricing + the Nov-2024 cut, warm throughput, the full quota table, hot-partition diagnosis + sharding.
-
-Route elsewhere when the engine is different: relational schema / SQL / EXPLAIN / indexing →
-`../postgresdb/SKILL.md`; MySQL-engine schema → `mysql`; document modeling + aggregation pipeline →
-`mongodb`; cache / queue / rate-limiter → `redis`; vector store / semantic search → `vector-db`; AWS
-account / IAM / VPC setup → `aws-essentials`; provisioning the table in CI/CD → `../deployment/SKILL.md`;
-API-layer auth/secrets in front of the table → `../secure-coding/SKILL.md`.
-
-## verify.sh
-
-`scripts/verify.sh <path-to-key-design.{md,json}>` checks the access-pattern artifact: every row has a
-key target (`pk`/`sk` or a named `gsi`) and a `query_type`; it FAILS on any pattern served by `Scan`,
-WARNS on `FilterExpression`, and asserts ≤20 GSIs / ≤5 LSIs. Read-only; exits 0 on an empty or clean
-target.
+Relational schema / SQL / EXPLAIN / indexing → `../postgresdb/SKILL.md`; MySQL-engine schema → `mysql`;
+document modeling + aggregation pipeline → `mongodb`; cache / queue / rate-limiter → `redis`; vector
+store / semantic search → `vector-db`; AWS account / IAM / VPC setup → `aws-essentials`; provisioning the
+table in CI/CD → `../deployment/SKILL.md`; API-layer auth/secrets in front of the table →
+`../secure-coding/SKILL.md`.

--- a/skills/e-signature/SKILL.md
+++ b/skills/e-signature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: e-signature
-description: "Use when adding legally-valid electronic-signature flows to documents — sending a PDF or template for signature, embedding signing in your own app, tracking status, verifying signing webhooks, and retrieving the signed PDF plus its audit trail via DocuSign or Dropbox Sign. Triggers: 'send this contract for signature', 'create a DocuSign envelope', 'signature_request/send', 'embed signing in our app', 'notify us when it's signed', 'set up DocuSign JWT auth', 'is a typed-name signature legally binding?', 'do we need QES for EU customers?', 'enviar a firmar', 'firma electrònica amb validesa legal'. NOT drafting the contract text itself (that is contracts) and NOT OCR/parsing/extracting fields from documents (that is document-processing)."
+description: "Use when wiring an e-signature flow with DocuSign or Dropbox Sign — picking the SES/AES/QES legal tier, sending a PDF or template for signature, embedded signing, verifying signing webhooks, retrieving the signed PDF plus audit trail. NOT drafting contract text (that is `contracts`), NOT extracting fields from PDFs (that is `document-processing`)."
 tags: [e-signature, docusign, dropbox-sign, esignature-api, webhooks, eidas, esign-act, audit-trail]
 recommends: [contracts, document-processing, webhooks, api-connector-builder, gdpr-privacy, automation-flows]
 origin: risco
@@ -10,17 +10,13 @@ origin: risco
 
 You are wiring a third-party signing API (DocuSign eSignature or Dropbox Sign, ex-HelloSign) into someone's app or backend. You take a PDF or template, define signers and fields, send it for signature, track status, react to completion via a verified webhook, and retrieve the signed PDF plus its audit trail.
 
-You are NOT writing the contract language — clauses, indemnity, liability go to `../contracts/SKILL.md`. You are NOT doing OCR, field extraction, or PDF splitting with no signing involved — that is `../document-processing/SKILL.md`. You only build the signing flow.
-
-## Three rules
-
-1. **Pick the legal tier deliberately, before you write code.** A typed name (SES) is binding for most B2B in the US and EU, but a high-stakes EU document may need AES or QES. Choosing the tier decides which provider features you enable (ID Verification, SMS/access code, qualified signature). Get this wrong and the signature is hard to defend in court.
-2. **Sandbox / `test_mode` before prod, always.** A live send is billable and emails a real human. DocuSign demo env is `https://demo.docusign.net`; Dropbox Sign uses `test_mode: 1`. Only non-test sends count against quota and reach signers.
-3. **The deliverable is the signed PDF + audit trail, retrieved and stored.** A send is not done when status is `sent` — it is done when the signer completes and you have pulled the signed document AND its evidence (DocuSign Certificate of Completion, Dropbox Sign audit-trail PDF). Fire-and-forget is the most common bug here.
+Contract language — clauses, indemnity, liability — goes to `../contracts/SKILL.md`; OCR, field extraction, or PDF splitting with no signing involved is `../document-processing/SKILL.md`.
 
 ## Decision: which legal tier do you need?
 
-US law (ESIGN Act + UETA) has **no tiers** — e-signatures equal wet ink. The EU (eIDAS, and eIDAS 2.0 / Reg (EU) 2024/1183 in force since May 2024) defines three. Map the document's stakes to a tier, then to a provider feature.
+Pick the tier deliberately, **before you write code**: it decides which provider features you enable (ID Verification, SMS/access code, qualified signature), and getting it wrong leaves a signature that is hard to defend in court.
+
+US law (ESIGN Act + UETA) has **no tiers** — e-signatures equal wet ink. The EU (eIDAS, and eIDAS 2.0 / Reg (EU) 2024/1183 in force since May 2024) defines three. A typed name (SES) is binding for most B2B in the US and EU, but a high-stakes EU document may need AES or QES. Map the document's stakes to a tier, then to a provider feature.
 
 | Tier | What it is | When you need it | Provider feature to enable |
 |------|-----------|------------------|----------------------------|
@@ -46,6 +42,8 @@ Either is fine. Pick one and stay on it so you keep **one** consistent audit tra
 ## Auth & setup
 
 Never commit keys. Read everything from env; the RSA private key lives in a secret store or a file path, never inline in source.
+
+Point at the sandbox before prod, always — a live send is billable and emails a real human. DocuSign demo env is `https://demo.docusign.net`; Dropbox Sign uses `test_mode: 1`. Only non-test sends count against quota and reach signers.
 
 | Env var | Provider | Holds |
 |---------|----------|-------|
@@ -134,6 +132,8 @@ const res = await api.signatureRequestSend({
 - **Embedded** (signer signs inside your own UI): DocuSign requires a `clientUserId` on the recipient, then you request a recipient view URL and iframe/redirect to it. Dropbox Sign uses `signature_request/create_embedded` + the embedded sign URL. Embedded signing is included from the Dropbox Sign Essentials API plan up (it is not a Standard-only feature) — but it still requires a paid API plan, not `test_mode` alone.
 
 ## Webhooks / completion
+
+A send is not done when status is `sent` — it is done when the signer completes and you have pulled the signed document AND its evidence (DocuSign Certificate of Completion, Dropbox Sign audit-trail PDF), retrieved and stored. Fire-and-forget is the most common bug here.
 
 **Verify the signature before you trust anything in the payload.** The body is attacker-controllable until you have verified it.
 

--- a/skills/electron/SKILL.md
+++ b/skills/electron/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: electron
-description: "Use when building, hardening, or shipping a cross-platform desktop app with Electron — wiring the main/renderer/preload process model, exposing OS capabilities to a web UI over typed IPC, locking down an insecure shell, or packaging with code signing and auto-update. Triggers: 'build a desktop app for Mac/Windows/Linux from my web app', 'let my renderer read a file safely', 'audit my Electron security (nodeIntegration, sandbox, CSP)', 'my preload exposes ipcRenderer and the renderer can require(\"fs\")', 'Squirrel.Mac won\\'t auto-update my app', 'migrate off @electron/remote and BrowserView', 'empaquetar mi app de escritorio para Windows y Mac con firma de código y auto-actualización', 'empaquetar app d\\'escriptori amb auto-actualització'. NOT a smaller Rust-backed shell on the OS native webview (that is tauri)."
+description: "Use when building, hardening, or shipping a cross-platform Electron desktop app — main/renderer/preload process model, typed contextBridge IPC, locking down nodeIntegration/contextIsolation/sandbox/CSP, or packaging with signing and auto-update. NOT a Rust-backed shell on the native webview (that is tauri), nor the web UI inside it (that is react)."
 tags: [electron, desktop, ipc, security, packaging, auto-update, code-signing]
 recommends: [tauri, react, nodejs, github-actions, secure-coding]
 origin: risco
@@ -8,13 +8,9 @@ origin: risco
 
 # Electron — desktop shell, typed IPC, hardening, signing
 
-> Build, harden, and ship cross-platform desktop apps. Treat the renderer as hostile
-> territory and the IPC channel as an attack surface — that is the dominant failure mode
-> in real Electron apps, so the whole skill is organized around it.
-
 This skill owns the **desktop shell**: process model, IPC, security, packaging, signing,
-auto-update. It does **not** own the web UI inside the window (`../react/SKILL.md` if it
-existed), the Node backend logic, or the CI runner matrix.
+auto-update. It does **not** own the web UI inside the window (`../react/SKILL.md`), the
+Node backend logic, or the CI runner matrix.
 
 ## The mental model — three processes, one rule
 
@@ -28,7 +24,8 @@ wrong one is the root cause of most security holes.
 | preload  | isolated world, runs before page JS | semi-trusted | window | the **only** bridge: `contextBridge` exposes a tiny API |
 
 **The governing rule: the renderer is untrusted, the main process holds all privilege, and
-the preload is the only sanctioned bridge between them.** Everything below is a corollary.
+the preload is the only sanctioned bridge between them.** Renderer-to-OS escalation is the
+dominant failure mode in real Electron apps, so everything below is a corollary.
 
 ## Start right
 
@@ -55,7 +52,7 @@ src/
   ipc/types.ts  # IPC contract shared by main + preload
 ```
 
-## The security baseline — non-negotiable
+## The security baseline
 
 Modern Electron defaults are already secure (`nodeIntegration:false`,
 `contextIsolation:true`, `sandbox:true` since Electron 20). **Assert them explicitly anyway**
@@ -185,32 +182,23 @@ Authenticode, and `electron-updater` + GitHub Releases wiring: `references/packa
 The CI matrix that *runs* these builds across three OSes is `github-actions`' job; this skill
 defines *what* to build and sign.
 
-## Migration smells — and the fix
-
-| Smell in the code                          | Why it's dangerous                          | Fix                                              |
-|--------------------------------------------|---------------------------------------------|--------------------------------------------------|
-| `nodeIntegration: true`                    | Page JS gets `require('fs')`, full Node     | Set `false`; move the capability behind IPC      |
-| `contextIsolation: false`                  | Page can rewrite the preload's globals      | Set `true` (default)                             |
-| `@electron/remote` import                  | Sync main-object access = renderer→main RCE | Replace with explicit `ipcMain.handle` channels  |
-| `new BrowserView(...)`                     | Deprecated since 30, will be removed        | `new WebContentsView(...)`                        |
-| `exposeInMainWorld('api', ipcRenderer)`    | Universal IPC weapon (empty object now)     | One function per channel                          |
-
-## Anti-patterns
+## Anti-patterns and migration smells
 
 | Anti-pattern                                          | Why it's wrong                                              | Do instead                                            |
 |-------------------------------------------------------|------------------------------------------------------------|-------------------------------------------------------|
-| `nodeIntegration: true`                               | Any XSS in the renderer becomes OS-level RCE               | `false` + IPC for every privileged op                 |
-| `contextIsolation: false`                             | Renderer can tamper with preload internals                 | `true` (the default)                                  |
+| `nodeIntegration: true`                               | Page JS gets `require('fs')`; any XSS becomes OS-level RCE | `false`; move the capability behind IPC               |
+| `contextIsolation: false`                             | Page can rewrite the preload's globals                     | `true` (the default)                                  |
 | `sandbox: false` without a reason                     | Drops the OS sandbox around the renderer                   | `true`; only relax for a measured, isolated need      |
-| Exposing `ipcRenderer`/its methods over the bridge    | Page can call any channel with any payload                 | One typed function per channel                        |
+| `exposeInMainWorld('api', ipcRenderer)` or its methods | Universal IPC weapon — any channel, any payload (and an empty object now) | One typed function per channel        |
 | No arg validation in `ipcMain.handle`                 | Renderer is an untrusted client; you trust its input       | Type-check + bound every arg before acting            |
 | `webSecurity: false` to "fix CORS"                    | Disables same-origin policy app-wide                       | Keep `true`; proxy/handle CORS in main                |
 | CSP only in a `<meta>` tag                            | Doesn't cover the initial document; bypassable             | Set CSP in `onHeadersReceived`                         |
 | Loading a remote URL into a Node-enabled window       | Remote site runs with your app's privilege                 | Bundle UI locally; sandbox + nav lockdown for remote  |
+| `@electron/remote` import                             | Sync main-object access = renderer→main RCE                | Replace with explicit `ipcMain.handle` channels       |
+| `new BrowserView(...)`                                | Deprecated since Electron 30, will be removed              | `new WebContentsView(...)`                            |
 | Auto-update with an unsigned/un-notarized build       | Squirrel.Mac silently refuses; no updates ship             | Sign + notarize (mac), Authenticode (win) first       |
 | Shipping on an EOL Electron major                     | Unpatched Chromium CVEs in your users' hands               | Stay within the latest 3 majors                       |
 | Heavy CPU work in the main process                    | Blocks the event loop → the whole UI freezes               | `utilityProcess`/worker, or do it in the renderer     |
-| Keeping `@electron/remote`                             | A known renderer→main escalation path                      | Migrate to explicit IPC                               |
 
 ## Verify
 

--- a/skills/elixir/SKILL.md
+++ b/skills/elixir/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elixir
-description: "Use when writing or refactoring Elixir/OTP code — GenServers, supervision trees, processes, pattern matching, mix projects and releases — or when BEAM behaviour misbehaves (restart loops, mailbox growth, timeouts). Triggers: 'write a GenServer', 'design a supervision tree', 'restart strategy one_for_one', 'let it crash instead of try/rescue', 'mix release for production', non-obvious 'my process mailbox keeps growing', 'GenServer call timeout / restart loop', Catalan 'arbre de supervisio en Elixir / processos que peten', Spanish 'arbol de supervision / procesos en Elixir / que es let it crash'. NOT building a Phoenix web app, LiveView, Ecto schemas, controllers or channels (that is phoenix)."
+description: "Use when writing or refactoring Elixir/OTP on the BEAM — GenServers, supervision trees and restart strategies, pattern matching, mix projects and releases — or when processes misbehave (restart loops, mailbox growth, call timeouts). NOT a Phoenix web app, LiveView, Ecto or channels (that is `phoenix`)."
 tags: [elixir, otp, genserver, supervision, beam, mix, concurrency, functional]
 recommends: [phoenix, postgresdb, docker]
 origin: risco
@@ -14,7 +14,7 @@ Default to **pure functions**. Most of your code is data transformation and need
 
 ## Decision: do you even need a process?
 
-A process is not "an object". Spawning one to hold a value you could pass as an argument is the most common beginner mistake — it adds a serialization bottleneck and a failure mode for nothing.
+A process is not "an object": spawning one to hold a value you could pass as an argument is the most common beginner mistake, and it adds a serialization bottleneck and a failure mode for nothing.
 
 | Situation | Use | Why |
 |---|---|---|
@@ -27,8 +27,6 @@ A process is not "an object". Spawning one to hold a value you could pass as an 
 Rule: if two pieces of code never run at the same time and share no mutable state, they are functions, not processes.
 
 ## The functional core
-
-Each rule below earns its place; the why is one line.
 
 **Match in function heads, not with `if`** — branches become exhaustive and self-documenting, and a non-match crashes loudly instead of silently falling through.
 
@@ -80,12 +78,10 @@ end
 
 ## Processes and message passing
 
-Raw `spawn`/`send`/`receive` exists, but in production you almost always want an OTP behaviour (GenServer/Task/Agent) so you get `child_spec`, supervision, and shutdown handling for free.
+Raw `spawn`/`send`/`receive` exists and is fine for a throwaway fire-and-forget where supervision genuinely does not matter, but in production you almost always want an OTP behaviour (GenServer/Task/Agent) so you get `child_spec`, supervision, and shutdown handling for free.
 
 - **Link** (`spawn_link`) couples lifetimes: if one dies abnormally, the other gets an exit signal. This is how supervision works.
 - **Monitor** (`Process.monitor/1`) is one-directional and non-fatal: you get a `{:DOWN, ...}` message but you do not die. Use it when you care *that* something died but should survive it.
-
-Drop to raw processes only for a throwaway fire-and-forget where supervision genuinely does not matter; otherwise reach for OTP.
 
 ## GenServer
 
@@ -124,11 +120,9 @@ defmodule Counter do
 end
 ```
 
-Rules, each with its why:
-
 - **Never block in `init/1`.** `start_link` blocks until `init` returns, so a slow `init` stalls the whole supervision tree boot. Return `{:ok, state, {:continue, term}}` and do the work in `handle_continue/2`.
 - **`use GenServer` auto-defines `child_spec/1`** — you rarely write one by hand; override only to change `:restart` or `:shutdown`.
-- **`call` is synchronous (with a 5s default timeout), `cast` is fire-and-forget.** Use `call` when the caller needs the result or backpressure; `cast` when it does not. A flood of `cast`s with no backpressure is the classic mailbox-growth bug — see references/otp-patterns.md.
+- **`call` is synchronous (with a 5s default timeout), `cast` is fire-and-forget.** Use `call` when the caller needs the result or backpressure; `cast` when it does not. A flood of `cast`s with no backpressure is the classic mailbox-growth bug — timeouts and backpressure recipes in `references/otp-patterns.md`.
 - **Name via `Registry`, not a global atom**, when you have many dynamic instances — atoms are never garbage-collected (see anti-patterns).
 
 ## Supervision trees
@@ -164,7 +158,7 @@ end
 
 **Let it crash**: do not wrap business logic in `try/rescue` to keep a process alive. Validate inputs at the boundary, then trust the happy path; if an invariant breaks, crashing and restarting from a known-good `init` state is the recovery mechanism. Reserve `rescue` for boundaries where you must convert an exception into a tagged tuple for a caller.
 
-For runtime-spawned children (a worker per connection/job) use `DynamicSupervisor` + `Registry` for lookup. Full recipe in references/otp-patterns.md.
+For runtime-spawned children (a worker per connection/job) use `DynamicSupervisor` + `Registry` for lookup. Full recipe — plus `Task`, `Agent`, `:ets` and how to choose an OTP behaviour — in `references/otp-patterns.md`.
 
 ## mix project
 
@@ -189,7 +183,7 @@ MIX_ENV=prod mix release
 _build/prod/rel/my_app/bin/my_app start
 ```
 
-Deps anatomy, environments, env vars, and the umbrella decision live in references/mix-and-releases.md.
+`mix.exs` anatomy, deps, environments, env vars, releases and the umbrella decision live in `references/mix-and-releases.md`.
 
 ## Types and modern stdlib
 
@@ -213,5 +207,3 @@ Deps anatomy, environments, env vars, and the umbrella decision live in referenc
 ## Verify
 
 Run `scripts/verify.sh` from your mix project root (the directory containing `mix.exs`). It checks `mix format --check-formatted` and `mix compile --warnings-as-errors`, and skips cleanly with exit 0 when Elixir/mix is not installed so it never blocks a toolchain-free CI.
-
-See references/otp-patterns.md (DynamicSupervisor+Registry, Task, Agent, ETS, timeouts/backpressure, choosing an OTP behaviour) and references/mix-and-releases.md (mix.exs anatomy, config vs runtime, releases, umbrellas).

--- a/skills/email-deliverability/SKILL.md
+++ b/skills/email-deliverability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: email-deliverability
-description: "Use when mail you send lands in spam, gets rejected, or fails the Gmail/Yahoo bulk-sender checks, and you must fix authentication and reputation rather than the sending code — setting SPF/DKIM/DMARC DNS records so they align, raising a cold domain through warmup, keeping the spam-complaint rate under threshold, adding one-click unsubscribe, getting the brand logo and verified checkmark to show via BIMI, and reading why 'soft' rejections and Postmaster Tools say you are throttled. Triggers: 'our emails go to spam since the Gmail update', 'DMARC fails even though SPF passes', 'how do I warm up a new sending domain', 'do I need one-click unsubscribe to send to gmail', '550 5.7.26 unauthenticated', 'how do I get our logo and the blue checkmark to show in Gmail with BIMI', 'los correos caen en spam y el SPF está bien', 'configurar BIMI i el logo verificat al correu'. NOT putting transactional/bulk email on the wire through a provider API (that is email-connector)."
+description: "Use when mail already sent lands in spam, is rejected, or fails the Gmail/Yahoo bulk-sender checks and the fix is authentication and reputation, not the sending code: SPF/DKIM/DMARC alignment, domain warmup, spam-complaint rate, one-click unsubscribe, BIMI. NOT putting mail on the wire through a provider API (that is `email-connector`)."
 tags: [email, deliverability, spf, dkim, dmarc, bimi, sender-reputation, bulk-sender]
 recommends: [email-connector, newsletter, cold-outreach, gdpr-privacy, data-policy]
 origin: risco
@@ -9,34 +9,26 @@ origin: risco
 # email-deliverability — make mail authenticate and land in the inbox
 
 This skill owns one layer: **why mail you already send gets filtered, deferred,
-or rejected, and the DNS + reputation work that fixes it.** It does not put mail
-on the wire — that is `email-connector`. It starts where the send technically
-succeeds but the message never reaches the inbox.
+or rejected, and the DNS + reputation work that fixes it.** It starts where the
+send technically succeeds but the message never reaches the inbox.
 
 The lever is almost never the sending code. It is three DNS records that must
 *align*, a complaint rate you must hold down, and a reputation you build slowly
 and lose fast. Treat this as ops on a domain, not a code change.
 
-## When to use / When NOT to use
-
-**Use when:** mail lands in spam or Promotions and you suspect auth/reputation,
-not copy; a receiver returns `550 5.7.26` (unauthenticated), `421`/`451`
-deferrals, or `dmarc=fail`; you must meet the Gmail/Yahoo bulk-sender rules
-before a launch; you are standing up a brand-new sending domain and need a
-warmup plan; Google Postmaster Tools shows a rising spam rate or "Bad" domain
-reputation; you want the brand logo and a verified checkmark to show in Gmail
-(BIMI + VMC/CMC).
-
-**Do NOT use for:**
+## Not this skill
 
 - **Sending the mail at all** — provider SDK, `sendEmail()` seam, templates,
-  retries, batch caps, bounce/complaint webhooks → `email-connector`. That skill
-  feeds the suppression list; this one explains the reputation it protects.
+  retries, batch caps, bounce/complaint webhooks → `../email-connector/SKILL.md`.
+  That skill feeds the suppression list; this one explains the reputation it
+  protects.
 - **Subject lines, open/click optimization, list growth** → `newsletter`.
 - **Outbound prospecting sequences, lead lists** → `cold-outreach` (deliverability
   is a *constraint* on it, not the same job).
 - **Consent, lawful basis, retention of the address list** → `gdpr-privacy` and
   `data-policy`. Unsubscribe *mechanics* live here; consent *law* does not.
+- **Handling the DKIM private key and provider API secrets** →
+  `../secure-coding/SKILL.md`.
 
 ## The three records that must align
 
@@ -154,15 +146,3 @@ low-complaint sending.
 | Faking transactional headers to dodge Promotions | Violates bulk rules; risks rejection, not just foldering | Accept Promotions placement; earn Primary via engagement |
 | Routing the unsubscribe to a form that takes a week | Breaks the 2-day one-click honor rule; raises complaints | Honor `List-Unsubscribe-Post` one-click within 2 days, automatically |
 | Adding BIMI to fix spam-foldering | BIMI needs DMARC enforcement you do not have yet, and it changes logo display, not placement | Fix auth + reputation first; add BIMI last as a branding layer |
-
-## See also
-
-- `../email-connector/SKILL.md` — the provider/SDK send path, suppression list,
-  and bounce/complaint webhook that this skill's reputation rules sit on top of.
-- `../secure-coding/SKILL.md` — handling the DKIM private key and provider API
-  secrets without leaking them.
-
-Recommended companions (siblings): `email-connector` for the actual send,
-`newsletter` for the copy/engagement side that drives complaint rate down,
-`cold-outreach` (deliverability gates it), and `gdpr-privacy` / `data-policy`
-for the consent and retention behind a clean list.

--- a/skills/embeddings-search/SKILL.md
+++ b/skills/embeddings-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: embeddings-search
-description: "Use when results from a semantic search feel irrelevant, when you don't know which embedding model or chunk size to use, when you need to add a reranker or hybrid scoring, or when you have no way to tell whether a retrieval change actually helped. Symptoms: search returns garbage, exact-match queries miss, paraphrases work but keywords don't, recall looks fine but the top result is wrong, every chunking idea is a guess. Triggers: 'which embedding model and chunk size should I use', 'my semantic search returns irrelevant results', 'how do I measure if retrieval is good — recall@k, nDCG', 'add a reranker and hybrid BM25+vector', 'exact product codes return nothing but paraphrases work fine', 'recall@k is fine but the top answer is wrong', 'quin model d'embeddings i quina mida de chunk faig servir per a aquests documents', 'la cerca semàntica retorna resultats irrellevants'. NOT operating the vector store (that is vector-db)."
+description: "Use when choosing an embedding model, chunk size, or query form, when semantic search returns irrelevant results, when adding hybrid BM25+vector or a reranker, or when a retrieval change needs a number (recall@k, nDCG, MRR). NOT operating the store — index tuning, quantization (that is `vector-db`) — nor the retrieve-to-answer loop (that is `rag`)."
 tags: [embeddings, semantic-search, chunking, hybrid-search, reranking, rrf, retrieval-eval, mteb, matryoshka]
 recommends: [vector-db, rag, structured-extraction, prompt-engineering, postgresdb]
 origin: risco
@@ -9,10 +9,9 @@ origin: risco
 # embeddings-search — make and judge the vectors
 
 You own the **embedding technique layer**: turn a corpus into searchable vectors, turn a
-question into a good retrieval, and **measure whether that retrieval is any good**. When the
-symptom is "results are irrelevant," "I don't know which model or chunk size," or "how do I
-even tell if search improved," this is the skill. You stop the moment the right chunks come
-back, measured by a number. You do not assemble a prompt or generate an answer.
+question into a good retrieval, and **measure whether that retrieval is any good**. You stop the
+moment the right chunks come back, measured by a number. You do not assemble a prompt or
+generate an answer.
 
 Route the adjacent surfaces away:
 
@@ -41,7 +40,9 @@ cost — where cost is set by **dimensions**, because dims set storage and memor
 
 Quality anchor (mid-2026 MTEB English retrieval): Gemini ~68.3, Cohere `embed-v4` ~65.2,
 OpenAI `3-large` ~64.6, `BGE-M3` ~63.0. MTEB is the standard comparison, not a verdict on
-*your* domain (see `references/models.md` for the over-trust caveat).
+*your* domain — [`references/models.md`](references/models.md) carries the full model matrix
+(dims, max tokens, price, `input_type` convention, Matryoshka support) and how to read MTEB
+without over-trusting it.
 
 Two hard rules — each is a **silent** failure, no error, just worse results:
 
@@ -153,7 +154,9 @@ This is the rigor of the skill. "Search is bad" is not actionable; "recall@10 is
 
 1. **Build a golden query set** — 30–50+ labeled `query → relevant doc ids` pairs drawn from
    real questions. This is the asset; everything else is reproducible from it.
-2. **Pick metrics** (definitions + runnable skeleton in `references/evaluation.md`):
+2. **Pick metrics** — definitions, a runnable Python eval skeleton, golden-set construction and
+   the A/B-one-change methodology are in
+   [`references/evaluation.md`](references/evaluation.md):
    - **recall@k** — of the truly relevant docs, how many landed in the top-k. Catches "the
      right chunk never came back."
    - **nDCG@k** — rewards relevant docs ranked higher. Catches "right docs, wrong order."
@@ -179,15 +182,3 @@ flags hybrid/rerank artifacts that mention no recall/nDCG/MRR for exactly this r
 | Over-large dims "for safety" | Doubles storage/RAM, little recall gain | Right-size; truncate via Matryoshka |
 | Re-embedding the corpus to change dims | Wasteful when the model is Matryoshka-trained | Truncate dims, don't re-embed |
 | Embedding raw HTML/boilerplate | Match signal drowns in markup | Embed clean text; keep the rest as metadata |
-
-## References & siblings
-
-- `references/models.md` — current model matrix (dims, max tokens, price, `input_type`
-  convention, Matryoshka support) and how to read MTEB without over-trusting it.
-- `references/evaluation.md` — golden-set construction, recall@k / nDCG@k / MRR definitions, a
-  runnable Python eval skeleton, and the A/B-one-change methodology.
-
-Siblings: store ops → [`../vector-db/SKILL.md`](../vector-db/SKILL.md) · full answer loop →
-[`../rag/SKILL.md`](../rag/SKILL.md) · typed extraction →
-[`../structured-extraction/SKILL.md`](../structured-extraction/SKILL.md) · prompt design →
-[`../prompt-engineering/SKILL.md`](../prompt-engineering/SKILL.md).

--- a/skills/expo/SKILL.md
+++ b/skills/expo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo
-description: "Use when building, shipping, or hot-patching a React Native app with Expo — EAS Build/Submit/Update, eas.json build profiles, config plugins, prebuild/CNG, the managed workflow, confirming you are on the New Architecture (mandatory since SDK 55). Triggers: 'eas build', 'eas.json', 'config plugin', 'expo prebuild', 'my OTA update isn't showing up on devices', 'runtime version mismatch', 'how do I add a permission without editing Xcode/Gradle', 'newArchEnabled is gone from app.json', 'com publico una actualització OTA sense passar per la store', 'subir la app a la Play Store con EAS'. NOT generic React Native components/navigation/native-module authoring (that is react-native), NOT a Dart mobile app (that is flutter)."
+description: "Use when shipping a React Native app with Expo — EAS Build/Submit/Update, eas.json profiles and channels, config plugins, prebuild/CNG, runtime-version policy, OTA updates that never land, SDK upgrades, the New Architecture. NOT RN UI, navigation or native-module authoring (that is `react-native`), NOT a Dart app (that is `flutter`)."
 tags: [expo, eas, react-native, mobile, ota-updates, app-store]
 recommends: [react-native, github-actions, ship, deployment, secure-coding]
 origin: risco
@@ -13,29 +13,19 @@ origin: risco
 Expo is the toolchain and **EAS cloud platform** layered on React Native: cloud
 builds, store submission, over-the-air JS updates, and **native configuration
 declared in JavaScript** instead of hand-edited Xcode/Gradle projects. This skill
-owns the *shipping pipeline* and *native-config-via-JS*. It does **not** own RN UI,
-navigation, animation, or native-module authoring — that is `react-native`.
+owns the *shipping pipeline* and *native-config-via-JS*.
 
 The verb rule of thumb: if the verb is **build / submit / update / prebuild /
 plugin / EAS / channel / runtime-version**, you are in `expo`. If it is **render /
-navigate / animate / bridge / write a native module**, route to react-native.
-(Current stable as of 2026-06-02: **Expo SDK 55** — React Native 0.83.1, React
+navigate / animate / bridge / write a native module**, route to `react-native`.
+Other exits: web React/hooks/state → `react`, a Dart app → `flutter`, native-only
+Swift/Kotlin → `swift-ios`/`kotlin-android`, a desktop wrapper → `tauri`/`electron`,
+CI unrelated to EAS → `github-actions`.
+
+Current stable as of 2026-06-02: **Expo SDK 55** — React Native 0.83.1, React
 19.2.0, shipped 2026-02-25. **SDK 56 is in beta** (beta opened 2026-05-06, ~2-week
 window; RN 0.85.2, React 19.2.3) — upcoming, not yet shipped stable. Both run
-exclusively on the New Architecture; the Legacy Architecture was removed in SDK 55.)
-
-## When to use / when NOT to use
-
-**Use when:** wiring `eas.json` profiles or channels; cloud-building `.ipa`/`.aab`/
-`.apk` and debugging EAS Build/credentials/queues; shipping EAS Update OTA JS
-(runtime policy, branches, channels, rollouts/rollbacks); submitting with EAS
-Submit; writing/debugging config plugins or `app.config.{js,ts}`/prebuild; building
-a dev client; EAS Workflows YAML; migrating to the New Architecture or upgrading SDK.
-
-**Do NOT use when** the work is pure RN code with no Expo/EAS angle (route to
-react-native), web React/hooks/state (`react`), a Dart app (`flutter`), native-only
-Swift/Kotlin (`swift-ios`/`kotlin-android`), a desktop wrapper (`tauri`/`electron`),
-or generic CI unrelated to EAS (`github-actions`).
+exclusively on the New Architecture; the Legacy Architecture was removed in SDK 55.
 
 ## Decision rules
 
@@ -90,6 +80,9 @@ stamped with a `channel`; a channel maps to a same-named EAS Update branch by de
   }
 }
 ```
+
+Run `scripts/verify.sh` inside an Expo project to gate `eas.json`, the runtime
+policy, committed secrets, and New-Arch readiness.
 
 ## EAS Update mental model
 
@@ -220,34 +213,26 @@ $50/concurrency/month, up to 5 extra. If a user complains about build queue wait
 the fix is usually the plan, not the config. (Pricing per expo.dev/pricing, verified
 2026-06-02; re-check before quoting — Expo adjusts tiers and dollar figures.)
 
-## Anti-patterns → STOP
+## Anti-patterns
 
-| Rationalization | Reality |
+| Anti-pattern | Do instead |
 |---|---|
-| "I'll just edit `ios/Info.plist` directly" | `prebuild --clean` overwrites it; write a config plugin / `withInfoPlist`. |
-| "Hardcode `runtimeVersion: '1.0.0'`, simpler" | it drifts from the binary; updates silently stop matching. Use the `fingerprint` policy. |
-| "I bumped a native dep, the OTA update will deliver it" | EAS Update is JS-only; native changes need a new `eas build`. |
-| "Published the update, devices just need to refresh" | check the channel→branch and exact runtime match first — wrong channel = no delivery. |
-| "Test this custom native module in Expo Go" | Expo Go can't load arbitrary native code; build a dev client. |
-| "Upgrade the SDK, then build straight to production" | run `expo-doctor` + a preview build first; there is no Legacy-Arch fallback to catch a New-Arch-incompatible dep. |
-| "Set `newArchEnabled: false` to dodge the broken native dep" | the flag was removed in SDK 55 and the Legacy Architecture is gone; fix or replace the dep. |
-| "Commit the keystore so CI can sign" | never; let EAS manage credentials or use EAS secrets. |
-| "Put the API key in `app.config` extra" | app config ships in the public bundle; use EAS env vars / a backend. |
-| "Use GitHub Actions to call `eas build`" | EAS Workflows is the native CI; only reach for github-actions if explicitly required. |
+| Editing `ios/Info.plist` directly | `prebuild --clean` overwrites it; write a config plugin / `withInfoPlist`. |
+| Hardcoding `runtimeVersion: '1.0.0'` because it is simpler | it drifts from the binary; updates silently stop matching. Use the `fingerprint` policy. |
+| Expecting an OTA update to deliver a bumped native dep | EAS Update is JS-only; native changes need a new `eas build`. |
+| Telling users to "just refresh" when a published update does not land | check the channel→branch and exact runtime match first — wrong channel = no delivery. |
+| Testing a custom native module in Expo Go | Expo Go can't load arbitrary native code; build a dev client. |
+| Upgrading the SDK and building straight to production | run `expo-doctor` + a preview build first; there is no Legacy-Arch fallback to catch a New-Arch-incompatible dep. |
+| Setting `newArchEnabled: false` to dodge a broken native dep | the flag was removed in SDK 55 and the Legacy Architecture is gone; fix or replace the dep. |
+| Committing the keystore so CI can sign | never; let EAS manage credentials or use EAS secrets. |
+| Putting the API key in `app.config` extra | app config ships in the public bundle; use EAS env vars / a backend. |
+| Reaching for GitHub Actions to call `eas build` | EAS Workflows is the native CI; only reach for github-actions if explicitly required. |
 
 ## Project grounding (02-DOCS + CLAUDE.md)
 
-When this skill runs in a project with a `02-DOCS/` layer (the
-[`harness`](../harness/SKILL.md) wiki), record this app's shipping decisions —
-managed-vs-bare, the runtime-version policy, channel/branch map, and the SDK/New-Arch
-status — in `02-DOCS/wiki/stack/expo.md` and link it from the root `CLAUDE.md`
-`## Knowledge map`. Read it first on every use; bump its `Updated` date when a
-convention changes. No `02-DOCS/`? Skip silently. Conventions are *recorded, not
-gated* — never block the task on this.
-
-## See also
-
-- `references/eas-update.md` — runtime version policies, channel↔branch ops, rollouts/rollbacks, republish, "update not applying" debug flow.
-- `references/config-plugins.md` — plugin anatomy, mods/dangerous-mods/ordering, common community plugins, prebuild troubleshooting, dynamic `app.config.ts`.
-- `scripts/verify.sh` — run in your Expo project to gate `eas.json`, runtime policy, committed-secret, and New-Arch readiness.
-- Sibling skills: `react-native` (RN UI/navigation/native modules — the other half of every Expo app), `secure-coding` (credential & secret handling), `ship`/`deployment` (release process), `github-actions` (only if you want non-Expo CI).
+In a project with a `02-DOCS/` layer (the [`harness`](../harness/SKILL.md) wiki),
+read `02-DOCS/wiki/stack/expo.md` first and record this app's shipping decisions
+there — managed-vs-bare, runtime-version policy, channel/branch map, SDK/New-Arch
+status — linked from the root `CLAUDE.md` `## Knowledge map`, bumping its `Updated`
+date when a convention changes. No `02-DOCS/`? Skip silently. Conventions are
+*recorded, not gated* — never block the task on this.

--- a/skills/fal/SKILL.md
+++ b/skills/fal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fal
-description: "Use when calling a fal.ai model endpoint by id to generate an image, audio, or video from JS/Python/curl, wiring the queue (subscribe vs submit), receiving results by webhook and verifying the ED25519 signature, estimating per-call cost, or migrating off the deprecated @fal-ai/serverless-client. Use when a fal request is stuck IN_QUEUE, a webhook never arrives or its signature won't verify, or a long video gen drops mid-call. Triggers: 'generate an image with fal-ai/flux/dev', 'subscribe vs submit on fal', 'my fal webhook signature won't verify', 'fal request stuck IN_QUEUE', 'how much will 500 Seedream images cost on fal', 'migrate off @fal-ai/serverless-client', 'genera esta imagen con fal y guarda la URL', 'munta el webhook de fal i verifica la firma'. NOT picking the model or art direction (that is ai-media)."
+description: "Use when calling a fal.ai endpoint by id to generate image, audio, or video from JS/Python/curl: subscribe vs submit, queue states, ED25519 webhook signature verification, per-call cost, or migrating off @fal-ai/serverless-client. NOT which model or art direction (that is ai-media); NOT the same models on another platform (that is replicate)."
 tags: [fal, fal-ai, inference, image-generation, video-generation, queue, webhooks, serverless]
 recommends: [ai-media, replicate, replicate-images, modal, webhooks]
 origin: risco
@@ -10,16 +10,7 @@ origin: risco
 
 The wire to fal.ai's fast, pre-warmed media endpoints: call a model by id, control the queue, get the file back. fal is the **fast-media path** — latency-optimized image (FLUX, Seedream, SD), audio (TTS, music), and video (Veo, Wan, Kling, Hailuo) endpoints you invoke by id with `FAL_KEY`.
 
-You own the *mechanics*: auth, call mode, queue states, webhook signatures, file I/O, per-call cost. You do not decide *what* to generate or which model is artistically right — that is the strategy layer above you.
-
-## When to use
-
-- Generating media by calling a fal endpoint (`fal-ai/flux/dev`, `fal-ai/veo3`, `fal-ai/wan-2.5`) from JS, Python, or curl.
-- Choosing the call mode: `subscribe` (block + auto-poll) vs `submit` (instant `request_id`) + queue polling or webhook.
-- Receiving a result by webhook and verifying its ED25519 signature; handling retries and idempotency.
-- Uploading local inputs (image-to-image, image-to-video, ref audio) and reading output URLs.
-- Estimating and capping cost: per-image / per-second / per-megapixel / GPU-hour, plus the 50%-off batch path.
-- Migrating off the deprecated `@fal-ai/serverless-client`.
+You own the *mechanics*: auth, call mode, queue states, webhook signatures, file I/O, per-call cost.
 
 ## When NOT to use
 
@@ -203,8 +194,3 @@ The full model-family map and per-modality knob list live in [`references/models
 | Ignoring the model's pricing unit | "$0.05" is per-second, not per-video — surprise bill | Read the pricing tab; pick the right knob |
 | Tight `while` loop on `queue.status` | Hammers the API, gains nothing | Back off, or use a webhook |
 | `@fal-ai/serverless-client` | Deprecated; missing fixes and APIs | `@fal-ai/client` (v1.10.1) |
-
-## References
-
-- [`references/queue-and-webhooks.md`](references/queue-and-webhooks.md) — full async lifecycle, complete ED25519 verification (Node + Python), JWKS caching, IP allowlist, idempotent handler, retry/timeout handling.
-- [`references/models-and-cost.md`](references/models-and-cost.md) — model-family map, pricing-unit cheatsheet with 2026 examples, batch path, per-modality spend knobs, finding an endpoint id and its schema.

--- a/skills/finance-ops/SKILL.md
+++ b/skills/finance-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finance-ops
-description: "Use when running the money side of a small company on a cash basis — building a rolling cash-flow forecast, reconciling the bank against the books, fixing a messy expense-category map, or driving a month-end close. Triggers: 'are we going to run out of cash', 'what's our runway', '13-week cash flow forecast', 'reconcile the bank statement', 'these two numbers don't match', 'the ending balance doesn't roll into next week', 'everything landed in Other expenses', 'close the books for May', 'what's our burn this month', 'tancar el mes', 'conciliar el banc amb els llibres', 'cuánto runway nos queda al ritmo actual'. NOT recording journal entries or payroll/depreciation postings (that is bookkeeping)."
+description: "Use when running the money side of a small company on a cash basis: a 13-week rolling cash-flow forecast and runway, bank-vs-books reconciliation, mapping spend to tax-return expense categories, or a month-end close. NOT posting journal entries, payroll or depreciation (that is `bookkeeping`); NOT multi-year projections (that is `financial-model`)."
 tags: [cash-flow, reconciliation, month-close, expense-categories, runway, small-business-finance]
 recommends: [bookkeeping, invoicing, financial-model, unit-economics, cost-tracking, forecasting, spreadsheet-ops]
 origin: risco
@@ -10,13 +10,7 @@ origin: risco
 
 You are the controller for a small company run on a **cash basis**. Your job is not to post the ledger and not to send invoices — it is to answer four questions and leave proof: *is the company solvent, are the books trustworthy, did we close the month, and where will the cash run out.*
 
-Every engagement leaves behind one or more of **three checkable artifacts**:
-
-1. A **13-week rolling cash-flow forecast** (CSV/sheet) — the runway answer.
-2. A **reconciliation report** partitioning every bank line into matched / unmatched / needs-review.
-3. A **month-close checklist** with every gate marked done or blocked.
-
-`scripts/verify.sh` checks the *shape and internal consistency* of those artifacts (columns present, ending balance rolls forward, no unclassified bank lines, no silently-missing close gates). It does not judge whether the dollar figures are right — that is your job.
+Every engagement leaves behind at least one checkable artifact — which one depends on the job you pick below. `scripts/verify.sh` checks the *shape and internal consistency* of those artifacts (columns present, ending balance rolls forward, no unclassified bank lines, no silently-missing close gates). It does not judge whether the dollar figures are right — that is your job.
 
 ## Pick the job first
 
@@ -24,10 +18,10 @@ The flow genuinely branches. Decide which of the four you are doing before touch
 
 | If the ask is… | You are doing | Artifact you produce | Reference |
 |---|---|---|---|
-| "will we run out of cash", "what's our runway", "13-week forecast", "burn rate" | **Forecast** | 13-week rolling forecast CSV | `references/cash-flow-forecast.md` |
-| "reconcile the bank", "these don't match", "what cleared" | **Reconcile** | matched/unmatched/needs-review report | `references/reconciliation.md` |
+| "will we run out of cash", "what's our runway", "13-week forecast", "burn rate" | **Forecast** | 13-week rolling forecast CSV/sheet — the runway answer | `references/cash-flow-forecast.md` |
+| "reconcile the bank", "these don't match", "what cleared" | **Reconcile** | report partitioning every bank line into matched / unmatched / needs-review | `references/reconciliation.md` |
 | "set up categories", "everything's in Other", "how do I categorize this" | **Categorize** | tax-return-aligned category map | (inline below) |
-| "close the books for May", "what's left before we close" | **Close** | 5-day gate checklist | `references/month-close.md` |
+| "close the books for May", "what's left before we close" | **Close** | 5-day checklist, every gate done or blocked | `references/month-close.md` |
 
 If the ask is actually about posting entries, sending invoices, or a multi-year model, stop and route — see **Hand-offs** at the bottom. Do not silently do another skill's job.
 
@@ -104,8 +98,6 @@ A line that is silently dropped is a hole in the books. `verify.sh` fails if any
   - Business standard mileage: **70¢/mile for 2025** (IRS Notice 2025-5), rising to **72.5¢/mile for 2026**. Re-confirm the year before applying.
   - Business meals deductible at **50%** (book them at a rate that preserves the 50% haircut, e.g. category L24b).
   - **1099-NEC required for any contractor paid ≥ $600/yr** — flag contractors crossing that line during categorization so nothing is missed at filing.
-
-Categories are the one job here with no separate reference file — the rule (mirror the return, no junk drawer, confirm current-year numbers) is the whole skill.
 
 ## Month-close
 

--- a/skills/financial-model/SKILL.md
+++ b/skills/financial-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: financial-model
-description: "Use when a founder needs the multi-period, driver-based projection that raises a round and steers the company — build 3-year projections, model revenue + costs + headcount + runway, size the raise, or stress-test scenarios. Triggers: 'build a financial model for our seed', 'model our revenue costs and runway', 'when do we run out of cash', 'how much should we raise to get 24 months', 'what runway does $2M buy us', 'model the hiring plan's effect on burn', 'add a downside scenario if we miss plan by 30%', 'modelo financiero a 3 años', 'cuánto runway nos da la ronda', 'model financer i projeccions', 'quant de pista de despegament'. The engine is assumptions → revenue/cost/headcount builds → cash/burn/runway/scenarios, 18–36 months forward, every output a formula. NOT the next-13-weeks liquidity reconciled to the actual bank balance (that is finance-ops), NOT the isolated LTV/CAC math (that is unit-economics, which this model consumes as drivers), NOT the slide story (that is pitch-deck)."
+description: "Use when a founder needs the driver-based 18–36 month projection: revenue, cost and headcount builds resolving to net burn, runway, cash-out date, scenarios and the raise size. NOT the 13-week bank-reconciled cash view (that is `finance-ops`), NOT single-series forecasting (that is `forecasting`), NOT running the round (that is `fundraising`)."
 tags: [financial-model, projections, runway, burn-rate, fundraising, fp-and-a, forecast]
 recommends: [finance-ops, unit-economics, pricing, forecasting, pitch-deck, investor-materials, fundraising]
 origin: risco
@@ -8,7 +8,7 @@ origin: risco
 
 # Financial model — the projection engine that raises and steers
 
-You are a startup FP&A analyst building the **projection engine**: an assumptions layer that feeds a monthly revenue build, a cost build (COGS + OpEx by function + a headcount plan), and a cash projection that resolves to **net burn, runway, and the cash-out date** — plus a scenario switch (base / downside / upside). It is forward-looking and assumption-driven, 18–36 months out. It is not the controller's short-horizon liquidity tool, not the deck narrative, not the LTV/CAC deep dive. It produces the numbers the fundraising siblings present.
+You are a startup FP&A analyst building the **projection engine**: an assumptions layer that feeds a monthly revenue build, a cost build (COGS + OpEx by function + a headcount plan), and a cash projection that resolves to **net burn, runway, and the cash-out date** — plus a scenario switch (base / downside / upside). It is forward-looking and assumption-driven, 18–36 months out. It produces the numbers the fundraising siblings present.
 
 The test of a model is not "does it look right" but **"does it re-flow when I change three input cells."** A spreadsheet of typed-in numbers is a picture, not a model.
 
@@ -20,18 +20,21 @@ Three connected artifacts, every output traced to an input:
 2. **A monthly projection grid** (CSV/spreadsheet, 18–36 columns) — month index, revenue, COGS, gross margin, OpEx by function, headcount, net burn, starting/ending cash, runway-months. This is what `scripts/verify.sh` checks for shape and internal consistency.
 3. **A scenario + runway summary** — one screen: ending-cash trajectory and runway under base/downside/upside, the raise number, and the burn-multiple / Rule-of-40 cross-check.
 
-## What it does NOT do — route out first
+## Route out first
 
-This skill answers **"how much / what runway / does the plan tie out."** The moment the real ask is something else, stop and route:
+This skill answers **"how much / what runway / does the plan tie out."** The moment the real ask is something else, stop and route — at the intake gate or mid-build:
 
-- Next-13-weeks liquidity reconciled to the **actual bank balance**, this-month burn, are-we-solvent-now → `finance-ops`.
-- Recording actual ledger entries, journals, double-entry, payroll postings → `bookkeeping`.
-- The isolated **LTV / CAC / payback / contribution-margin** math → `unit-economics` (the model imports these as drivers, it does not derive them).
-- Setting the **price / packaging / tier / margin floor** itself → `pricing` (the model takes price as input).
-- Statistical / time-series **forecasting** of a single series (churn, demand, ARR) from history → `forecasting`.
-- The slide **story** and decision-grade headline numbers → `pitch-deck`. Packaging the model into the data room / sending it → `investor-materials`.
-- Round **strategy**, investor pipeline, SAFE-vs-priced, term-sheet mechanics → `fundraising`.
-- Per-unit COGS / infra / AI spend as actuals → `cost-tracking`.
+| The real ask | Route to |
+| --- | --- |
+| Next-13-weeks liquidity reconciled to the **actual bank balance**, this-month burn, are-we-solvent-now | `finance-ops` |
+| Recording actual ledger entries, journals, double-entry, payroll postings | `bookkeeping` |
+| The isolated **LTV / CAC / payback / contribution-margin** math — the model imports these as drivers, it does not derive them | `unit-economics` |
+| Setting the **price / packaging / tier / margin floor** itself — the model takes price as input | `pricing` |
+| Statistical / time-series **forecast** of a single series (churn, demand, ARR) from history | `forecasting` |
+| The slide **story** and decision-grade headline numbers | `pitch-deck` |
+| Packaging the model into the data room / sending it | `investor-materials` |
+| Round **strategy**, investor pipeline, SAFE-vs-priced, term-sheet mechanics | `fundraising` |
+| Per-unit COGS / infra / AI spend as actuals | `cost-tracking` |
 
 ## The intake gate
 
@@ -43,12 +46,6 @@ Pin four inputs before you build a single cell. Without them the model is fictio
 | **Current cash** | the numerator of runway; the model is meaningless without it |
 | **Current revenue / MRR + recent growth** | the base the revenue build grows from, not a fresh hockey stick |
 | **Target raise & horizon** (or "size it for me") | the model either takes the raise as input or solves for it from a runway target |
-
-STOP-and-route at the gate:
-
-- If the ask is "what does next quarter's cash look like against the bank" → that is the 13-week tool, route to `finance-ops`.
-- If the ask is "what's our LTV and CAC" with no projection attached → route to `unit-economics`; come back when you need them as drivers.
-- If the ask is "what should we charge" → route to `pricing`; the model takes the price it sets.
 
 ## Rule 1 — three layers, no hardcoded outputs
 
@@ -131,7 +128,7 @@ Most companies miss Rule of 40 — McKinsey's run of 200+ software firms (2011�
 
 ## Anti-patterns
 
-| Bad | Good | Why |
+| Anti-pattern | Do instead | Why |
 | --- | --- | --- |
 | Hockey-stick revenue, one line, no downside | base / downside / upside off toggled drivers | investors stress-test the downside first; no downside reads as naive |
 | Runway computed from net income / P&L | runway from cash balance ÷ net cash burn | depreciation, prepaids, AR make profit ≠ cash; cash is the survival line |
@@ -152,19 +149,4 @@ The model emits a checkable artifact, so `scripts/verify.sh` runs against your g
 ./scripts/verify.sh --strict             # treat warnings as failures (CI gate)
 ```
 
-It checks: required columns present (month, revenue, cogs, gross_margin, opex, net_burn, ending_cash, runway_months); **cash continuity** (ending_cash[m] == starting_cash[m+1]); **gross_margin == (revenue − COGS)/revenue** recomputes; **net_burn == gross_burn − revenue** ties; runway_months ties to cash ÷ net_burn; ≥1 scenario present; and a defect lint for placeholders (`TBD`, `XX`, `#REF`, `[assumption]`) and impossible values (gross margin >100%/<−100%, negative headcount). It exits 0 on a clean or empty target — a missing file is a skip, never a false failure. The schema it enforces is documented in `references/model-structure.md`.
-
-## Hand-offs
-
-- Need the LTV/CAC/payback that feed the drivers → `unit-economics`.
-- Price/packaging the model assumes → `pricing`.
-- Single-series statistical forecast of churn/ARR → `forecasting`.
-- The near-term bank-reconciled cash view → `finance-ops`.
-- Turn the numbers into the slide story → `pitch-deck`; into the data room → `investor-materials`.
-- Run the actual round off the raise number → `fundraising`.
-
-## references/
-
-- `references/revenue-build.md` — bottom-up funnel template, the MRR new/expansion/contraction/churn waterfall, the top-down TAM cross-check, and a worked monthly build.
-- `references/benchmarks-and-scenarios.md` — the 2025/26 benchmark sanity-table, the base/downside/upside driver-toggle recipe, and a worked runway-under-scenarios example.
-- `references/model-structure.md` — the assumptions/projection row+column contract `verify.sh` enforces, the cash-continuity rule, and the `model.csv` schema with a filled mini-example.
+It checks: required columns present (month, revenue, cogs, gross_margin, opex, net_burn, ending_cash, runway_months); **cash continuity** (ending_cash[m] == starting_cash[m+1]); **gross_margin == (revenue − COGS)/revenue** recomputes; **net_burn == gross_burn − revenue** ties; runway_months ties to cash ÷ net_burn; ≥1 scenario present; and a defect lint for placeholders (`TBD`, `XX`, `#REF`, `[assumption]`) and impossible values (gross margin >100%/<−100%, negative headcount). It exits 0 on a clean or empty target — a missing file is a skip, never a false failure. The row+column contract it enforces, the cash-continuity rule, and the `model.csv` schema with a filled mini-example are in `references/model-structure.md`.

--- a/skills/finetuning/SKILL.md
+++ b/skills/finetuning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finetuning
-description: "Use when adapting an open-weight model to a target FORM or BEHAVIOR — tone, output format, domain style, a reasoning/tool-calling pattern — via LoRA/QLoRA or full fine-tuning with TRL SFTTrainer and then preference optimization (DPO/ORPO/KTO/GRPO); when choosing fine-tune vs prompt vs RAG vs longer context; when setting LoRA r/alpha/target_modules; when eval loss climbs while train loss keeps falling; when the adapter seems to have learned nothing; when inference outputs garbage after a run. Triggers: 'fine-tune Llama/Qwen on our data', 'LoRA vs QLoRA vs full fine-tune', 'SFT then DPO/ORPO/KTO/GRPO', 'set target_modules / rank / alpha', 'my fine-tune overfits', 'the model forgot everything after training', 'write a GRPO reward function', 'ajustar un modelo amb LoRA amb les nostres dades'. NOT adding facts or fresh knowledge to a model (that is rag); NOT the fast single-GPU Unsloth backend or GGUF export (that is unsloth); NOT serving the trained model (that is vllm)."
+description: "Use when adapting an open-weight model to a target form or behavior — tone, output format, reasoning pattern — via LoRA/QLoRA or full fine-tuning with TRL SFTTrainer, then preference optimization (DPO/ORPO/KTO/GRPO), and for fine-tune vs prompt vs RAG. NOT adding facts to a model (that is rag); NOT the single-GPU Unsloth backend or GGUF export (that is unsloth)."
 tags: [finetuning, lora, qlora, sft, dpo, grpo, peft, trl, preference-optimization]
 recommends: [training-data, unsloth, open-weights, huggingface, vllm, rag]
 origin: risco
@@ -33,8 +33,10 @@ row below is a real off-ramp.
 
 Route out explicitly. Facts / freshness / citations → `../rag/SKILL.md`. Squeezing a prompt before
 spending money → `prompt-engineering`. Picking *which* base model (size/license/task) → `open-weights`.
-Building the JSONL/preference corpus → `training-data`. A fast single-GPU run + GGUF export →
-`../unsloth/SKILL.md`. Serving the result → `../vllm/SKILL.md`.
+Building the JSONL/preference corpus → `training-data` (LLM corpora, NOT tabular cleaning — that is
+`data-cleaning`). A fast single-GPU run + GGUF export → `../unsloth/SKILL.md` (same LoRA/QLoRA
+concepts, one optimized implementation; this skill stays backend-agnostic). Downloading the base or
+pushing the adapter/merged model → `huggingface`. Serving the result → `../vllm/SKILL.md`.
 
 > The cheapest fine-tune is the one you didn't need. Prompt + RAG solves most "make it behave"
 > asks at zero training cost and updates instantly. Fine-tune when that ceiling is real, measured,
@@ -201,6 +203,8 @@ score). Judge the run on that, plus **eval loss**.
   eval; keep the held-out set quarantined. (Corpus-side hygiene is `training-data`.)
 - General LLM/agent eval harness and judging → `agent-eval`. Bring your task metric here.
 
+The full tuning + forgetting + evaluation playbook is in `references/hyperparameters-and-eval.md`.
+
 ## When NOT to fine-tune (anti-patterns)
 
 | Anti-pattern | Why it breaks | Do instead |
@@ -214,19 +218,6 @@ score). Judge the run on that, plus **eval loss**.
 | A few dozen examples for full FT | Not enough signal; unstable | Curate ~hundreds–thousands (LIMA) or use LoRA |
 | Fine-tune a model you can't legally deploy | License blocks your use case | Check the model card first → `open-weights` |
 
-## Related skills
-
-- **`../rag/SKILL.md`** — the fork of the decision gate: facts/freshness/citations live there;
-  form/behavior lives here. Most "make it behave" asks are RAG or prompting, not training.
-- **`prompt-engineering`** — the cheaper lever to exhaust before spending a GPU.
-- **`training-data`** — builds/validates the JSONL `messages` and preference-pair corpus you feed
-  here (LLM corpora, NOT tabular cleaning — that is `data-cleaning`).
-- **`open-weights`** — chooses *which* base model by task/size/license; you consume that choice.
-- **`../unsloth/SKILL.md`** — a fast single-GPU training backend + GGUF export; same LoRA/QLoRA
-  concepts, one optimized implementation. This skill stays backend-agnostic.
-- **`huggingface`** — download the base, push the adapter/merged model, host inference (NOT training).
-- **`../vllm/SKILL.md`** — serves the trained/merged model (adapter hot-swap, throughput flags).
-
 ## Checklist
 
 - [ ] Ran the decision gate: confirmed this is a form/behavior need, not a facts need (else → rag).
@@ -239,6 +230,3 @@ score). Judge the run on that, plus **eval loss**.
 - [ ] Trained 1–3 epochs; watched **eval** loss (not train) for the overfitting turn.
 - [ ] Preference stage only if needed; correct method for the data (pairs→DPO/ORPO, votes→KTO, verifier→GRPO); tiny LR.
 - [ ] Verified `trl`/`peft`/`transformers` current majors and import paths at author time.
-
-See `references/methods.md` for full SFT→DPO/GRPO/ORPO/KTO scripts, dataset schemas, and adapter
-merging; `references/hyperparameters-and-eval.md` for the tuning + forgetting + evaluation playbook.

--- a/skills/firebase/SKILL.md
+++ b/skills/firebase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firebase
-description: "Use when building on Firebase — modeling Firestore data, writing or auditing Security Rules, wiring Auth, shipping Cloud Functions, storing files in Cloud Storage, or choosing modular Web/Admin SDK imports — and when symptoms appear like 'my database is open to the internet', 'rules reject my query', a counter stuck at 1 write/sec, custom-claim RBAC, or a callable function. Triggers: 'firestore.rules audit', 'denormalize for read paths', 'collection vs subcollection', 'my query works in the emulator but fails in prod with requires-an-index', 'set a custom admin claim', 'regles de seguretat de Firestore', 'mi base de datos está abierta a internet'. NOT managed-Postgres BaaS with SQL and RLS (that is supabase)."
+description: "Use when building on Firebase — Firestore data modeling, Security Rules, Auth and custom claims, Cloud Functions, Storage, modular Web/Admin SDK imports — including symptoms like a database open to the internet, a query rejected by rules, or a doc stuck at ~1 write/sec. NOT managed-Postgres BaaS with SQL and RLS (that is supabase)."
 tags: [firebase, firestore, security-rules, cloud-functions, auth]
 recommends: [secure-coding, gcp-essentials, nextjs]
 origin: risco
@@ -8,43 +8,29 @@ origin: risco
 
 # Firebase — Firestore, Rules, Auth, Functions, Storage
 
-Build correctly on the Firebase product surface that sits on top of GCP: model Firestore data,
-write and test Security Rules, wire Auth, ship Cloud Functions, and store files — all on the
-modular Web SDK (v12) and the Admin SDK. The whole skill exists to stop two failure modes: dragging
-relational/SQL habits into a NoSQL document store, and leaving the database open to the internet.
+The Firebase product surface that sits on top of GCP, on the modular Web SDK (v12) and the Admin SDK.
+The whole skill exists to stop two failure modes: dragging relational/SQL habits into a NoSQL
+document store, and leaving the database open to the internet.
 
-Hold these three facts the entire time:
+Two facts drive everything below:
 
-- **It is a NoSQL document store.** No joins, no server-side `OR` across different fields without a
-  composite index, no `SELECT *` across collections. You shape data for the read path, not for
-  normalization.
+- **It is a NoSQL document store, shaped for the read path.** No joins, no server-side `OR` across
+  different fields without a composite index, no `SELECT *` across collections. Denormalize and
+  fan-out so a screen is one cheap query — reads are what you pay for and what users wait on.
 - **Rules ARE the access control.** Firestore is reachable directly from untrusted clients. There is
   no app server in the trust path by default — `firestore.rules` (CEL) is the only thing between a
   browser and your data. App Check attests the request even came from your app before Rules evaluate.
-- **Shape data for reads.** Denormalize and fan-out so a screen is one cheap query. Reads are the
-  thing you pay for and the thing users wait on.
 
-## When to use / When NOT to use
+Not this skill:
 
-**When to use:**
-
-- Firestore data modeling: collections vs subcollections, denormalization, fan-out, the 1 MiB
-  document limit, hotspot avoidance, query constraints.
-- Writing or auditing Firestore/Storage Security Rules and testing them with the emulator.
-- Firebase Auth: providers, ID-token verification on the server, custom claims, session cookies.
-- Cloud Functions (2nd gen): Firestore/HTTPS/callable/Auth-blocking triggers, secrets, idempotency.
-- Cloud Storage uploads/downloads gated by Rules + signed URLs.
-- Modular SDK imports for tree-shaking, `firebase.json` / `firestore.indexes.json`, Emulator Suite.
-
-**When NOT to use:**
-
-- Relational schema, SQL, EXPLAIN, indexing a SQL engine → `../postgresdb/SKILL.md`.
-- Managed Postgres BaaS (SQL + Postgres RLS + PostgREST) → `supabase`. This is the most-confused
-  sibling: same "backend-as-a-service" shape, but a completely different data model and rules language.
-- AWS document/key-value store with its own capacity model → `dynamodb`.
-- Self-hosted Mongo document modeling → `mongodb`.
-- Generic GCP project/IAM/billing not specific to a Firebase product → `gcp-essentials`.
-- React/Next.js component or rendering work that merely calls Firebase → `react` / `../nextjs/SKILL.md`.
+| Instead of Firebase | Go to |
+|---|---|
+| Relational schema, SQL, EXPLAIN, indexing a SQL engine | `../postgresdb/SKILL.md` |
+| Managed Postgres BaaS (SQL + Postgres RLS + PostgREST) — the most-confused sibling: same "backend-as-a-service" shape, completely different data model and rules language | `supabase` |
+| AWS document/key-value store with its own capacity model | `dynamodb` |
+| Self-hosted Mongo document modeling | `mongodb` |
+| Generic GCP project/IAM/billing not specific to a Firebase product | `gcp-essentials` |
+| React/Next.js component or rendering work that merely calls Firebase | `react` / `../nextjs/SKILL.md` |
 
 ## Data modeling
 

--- a/skills/fly-io/SKILL.md
+++ b/skills/fly-io/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fly-io
-description: "Use when deploying or operating an app on Fly.io — writing fly.toml, running Machines across regions near users, attaching Volumes, managing secrets, or scaling (autostop/autostart, scale count, fly-replay). Triggers: 'fly deploy', 'fly launch', 'desplega a Fly.io a prop dels usuaris', 'users in Sydney see high latency but my app only runs in iad', 'scale my Fly app to zero overnight', 'attach a persistent disk to my Fly machine', 'forward writes to the primary region'. NOT a generic git-push PaaS (that is railway), NOT frontend edge hosting (that is vercel)."
+description: "Use when deploying or operating an app on Fly.io — writing fly.toml, placing Machines in regions near users, attaching Volumes, managing secrets, or picking a scaling lever (autostop/autostart, scale count, fly-replay). NOT choosing which host to deploy on (that is `deployment`), NOT a git-push PaaS with no regions model (that is `railway`)."
 tags: [fly-io, deployment, machines, regions, scaling]
 recommends: [docker, scaling, postgresdb, railway, domains-dns]
 origin: risco
@@ -8,7 +8,7 @@ origin: risco
 
 # Deploy on Fly.io
 
-You are deploying an app to Fly.io: a `fly.toml`, Machines (Firecracker microVMs) placed in regions close to users, optional region-pinned Volumes, secrets, and the right scaling lever. Get the mental model right first, then the config follows.
+You are deploying an app to Fly.io: a `fly.toml`, Machines (Firecracker microVMs) placed in regions close to users, optional region-pinned Volumes, secrets, and the right scaling lever. Get the mental model right first, then the config follows. If none of that placement control matters, ../railway/SKILL.md is the git-push PaaS with no Machines/regions model.
 
 ## Mental model
 
@@ -72,7 +72,7 @@ primary_region = "iad"            # 3-letter region code: iad, ord, ams, syd, gr
   initial_size = "1gb"
 ```
 
-Full field surface (`[[services]]` vs `[http_service]`, health checks, `[[statics]]`, `[[files]]`, all VM sizes, `[restart]`, `[metrics]`) lives in `references/fly-toml.md` — read it when you need a key that is not above.
+Full field surface (`[[services]]` vs `[http_service]`, health checks, `[[statics]]`, `[[files]]`, all VM sizes, `[restart]`, `[metrics]`) lives in `references/fly-toml.md` — read it when you need a key that is not above. Custom domains, certs and registrar-level DNS are ../domains-dns/SKILL.md.
 
 ## Regions: place Machines near users
 
@@ -162,7 +162,7 @@ Treat secret hygiene as non-negotiable — see ../secure-coding/SKILL.md.
 
 Key distinction: **autostop ≠ autoscaler.** Autostop only toggles Machines that already exist; it never changes the count. The metrics autoscaler is what actually adds/removes Machines. Set `auto_stop_machines` and `auto_start_machines` **together** — configuring one without the other is undefined behavior.
 
-`fly-replay` is the multi-region write-forwarding pattern: read-replicas serve local reads, a write replies with `fly-replay: region=<primary>` and the Proxy re-runs the request there. Full header forms and the primary/replica split are in `references/multi-region.md`.
+`fly-replay` is the multi-region write-forwarding pattern: read-replicas serve local reads, a write replies with `fly-replay: region=<primary>` and the Proxy re-runs the request there. Full header forms and the primary/replica split are in `references/multi-region.md`. These are the Fly levers only; platform-agnostic scaling theory (queues, sharding, load shedding) is ../scaling/SKILL.md.
 
 ## Cost & HA
 
@@ -195,12 +195,3 @@ It prefers `fly config validate` when flyctl is on PATH, else does structural ch
 | Treating Fly Postgres as managed | Fly Postgres is unmanaged; you operate it | Route to it here; operate it via ../postgresdb/SKILL.md |
 | `min_machines_running` in a non-primary region | Ignored outside primary | Keep warm capacity via `scale count` there |
 | `fly deploy` with no `release_command` for a schema change | New code hits an old schema mid-rollout | `release_command` runs the migration first |
-
-## Related skills
-
-- ../docker/SKILL.md — the Dockerfile/image build Fly consumes.
-- ../scaling/SKILL.md — generic horizontal-scaling theory (queues, sharding, load shedding).
-- ../postgresdb/SKILL.md — operating the Postgres engine itself; Fly Postgres is unmanaged.
-- ../railway/SKILL.md — git-push PaaS with no Machines/regions model.
-- ../domains-dns/SKILL.md — custom domains, certs, registrar-level DNS.
-- ../secure-coding/SKILL.md — secret handling beyond `fly secrets`.

--- a/skills/fundraising/SKILL.md
+++ b/skills/fundraising/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fundraising
-description: "Use when planning or running an equity fundraising round and you need the STRATEGY and PROCESS, not a single document — sizing the raise to a milestone, choosing post-money SAFE vs priced round, building and tiering the investor target list around intro paths, sequencing outreach to manufacture momentum, managing the diligence pipeline, or reading a term sheet to know what to push on before you sign. Triggers: 'plan our seed raise', 'how much should we raise and on what terms', 'SAFE or priced round, what cap', 'build my investor target list', 'how many investors do I actually need to contact', 'we have meetings but no term sheet — the raise stalled', 'got a term sheet, what do I push back on', 'planifica la ronda seed', 'cuántos inversores tengo que contactar', '¿SAFE o ronda con precio?', 'planifiquem la ronda d'inversió'. NOT the slide-deck narrative (that is pitch-deck) and NOT the cap-table/valuation math (that is financial-model)."
+description: "Use when planning or running an equity round as a process: sizing the raise to a milestone, choosing post-money SAFE vs priced round, tiering investors by intro path, sequencing outreach for momentum, or reading a term sheet before signing. NOT the slide narrative (that is `pitch-deck`), NOT the cap-table or valuation math (that is `financial-model`)."
 tags: [fundraising, seed, safe, term-sheet, investor-pipeline, venture-capital, round-strategy]
 recommends: [pitch-deck, financial-model, investor-materials, cold-outreach, contracts, grants, unit-economics]
 origin: risco
@@ -8,7 +8,7 @@ origin: risco
 
 # Fundraising — The Operating System for an Equity Round
 
-*Own the round as a PROCESS: size it, pick the instrument, build a tiered list around intro paths, run a concentrated sprint, read the term sheet. You do NOT write the deck, build the model, or package the data room — you decide the strategy and drive the sequence.*
+*Own the round as a PROCESS: size it, pick the instrument, build a tiered list around intro paths, run a concentrated sprint, read the term sheet.*
 
 This skill thinks in **funnels** (how many investors at the top to land N term sheets), in **instruments** (post-money SAFE vs priced Series Seed), and in **leverage** (warm intros, parallel meetings, a first term sheet that creates real urgency). It consumes the deck, the model, and the collateral that siblings produce, and orchestrates them into a closed round. Scope: pre-seed through Series A priced rounds and SAFE rounds, founder-side.
 
@@ -119,9 +119,7 @@ Sprint shape
   Close         first term sheet → use it to compress the rest → sign
 ```
 
-**The first term sheet changes everything** — it converts soft interest into urgency across the whole pipeline. Use it. But the honesty rule is absolute:
-
-> **Manufacture FOMO from a visibly busy calendar and a real first term sheet — never from fabricated competing offers or invented deadlines.** Lying about a term sheet you don't have is how a raise dies when one investor calls another; the cost of getting caught is the round.
+**The first term sheet changes everything** — it converts soft interest into urgency across the whole pipeline. Use it. But the honesty rule is absolute, because it is the one mistake with no recovery: **manufacture FOMO from a visibly busy calendar and a real first term sheet — never from fabricated competing offers or invented deadlines.** Lying about a term sheet you don't have is how a raise dies when one investor calls another; the cost of getting caught is the round.
 
 Track **count-in-pipeline and stage conversion, not activity**. Benchmarks to instrument the funnel: outreach→meeting ~15%, first→second ~50%. Pipeline stages: `Sourced → Intro requested → First meeting → Partner/2nd → Diligence → Term sheet → Closed`. Week-by-week playbook and the honest-momentum mechanics → `references/process-playbook.md`.
 
@@ -140,9 +138,9 @@ A founder negotiates the few terms that **compound** — not the headline valuat
 
 Median seed lead ownership runs ~12.6%. **Don't sign the first term sheet without a comparison** — a single offer with no comp gives away your only leverage. And the hard handoff: the term sheet is mostly non-binding, but **the binding SAFE / SPA / side letter is a legal document → `../contracts/SKILL.md` and a real lawyer.** You read the term sheet to negotiate; you do not draft the binding instrument here. Full term-by-term cheat sheet with bands and push-on guidance → `references/process-playbook.md`.
 
-## Anti-patterns / rationalizations → STOP
+## Anti-patterns
 
-| Rationalization | Reality / Fix |
+| Anti-pattern | Do instead |
 | --- | --- |
 | "Raise the max — more runway is always better." | More dilution for proof you don't have. Size to the next milestone (Step 1). |
 | "I'll send a few emails and see who bites." | A serial trickle kills momentum. Concentrate 30–50 meetings in 2 weeks, parallel. |
@@ -153,10 +151,3 @@ Median seed lead ownership runs ~12.6%. **Don't sign the first term sheet withou
 | "Cold outreach is the main channel." | Cold replies ~1–3%; warm converts ~30–50%. Build around intro paths, cold last. |
 | "Tell investors we have a competing term sheet." | If untrue, the raise dies when they call each other. FOMO from real signals only. |
 | "Push the valuation up, that's the win." | The terms that compound are pref, pool, board, dilution — not headline price alone. |
-
-## Handoffs + references
-
-- Story / slides → `../pitch-deck/SKILL.md` · numbers, cap-table, valuation → `../financial-model/SKILL.md` · one-pager, data room, updates → `../investor-materials/SKILL.md`.
-- Cold message copy → `../cold-outreach/SKILL.md` · binding legal doc → `../contracts/SKILL.md` · non-dilutive → `../grants/SKILL.md` · LTV/CAC probe → `../unit-economics/SKILL.md`.
-- `references/funnel-math.md` — work-backward funnel arithmetic, warm-intro priority ladder with per-path conversion bands, A/B/C tiering rubric, pipeline stage schema, worked $3M-seed top-of-funnel.
-- `references/process-playbook.md` — 6–8 week sprint week-by-week, honest momentum/FOMO mechanics, SAFE-vs-priced decision table (cost/speed/dilution), post-money SAFE pile-up worked example, term-sheet-basics cheat sheet with 2025 bands.

--- a/skills/game-design/SKILL.md
+++ b/skills/game-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: game-design
-description: "Use when designing or repairing the design of a game — inventing mechanics and systems, shaping the core loop, layering moment-to-moment / session / meta loops, planning progression, economy, currencies and sinks/faucets, tuning difficulty curves and balance, killing dominant strategies, adding 'juice'/game feel as design intent, prototyping and playtesting, or controlling scope, and especially when the ask is 'why isn't my game fun'. Triggers: 'design the core loop', 'my game isn't fun / doesn't hook', 'balance the economy', 'the difficulty curve feels off', 'players found a dominant strategy', 'how do I scope this', 'reward / progression loop', 'diseñar la mecánica', 'el juego no engancha', 'com equilibro l'economia'. NOT writing engine code, scripts or shaders (route to godot/unity/unreal), NOT narrative, dialogue or story beats (route to game-storytelling), NOT level layout or encounter placement (route to level-design)."
+description: "Use when designing or repairing what makes a game fun — verbs and mechanics, moment-to-moment/session/meta loops, progression, economy faucets and sinks, difficulty curves, dominant strategies, juice, prototyping and scope. NOT engine code (that is `godot`), NOT story (that is `game-storytelling`), NOT level layout (that is `level-design`)."
 tags: [game-design, mechanics, core-loop, balancing, progression, playtesting, scope, fun]
 recommends: [level-design, game-storytelling, godot, unity, unreal]
 profiles: [full]
@@ -9,36 +9,19 @@ origin: risco
 
 # Design games that are fun on purpose
 
-Engine-agnostic game design: mechanics, loops, progression, economy, balance, feel, and the discipline of prototyping and scope. No engine APIs live here — when the design is settled, the implementation belongs to `godot`, `unity`, or `unreal`.
+Engine-agnostic game design: mechanics, loops, progression, economy, balance, feel, and the discipline of prototyping and scope. No engine APIs live here — when the design is settled, the implementation belongs to [`godot`](../godot/SKILL.md), [`unity`](../unity/SKILL.md), or [`unreal`](../unreal/SKILL.md).
 
-## The one rule
+Two premises govern everything below. **Fun is discovered, not designed** — you cannot reason your way to a fun game on paper, you find it by building the smallest playable version and playing it, so every hour spent planning a mechanic you have not prototyped is an hour spent guessing. And **a game is the set of verbs it gives the player plus the loops those verbs live in** — art, story, and levels dress that skeleton; if the skeleton is not fun in greybox, nothing dresses it into fun.
 
-> Fun is discovered, not designed. You cannot reason your way to a fun game on paper; you find it by building the smallest playable version and playing it. Every hour spent planning a mechanic you have not prototyped is an hour spent guessing. Prototype the riskiest assumption first, play it, then decide.
-
-> The design of a game is the set of **verbs** it gives the player plus the **loops** those verbs live in. Everything else — art, story, levels — dresses that skeleton. If the skeleton is not fun in greybox, nothing dresses it into fun.
-
-## When to use / When NOT
-
-**Use when:**
-- Inventing or reworking mechanics and systems, or defining the player's verb set.
-- Shaping the core loop, or layering moment-to-moment → session → meta.
-- Planning progression, unlocks, pacing, or an in-game economy.
-- Tuning a difficulty curve, hunting a dominant strategy, or setting up data-driven balance.
-- Adding "juice" / game feel **as a design concept** (what feedback, why).
-- Prototyping, planning a playtest, deciding what to measure, or cutting scope.
-- The vague-but-critical ask: "why isn't my game fun / why doesn't it hook?"
-
-**Do NOT use — route instead:**
+Route elsewhere when the ask is not design:
 
 | The ask | Route to | Why not here |
 | --- | --- | --- |
-| Write the movement/AI/shader/save code | `godot` / `unity` / `unreal` | This skill decides *what* to build; the engine skill builds it. |
-| Author the story, dialogue, characters, lore | `game-storytelling` | Narrative design is its own craft; this skill owns systems and verbs. |
-| Lay out a level, encounter, or world map | `level-design` | Spatial/encounter design applies the mechanics this skill defines. |
-| Netcode, prediction, lag compensation | `gamedev-multiplayer` | A technical domain, not core design intent. |
-| Ship / store page / build pipeline | `gamedev-shipping` | Release logistics, not design. |
-
-(`godot`, `unity`, `unreal`, `game-storytelling`, `level-design` are linkable siblings; the rest are known ids you name but cannot link yet.)
+| Write the movement/AI/shader/save code | [`godot`](../godot/SKILL.md) / [`unity`](../unity/SKILL.md) / [`unreal`](../unreal/SKILL.md) | This skill decides *what* to build; the engine skill builds it. |
+| Author the story, dialogue, characters, lore | [`game-storytelling`](../game-storytelling/SKILL.md) | Narrative design is its own craft; this skill owns systems and verbs. |
+| Lay out a level, encounter, or world map | [`level-design`](../level-design/SKILL.md) | Spatial/encounter design applies the mechanics this skill defines. |
+| Netcode, prediction, lag compensation | [`gamedev-multiplayer`](../gamedev-multiplayer/SKILL.md) | A technical domain, not core design intent. |
+| Ship / store page / build pipeline | [`gamedev-shipping`](../gamedev-shipping/SKILL.md) | Release logistics, not design. |
 
 ## Loops: moment-to-moment → session → meta
 
@@ -148,13 +131,6 @@ Playtest protocols, metrics/retention definitions, the prototyping ladder, and c
 ## Project grounding
 
 If the workspace has a `02-DOCS/` harness, record the design in `02-DOCS/wiki/design/` — a `game-design.md` one-pager (hook, core loop, verbs, pillars, MVP scope, what's out) plus an `economy.md` if there is a currency system. Write each as an OKF v0.1 wiki article per the harness [`wiki-article-template.md`](../harness/references/wiki-article-template.md): YAML frontmatter with a non-empty `type:` (use `type: design`), a `timestamp` in ISO 8601, and standard markdown links — never wikilinks. Index it in `02-DOCS/wiki/index.md`. This is **recorded, not gated** — skip silently if there is no harness.
-
-## Related skills
-
-- `../level-design/SKILL.md` — applies these mechanics in space: layout, pacing beats, encounter design.
-- `../game-storytelling/SKILL.md` — narrative, dialogue, and how story wraps the systems you define here.
-- `../godot/SKILL.md`, `../unity/SKILL.md`, `../unreal/SKILL.md` — implement the settled design; all engine APIs, feel/juice code, and data-driven tuning loaders live there.
-- Known siblings to name but not yet link: `gamedev-multiplayer`, `gamedev-physics`, `gamedev-pathing`, `gamedev-shaders`, `gamedev-shipping`.
 
 ## Checklist
 


### PR DESCRIPTION
Third integration batch: `domains-dns`, `drizzle-orm`, `duckdb`, `dynamodb`, `e-signature`, `electron`, `elixir`, `email-deliverability`, `embeddings-search`, `expo`, `fal`, `finance-ops`, `financial-model`, `finetuning`, `firebase`, `fly-io`, `fundraising`, `game-design`.

**Catalog description weight 165.2 → 156.8 KB**, mean 656 → 622 chars. **114 of 258 migrated.**

## Two patterns the agents surfaced, now handled uniformly

**Stale "not in this collection" claims.** Five skills so far asserted a sibling did not exist when it does — `duckdb` about five of them, `game-design` about `gamedev-multiplayer`/`gamedev-shipping`, `postgresdb` about the ORM skills. Each is a factual correction, and the route tables now link the siblings that are actually there.

**Two overlapping rule tables.** `electron` carried an "Anti-patterns" table plus a near-duplicate "Migration smells" (4 of 5 rows shared). Merged into one, every distinct row and reason preserved. Later agents now get this instruction up front so the catalog stays consistent on it.

Also of note: `finetuning` overrode my suggested sibling boundaries — I proposed `deep-learning`/`machine-learning`/`prompt-engineering`, the agent used `rag` and `unsloth` on the grounds that none of mine is genuinely confusable with a LoRA/TRL training task. It is right, and that is the discrimination test working as intended.

Gates: `validate` OK, `manifest:check` OK (258 skills), `eval-lint` PASS (0 failures), `npm test` 194 pass.