### PR TITLE
refactor(harness): cut duplicated reference index, restated rules and description bloat

### DIFF
--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness
-description: "Use to control, govern or maintain a workspace's harness — software or non-code (a company, an ops desk, a knowledge vault). The harness is the control plane: the `01-TOOLS/` tooling layer, the `02-DOCS/` chaos→knowledge wiki, and the root Knowledge map. It audits, migrates legacy `XX-*` folders, scaffolds provider tooling, sweeps the inbox, and generates root CLAUDE.md/AGENTS.md. Brownfield-first. NOT the bootstrap front door (that is `init`, which hands off here)."
+description: "Use when governing a workspace's control plane, code or not — the `01-TOOLS/` tooling layer, the `02-DOCS/` chaos→knowledge wiki, the root Knowledge map. Audits it, migrates legacy `XX-*` folders, scaffolds provider tooling, sweeps the inbox, writes root CLAUDE.md/AGENTS.md. NOT the bootstrap front door (that is `init`, which hands off here)."
 tags: [harness, company, ops, docs, wiki, connect, tools, knowledge]
 recommends: [init]
 profiles: [minimal, core, full]
@@ -17,8 +17,9 @@ The **harness** is the control plane of a workspace. A workspace need not be cod
 
   Two on-ramps feed it. **Ingest**: the user drops any file in any format into `inbox/`, and the
   Auto-Ingest Sweep extracts, classifies, cross-links and compiles it — then goes for a walk,
-  discovering un-ingested documents anywhere in the workspace, bounded by `.rscignore` and
-  de-duplicated through the `wiki/.ingested.json` ledger. **Worklog**: every meaningful session of
+  discovering un-ingested documents anywhere in the workspace, bounded by `.rscignore` (baseline:
+  `references/ingest-ignore-defaults.md`) and de-duplicated through the `wiki/.ingested.json`
+  ledger. **Worklog**: every meaningful session of
   work is itself a raw source in `raw/worklog/`, captured on `PreCompact`/`SessionEnd`, at a commit
   milestone, or by the daily curation pass.
 
@@ -34,7 +35,8 @@ The **harness** is the control plane of a workspace. A workspace need not be cod
 
   It compounds on its own: every Ingest, Sweep and Query triggers a Maintenance Pass (lint, score
   recomputation, gap detection, Related sweep), a Micro-Improve runs every N interactions, and Deep
-  Improve runs on request or on the daily schedule. Protocol → `references/wiki-protocol.md`;
+  Improve runs on request or on the daily schedule (`references/daily-curation-automation.md` — on
+  Claude Code, wire it via the `schedule` skill). Protocol → `references/wiki-protocol.md`;
   formats → `references/ingest-formats.md`; capture → `references/wiki-worklog-template.md`;
   vault → `references/obsidian-scaffolding.md`.
 - **The Knowledge map** — the `## Knowledge map` section of the root `CLAUDE.md` that indexes the wiki (including the `harness/` topic) and is read by every other skill before it works in its area.
@@ -77,45 +79,7 @@ for harness-level choices, but defer concrete deploy mechanics to `deployment`, 
 
 The skill proposes, the user confirms, the skill executes. Every destructive operation (deleting a legacy folder, merging into an existing `CLAUDE.md`) requires explicit consent quoted back from the user, not inferred.
 
