### PR TITLE
refactor(hiring): migrate to the Claude-5-era authoring rubric

### DIFF
--- a/skills/hiring/SKILL.md
+++ b/skills/hiring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hiring
-description: "Use when there's an open role and you need to write the job post, screen inbound candidates, structure the interview loop, or build a scorecard to reach a fair hire decision; symptoms: gut-feel ratings, every interviewer asking the same question, a bloated requirements list, no consistent screen. Triggers: 'write a job description', 'screen these CVs', 'build an interview scorecard', 'structure the interview panel', 'redacta la oferta de empleo', 'necesito una scorecard', plus the non-obvious 'four people interviewed and we still can't decide' and 'is our AI résumé filter legal'. NOT managing the person after they're hired — onboarding, payroll, performance (that is people-ops)."
+description: "Use when a role is open and you must write the job post, screen inbound candidates, structure the interview loop, or score them to a defensible Hire / On-Hold / No-Hire — including whether an AI résumé filter is legal. NOT after the offer is accepted — onboarding, payroll, performance (that is `people-ops`), NOT offer terms (that is `contracts`)."
 tags: [hiring, recruiting, job-description, interview-scorecard, candidate-screening, structured-interview]
 recommends: [people-ops, brand-voice, contracts, compliance, cold-outreach, calendar-scheduling]
 profiles: []
@@ -17,8 +17,7 @@ No-Hire with the reason written down.
 
 Hard boundary: the moment the offer is accepted, you are done. Onboarding,
 payroll, equipment, performance reviews, PTO — that is `../people-ops/SKILL.md`.
-Hiring gets the right person in the door; people-ops takes it from day one. Do
-not draft offer-letter terms here either; that is `../contracts/SKILL.md`.
+Do not draft offer-letter terms here either; that is `../contracts/SKILL.md`.
 
 ## The funnel (the spine)
 
@@ -35,7 +34,7 @@ One rule per stage, with the why:
   named. Write the 3–6 competencies before the post, because they drive the
   post, the questions, and the scorecard.
 - **Write the post from the competencies.** A post is the competencies turned
-  outward, not a wish list. See "Write the job post".
+  outward, not a wish list.
 - **Screen against one rubric.** Same criteria, same order, every candidate, or
   the comparison is meaningless.
 - **Run a structured loop.** Same questions, same rubric, every candidate —
@@ -44,18 +43,6 @@ One rule per stage, with the why:
   re-analysis ranks them above cognitive-ability tests). Unstructured = lottery.
 - **Score independently, then calibrate.** Each interviewer submits before the
   group talks. Debrief is calibration, not a re-vote.
-
-### Screen decision table
-
-For each candidate at the screen stage:
-
-| Signal | Decision |
-|---|---|
-| Meets the must-haves on job-related evidence | Advance to loop |
-| Strong on most, one must-have unclear | Send a short work-sample / structured task to resolve it |
-| Misses a hard must-have (verified skill, legal eligibility) | Reject, with the job-related reason logged |
-| Borderline, more reqs open soon | Parking lot — note why, revisit, do not silently ghost |
-| Non-job factor (school name, age, gap, "vibe", name) | Ignore it — it is not in the rubric |
 
 ## Write the job post
 
@@ -102,7 +89,8 @@ How to apply: send a short note + anything you've shipped.
 ## Screen the pile
 
 Score every applicant against the **same job-related rubric** you derived from
-the competencies. No bespoke criteria per candidate.
+the competencies (template: `references/templates.md`). No bespoke criteria per
+candidate.
 
 - **Blind to non-job factors.** School prestige, name, age, employment gaps,
   photo — none of it is in the rubric, so it does not enter the decision.
@@ -116,8 +104,15 @@ the competencies. No bespoke criteria per candidate.
   criminal-history box on the application form. (Candidate-data retention and
   consent: `../gdpr-privacy/SKILL.md`.)
 
-Use the screen decision table above for the advance / work-sample / reject /
-parking-lot call.
+For each candidate, the call:
+
+| Signal | Decision |
+|---|---|
+| Meets the must-haves on job-related evidence | Advance to loop |
+| Strong on most, one must-have unclear | Send a short work-sample / structured task to resolve it |
+| Misses a hard must-have (verified skill, legal eligibility) | Reject, with the job-related reason logged |
+| Borderline, more reqs open soon | Parking lot — note why, revisit, do not silently ghost |
+| Non-job factor (school name, age, gap, "vibe", name) | Ignore it — it is not in the rubric |
 
 ## Structure the interview loop
 
@@ -239,10 +234,3 @@ This skill *follows* the rules; it does not run the legal program — that is
 | Screening on school / name / gap | Non-job factor, not in the rubric | Blind to it; rubric only |
 | Deleting interview notes | Breaks EEOC retention; no defense | Retain ≥1 yr (2 yr for fed contractors) |
 | Drifting into onboarding/payroll | Out of scope, wrong skill | Stop at the decision → `../people-ops/SKILL.md` |
-
-## References
-
-- `references/templates.md` — full anchored scorecard (one competency at all
-  five levels), the structured question bank by competency, a fill-in job-post
-  skeleton with the gender-coded word do/don't list, and a screening rubric
-  template.


### PR DESCRIPTION
Context-engineering pass on `hiring` against `scripts/skill-rubric.md`. Format only — no employment-law, validity, or figure changed.

## Numbers

| | before | after |
|---|---|---|
| description | 687 chars | 348 chars |
| SKILL.md | 12588 bytes / 248 lines | 11792 bytes / 236 lines |
| eval-lint | — | **PASS** (should_trigger=6, should_not_trigger=4, capability=1) |

## Description

The `Triggers: '…'` list carried six quoted phrases in two languages plus a `symptoms:` enumeration. That is paid for on every turn the skill is installed, invoked or not, and the model matches by meaning regardless. The replacement is built for discrimination rather than coverage: the four outputs this skill produces, the non-obvious "is our AI résumé filter legal" case, and two boundaries — `people-ops` for anything after the offer is accepted, `contracts` for offer terms. Both siblings exist under `skills/`, and both were already the body's stated hard boundary, so the description now agrees with it.

## What went

- The trailing `## References` index — `references/templates.md` was already linked inline at three points of use.
- `"Hiring gets the right person in the door; people-ops takes it from day one"` — a rhetorical restatement of the sentence directly above it.
- The `See "Write the job post"` pointer to the immediately following heading.

## What moved

- The **screen decision table**, out of a subsection of the funnel spine and into `## Screen the pile`, where the advance / work-sample / reject / parking-lot call actually happens. That retires the `"use the screen decision table above"` bridge sentence too.
- The screening-rubric pointer from the deleted tail index, now inline in the screen step — every file under `references/` stays linked from the body.

## What stayed, deliberately

- **The full 12-row anti-patterns table.** It is already `Anti-pattern | Why it fails | Do instead` with concrete failure modes, not a rationalization bank restating rules from above. The rubric requires one.
- **Every load-bearing claim verbatim:** NYC LL144, the EU AI Act Annex III high-risk classification and its 2 Dec 2027 date, Colorado's 2027 move, EEOC 1-year / 2-year retention, ban-the-box coverage, the Sackett et al. 2022 validity figures, and the 29% / 100%-vs-60% application-rate figures.
- Both worked bad/good pairs (job post, scorecard entry) and the scorecard skeleton — they teach the shape by demonstration.

`manifest.json` untouched; no `npm test` / `npm run validate` run (no `node_modules` in the worktree).