-## When to use
-
-- A workspace has grown organically and needs the canonical `01-TOOLS` / `02-DOCS` structure.
-- Old numbered folders (`00-TOOLS`, `03-NOTES`, `04-LEGACY`…) exist and need to be consolidated.
-- A new project is being kicked off and needs the harness from day one.
-- Provider integrations exist in code but there's no operational tooling for them.
-
-**Do NOT use when:**
-- The user only wants to add a single tool — they can `cp -r 01-TOOLS/_TEMPLATE 01-TOOLS/<X>` manually.
-- The user wants to refactor runtime code — this skill is operational tooling only, never runtime.
-
-## Architecture
-
-```
-harness/
-├── SKILL.md                          ← this file (the protocol)
-├── references/
-│   ├── providers.yaml                ← detector catalog with full file bodies per provider
-│   ├── claude-md-template.md         ← root CLAUDE.md template
-│   ├── agents-md-template.md         ← root AGENTS.md template
-│   ├── tools-readme-template.md      ← 01-TOOLS/README.md catalog template
-│   ├── audit-report-template.md      ← exact format of the audit report shown to user
-│   ├── wiki-protocol.md              ← embedded wiki protocol + Inbox/Worklog Sweep + Continuous Improvement
-│   ├── ingest-formats.md             ← multiformat Fetch (PDF, image, CSV, JSON, html…)
-│   ├── ingest-ignore-defaults.md     ← what the sweep skips by default (the .rscignore baseline)
-│   ├── inbox-readme-template.md      ← the inbox/README.md drop-zone contract
-│   ├── wiki-raw-template.md          ← format for raw/<topic>/*.md
-│   ├── wiki-worklog-template.md      ← format for raw/worklog/*.md (work-driven capture)
-│   ├── wiki-article-template.md     ← format for wiki/<topic>/*.md (OKF frontmatter + markdown links)
-│   ├── wiki-index-template.md       ← format for wiki/index.md (machine catalog; .base = human nav)
-│   ├── obsidian-scaffolding.md      ← .base views, .gitignore, attachments, .obsidian config
-│   ├── daily-curation-automation.md ← portable scheduled compounding pass (the third trigger)
-│   ├── wiki-archive-template.md     ← format for archived query answers
-│   └── wiki-gaps-template.md        ← format for wiki/gaps.md (Knowledge Gaps log)
-├── assets/
-│   └── _TEMPLATE/                    ← per-tool boilerplate (cp -r seed)
-└── examples/
-    └── audit-example.md              ← walked-through audit on a synthetic project
-```
+**Out of scope:** adding a single tool — the user does `cp -r 01-TOOLS/_TEMPLATE 01-TOOLS/<X>` manually, no need for the full protocol; and refactoring runtime code — this skill is operational tooling only, never runtime.
 
 ## Protocol — five phases
 
@@ -147,7 +111,7 @@ Walk the workspace root and gather:
 
 Render **two artifacts**:
 
-1. **A compact text summary in the conversation** — 1–3 sentences per section, the full destructive-ops list, the consent prompt. This keeps the terminal flow fast.
+1. **A compact text summary in the conversation** — 1–3 sentences per section, the full destructive-ops list, the consent prompt, in the format of `references/audit-report-template.md`. This keeps the terminal flow fast. A full walked-through audit on a synthetic project: `examples/audit-example.md`.
 2. **A full HTML report at `<workspace_root>/02-DOCS/audits/audit-YYYY-MM-DD-HHMM.html`** using `references/audit-report-template.html`. Self-contained (inline CSS, no CDN). Includes color-coded action tables, collapsible legacy-folder sections, highlighted destructive ops, and the consent prompt. **Gitignored** (per-run artifact).
 
 If `02-DOCS/audits/` does not exist, create it (with `.gitkeep`) before writing — even on first run, before Phase 4 builds the rest of `02-DOCS/`. Same for `02-DOCS/` itself: the audits subdirectory is the only piece allowed to materialize during Phase 2; the rest waits until APPLY. Never write the audit HTML at the workspace root.
@@ -183,7 +147,7 @@ Execute in this exact order. Each step writes to disk; abort and report on first
 1. **Root files.**
    - If `CLAUDE.md` does not exist: render `references/claude-md-template.md` with the scan data and write it.
    - If `CLAUDE.md` exists: read it, compute a section-level diff against the template, and apply ONLY additive merges. Never delete user content. Never overwrite a section the user has customized. Append missing sections at the end with an `<!-- added by harness YYYY-MM-DD -->` marker.
-   - Same logic for `AGENTS.md`.
+   - Same logic for `AGENTS.md`, rendered from `references/agents-md-template.md`.
 2. **Create `01-TOOLS/` skeleton.**
    - Create `01-TOOLS/` directory.
    - Copy `assets/_TEMPLATE/` to `01-TOOLS/_TEMPLATE/`. This template is **generic boilerplate with placeholders (`<NOMBRE_TOOL>`, `<TOOL>_API_KEY`)**. The user copies it manually when adding a tool NOT in the catalog. The skill itself does NOT use `_TEMPLATE/` to generate the detected tools — those come from `providers.yaml`.
@@ -197,7 +161,7 @@ Execute in this exact order. Each step writes to disk; abort and report on first
 4. **Migrate legacy `XX-*` folders.**
    - For each TOOLING file: move to its mapped destination in `01-TOOLS/<X>/`. If the destination file already exists from step 3, the legacy file goes to `01-TOOLS/<X>/migrated/<original-name>` so nothing is overwritten. The user resolves manually.
    - For each DOCS file: move to `02-DOCS/raw/migrated/<original-folder>/<path>`.
-   - For each AMBIGUOUS file: leave in place. Record in the verification report.
+   - For each AMBIGUOUS file: leave in place. Record in the verification report. Never force-classify — a file moved to the wrong place is harder to recover than one left where the user put it.
 5. **Verify migration.**
    - Count files moved vs files originally present. They must match (moved + ambiguous-remaining = original).
    - If counts don't match, abort and report. Don't proceed to deletion.
@@ -215,7 +179,14 @@ Execute in this exact order. Each step writes to disk; abort and report on first
      - Each `01-TOOLS/<TOOL>/README.md` and `CREDENTIALS.md`.
      - Every file under `02-DOCS/raw/migrated/` (from legacy `XX-*` migration in step 4).
      - Root `CLAUDE.md` and `AGENTS.md`.
-   - Use the templates in `references/wiki-*.md` verbatim. Do NOT invent a different format.
+   - Use these templates verbatim; `wiki-protocol.md` is the source of truth for `02-DOCS`, so do NOT invent a different structure or format:
+     - `references/wiki-raw-template.md` — `raw/<topic>/*.md`.
+     - `references/wiki-article-template.md` — `wiki/<topic>/*.md` (OKF v0.1 frontmatter + relative markdown links + `## Related`).
+     - `references/wiki-index-template.md` — `wiki/index.md` (machine catalog; the `.base` views are the human navigation).
+     - `references/wiki-gaps-template.md` — `wiki/gaps.md` (Knowledge Gaps log).
+     - `references/wiki-dashboard-template.html` — the live wiki dashboard, regenerated by Maintenance Pass.
+     - `references/wiki-archive-template.html` — archived query answers (point-in-time, never edited).
+     - `references/wiki-deep-improve-report-template.html` — Deep Improve run reports.
 
 ### Phase 5 — VERIFY
 
@@ -303,20 +274,13 @@ Opt out of the size nudge with `.rsc/.no-claudemd-check`.
 
 ## Invariants
 
-These are not style preferences you can weigh against convenience — each one exists because
-breaking it destroys something the user cannot get back. Violating any aborts the run.
+The consent, merge and `.env` rules live with the phases that enforce them above. These four are
+scope rules that no single phase owns, and breaking one destroys something the user cannot get back:
 
-1. **Audit before action.** Nothing is written before the AUDIT is rendered and CONSENT is given.
-2. **Explicit consent only.** Silence, ambiguity, "ok" all mean NO. Only the exact-form strings count as yes.
-3. **No `.env` real, ever.** The skill writes `.env.example` only. Real credentials are the user's responsibility.
-4. **No speculative tools.** A tool is created if and only if the detector found evidence in the user's code. No "we should probably have a Sentry tool too".
-5. **No overwrite without merge.** Existing `CLAUDE.md`, `AGENTS.md`, or tool files are merged additively. The skill never deletes user content.
-6. **Destructive ops require a second consent quoting the path.** "Yes, delete `00-TOOLS`" is different from a generic "yes, proceed".
-7. **Ambiguous files preserve the legacy folder.** Don't force-classify. If you can't classify with confidence, leave it.
-8. **Idempotent.** Running the skill twice produces no extra side effects. Re-scanning a project already canonical detects "nothing to do".
-9. **Out-of-scope dirs are invisible.** `node_modules/`, `.venv/`, `.next/`, `__pycache__/`, `.git/`, `dist/`, `build/`, `.dart_tool/` are never read for detection and never touched.
-10. **`references/wiki-protocol.md` is the source of truth for `02-DOCS`.** Do not invent a different wiki structure.
-11. **Subproject internals are out of scope.** `.env.example`, `requirements.txt`, `package.json`, source files inside subprojects are READ for detection only. They are NEVER moved, renamed, modified, or deleted. The skill operates exclusively on workspace-root artifacts (`CLAUDE.md`, `AGENTS.md`, `01-TOOLS/`, `02-DOCS/`, and `XX-*` legacy folders at the root level).
+1. **No speculative tools.** A tool is created if and only if the detector found evidence in the user's code. No "we should probably have a Sentry tool too".
+2. **Idempotent.** Running the skill twice produces no extra side effects. Re-scanning a project already canonical detects "nothing to do".
+3. **Out-of-scope dirs are invisible.** `node_modules/`, `.venv/`, `.next/`, `__pycache__/`, `.git/`, `dist/`, `build/`, `.dart_tool/` are never read for detection and never touched.
+4. **Subproject internals are out of scope.** `.env.example`, `requirements.txt`, `package.json`, source files inside subprojects are READ for detection only. They are NEVER moved, renamed, modified, or deleted. The skill operates exclusively on workspace-root artifacts (`CLAUDE.md`, `AGENTS.md`, `01-TOOLS/`, `02-DOCS/`, and `XX-*` legacy folders at the root level).
 
 ## Red flags — abort and re-plan
 
@@ -326,30 +290,7 @@ If any of these occur, stop and report:
 - The AUDIT shows zero detected tools AND zero legacy folders AND `CLAUDE.md`/`AGENTS.md` already exist → there's nothing for the skill to do. Tell the user.
 - The user types anything ambiguous after AUDIT → do not infer consent.
 - Migration verification (step 5 of APPLY) shows file count mismatch → abort, don't delete anything.
-- The catalog has no entry for a provider obviously present in code → tell the user, suggest adding a catalog entry, don't fake one.
-
-## References
-
-- `references/providers.yaml` — full provider catalog with detectors and per-file content. Edit this to add a new provider; don't edit `SKILL.md`.
-- `references/claude-md-template.md` — root `CLAUDE.md` template.
-- `references/agents-md-template.md` — root `AGENTS.md` template.
-- `references/tools-readme-template.md` — `01-TOOLS/README.md` catalog template.
-- `references/audit-report-template.md` — text summary format for the in-conversation audit summary.
-- `references/audit-report-template.html` — HTML format for the full per-run audit artifact written to `02-DOCS/audits/`.
-- `references/wiki-protocol.md` — embedded protocol for the `02-DOCS/` chaos→knowledge layer (initialization, **Inbox Sweep**, **Worklog Sweep**, ingest, query, lint, **Continuous Improvement**: Maintenance Pass, Micro-Improve, Deep Improve; Obsidian-native conventions).
-- `references/ingest-formats.md` — multiformat Fetch: how any input (PDF, image, CSV/Excel, JSON/API, html, docx, email, unknown binary) becomes `raw/` markdown with the original preserved in `_originals/`.
-- `references/inbox-readme-template.md` — the `inbox/README.md` drop-zone contract shown to the user.
-- `references/wiki-raw-template.md` — format for `02-DOCS/raw/<topic>/*.md`.
-- `references/wiki-worklog-template.md` — format for `02-DOCS/raw/worklog/*.md` (the work-driven capture; the session as a raw source).
-- `references/wiki-article-template.md` — format for `02-DOCS/wiki/<topic>/*.md` (OKF v0.1 frontmatter + relative markdown links + `## Related`).
-- `references/wiki-index-template.md` — format for `02-DOCS/wiki/index.md` (machine catalog; the `.base` views are the human navigation).
-- `references/obsidian-scaffolding.md` — the vault scaffolding: `.base` views, `.gitignore`, `attachments/`, `.obsidian` config (no vector DB / RAG).
-- `references/daily-curation-automation.md` — portable scheduled compounding pass; on Claude Code wired via the `schedule` skill.
-- `references/wiki-archive-template.html` — HTML format for archived query answers (point-in-time, never edited).
-- `references/wiki-dashboard-template.html` — HTML format for the live wiki dashboard, regenerated by Maintenance Pass.
-- `references/wiki-deep-improve-report-template.html` — HTML format for Deep Improve run reports.
-- `references/wiki-gaps-template.md` — format for `02-DOCS/wiki/gaps.md` (Knowledge Gaps log).
-- `assets/_TEMPLATE/` — the boilerplate copied into every new tool.
+- The catalog has no entry for a provider obviously present in code → tell the user, suggest adding an entry to `references/providers.yaml` (that file, never `SKILL.md`, is where providers are added), don't fake one.
 
 This skill is fully self-contained. No external sub-skill required.
 

--- a/skills/harness/evals/cases.yaml
+++ b/skills/harness/evals/cases.yaml
@@ -28,7 +28,7 @@ should_trigger:
 should_not_trigger:
   - prompt: "I want to add a single Sentry tool folder to 01-TOOLS. Just copy the template and wire it up."
     route_to: "none"
-    why: "SKILL.md 'Do NOT use' is explicit: adding a single tool is a manual `cp -r 01-TOOLS/_TEMPLATE 01-TOOLS/<X>` — the full SCAN/AUDIT/APPLY harness is overkill, no skill needed."
+    why: "SKILL.md 'Out of scope' is explicit: adding a single tool is a manual `cp -r 01-TOOLS/_TEMPLATE 01-TOOLS/<X>` — the full SCAN/AUDIT/APPLY harness is overkill, no skill needed."
 
   - prompt: "Refactor the runtime database layer in my FastAPI service to use async SQLAlchemy sessions."
     route_to: "fastapi"


### PR DESCRIPTION
Context-engineering pass on `harness` against `scripts/skill-rubric.md`. Format only — every claim, path, command and template that was in the skill is still in the skill.

| | Before | After |
|---|---|---|
| `description` | 470 chars | **344 chars** |
| `SKILL.md` | 359 lines / 28,039 B | **301 lines / 23,542 B** |
| eval-lint | — | **PASS** (should_trigger=7, should_not_trigger=6, capability=2) |

## Description

Kept the control-plane definition (the three layers) and the `NOT the bootstrap front door (that is init, which hands off here)` boundary — those are what let a reader pick this skill over its front door. Dropped the parenthetical examples of a non-code workspace and "Brownfield-first": characters paid for on every turn that never changed which skill gets chosen. No `Triggers:` list was present to remove.

## What went

- **The Architecture ASCII tree.** A second full index of `references/`, duplicating the tail References section line for line. Adding a reference meant editing two lists, and the two had already drifted — the tree listed `ingest-ignore-defaults.md`, the index listed `wiki-dashboard-template.html`, neither listed both.
- **The tail References section**, folded into point of use. Every `references/` file is still linked, now from the step that consumes it: `audit-report-template.md` + `examples/audit-example.md` at Phase 2, `agents-md-template.md` at APPLY 1, the seven wiki output templates at APPLY 8, `ingest-ignore-defaults.md` and `daily-curation-automation.md` in the 02-DOCS overview, `providers.yaml` in the red flag about a missing provider entry. Verified programmatically: 0 unlinked files under `references/`.
- **"When to use"** — restated the description, which is already in context on every turn. The two "Do NOT use" boundaries were substantive, so they moved up as an **Out of scope** line under Core principle, verbatim.
- **Invariants 1, 2, 3, 5, 6, 7 and 10.** Each was a word-for-word restatement of a phase step a few lines above (audit-before-action = Phase 2/3, explicit consent = Phase 3, no real `.env` = APPLY 3, merge-not-overwrite = APPLY 1, second destructive consent = APPLY 7, wiki-protocol authority = APPLY 8). A rule in an appendix is skimmed; a rule at the step is followed. The one piece of judgment that lived *only* in the appendix — never force-classify, and why — moved into APPLY 4 where classification happens.

## What stayed, on purpose

- **"Red flags — abort and re-plan".** Concrete failure modes with a named response, not rules already stated above — this is the skill's anti-pattern list, which the rubric requires.
- The five-phase protocol, the accepted consent forms, the `bash -n` syntax gate and the `python3` preflight **in full**, code fences included.
- The four remaining invariants — scope rules no single phase owns.
- "Keep CLAUDE.md lean", the Equip section, the Orientación block.
- **No result-envelope block added.** This skill never had one.

## Verification

- `bash scripts/eval-lint.sh` → `harness  PASS`
- All six `route_to` targets exist under `skills/`: `fastapi`, `init`, `deployment`, `postgresdb`, `nextjs`, plus one `none`. No stale "not in this catalog" claims in this skill's evals.
- `manifest.json` untouched; `npm test` / `npm run validate` not run (no `node_modules` in the worktree).
- One `why` string in `evals/cases.yaml` updated to cite "Out of scope" instead of the section name it replaced.

## For the orchestrator

`skills/harness/SKILL.md` has no `origin: risco` in its frontmatter — rubric deterministic gate 1. Pre-existing, not introduced here, and `skills/suggest/SKILL.md` is the only other skill in the catalog missing it (256/258 have it). The frontmatter schema does not currently declare or require `origin`, so `--validate` does not catch it. Left alone as a two-skill catalog fix rather than patched here.
