### PR TITLE
refactor(tauri): Claude-5-era context pass — description 782→339 chars

### DIFF
--- a/skills/tauri/SKILL.md
+++ b/skills/tauri/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tauri
-description: "Use when building a lightweight cross-platform desktop (or v2 mobile) app with Tauri — a Rust core plus the OS-native WebView — wiring Rust commands and IPC, streaming data to the frontend, locking down the capabilities/permissions security model, or bundling and auto-updating tiny signed binaries. Triggers: 'build a Tauri app', 'expose a Rust command to my frontend', 'invoke from JS', 'tauri.conf.json', 'capabilities and permissions', 'stream download progress to the WebView', 'my command froze the UI', 'shrink my desktop binary vs Electron', 'set up the Tauri updater', 'crear una app d'escriptori lleugera amb Rust en lloc d'Electron', 'reducir el tamaño del binario de escritorio'. NOT a Chromium+Node desktop app that needs Node APIs in a main process (that is electron)."
+description: "Use when building a lightweight cross-platform desktop (or v2 mobile) app with Tauri — a Rust core plus the OS-native WebView: Rust commands and IPC, streaming to the frontend, the default-deny capabilities/permissions ACL, bundling and signed auto-updates. NOT a Chromium+Node shell needing Node APIs in a main process (that is electron)."
 tags: [tauri, desktop, rust, cross-platform, ipc, webview]
 recommends: [rust, electron, react, secure-coding, github-actions]
 origin: risco
@@ -22,7 +22,8 @@ so the same Rust core can ship to mobile.
 
 This skill owns the **shell**: commands, IPC, the security ACL, the bundler, the updater.
 It does **not** own the Rust language itself (that is the `rust` skill), the web UI inside
-the window (the `react`/`nextjs` skills), or a Chromium+Node shell (`../electron/SKILL.md`).
+the window (the `react`/`nextjs` skills), a Chromium+Node shell (`../electron/SKILL.md`), or
+app-code hardening beyond the IPC boundary (`../secure-coding/SKILL.md`).
 
 ## Pick your starting shape
 
@@ -213,12 +214,6 @@ across three OSes is the `github-actions` skill's job; this skill defines what t
 | Copying a v1 `tauri.conf.json > allowlist` | That key does not exist in v2 | Use `capabilities/*.json` (ACL) |
 | Assuming bundled Chromium | It's the **OS** WebView (WebKit/WebView2) | Test rendering on each OS's engine; avoid Chromium-only CSS/JS |
 
-## Pointers
-
-- `references/security.md` — capabilities/permissions/scope JSON, CSP recipes, isolation setup.
-- `references/bundling-distribution.md` — per-OS signing, updater keypair, sidecar, CI matrix.
-- Siblings: `../electron/SKILL.md` (the Chromium+Node alternative when you need a Node main
-  process), `../secure-coding/SKILL.md` (app-code hardening). The `rust` skill owns the
-  language; `react`/`nextjs` own the frontend UI; `github-actions` owns the release CI matrix.
-- `scripts/verify.sh` — advisory static lint over `src-tauri/` (capabilities present, registered
-  commands exist, no v1 `allowlist`, fallible-looking commands return `Result`).
+`scripts/verify.sh` is an advisory static lint over an `src-tauri/` tree that catches several of
+these: capabilities present, registered commands exist, no v1 `allowlist`, fallible-looking
+commands return `Result`.


### PR DESCRIPTION
Context-engineering pass on `skills/tauri/` against `scripts/skill-rubric.md`. No content rewrite: same versions, commands, config keys, and figures.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 782 | **339** (target ≤350, hard limit 1024) |
| SKILL.md bytes | 11,470 | **10,650** |
| SKILL.md lines | 225 | **219** (ceiling 400) |

## What went, and why

- **The `Triggers:` keyword list** — eleven quoted phrases across English, Catalan and Spanish, more than half the description. The description is in context on every turn the skill is installed, invoked or not, so that was a per-turn cost for something the router already does by meaning. The rewritten description keeps what does the discriminating: the Rust-core-plus-OS-WebView value prop, the four surfaces it owns, and the `NOT a Chromium+Node shell needing Node APIs in a main process (that is electron)` boundary.
- **The trailing `## Pointers` index** — both `references/` files were already linked inline where they are used (`security.md` from the security section, `bundling-distribution.md` from the bundle section), and the sibling delegations were already stated in the intro and beside the CI matrix. Its two unique facts were folded inline rather than dropped: `secure-coding` moved into the intro's ownership sentence, and the `verify.sh` summary now sits directly under the anti-patterns table it checks.

## What stayed, and why

- **The anti-patterns table.** The rubric requires one, and these are concrete failure modes (blocking the IPC pool, unscoped `fs` permissions, a v1 `allowlist`, assuming bundled Chromium), not rules restated from above. It was already in `Anti-pattern | Why it's wrong | Do instead` form with no borrowed urgency framing, so no re-columning was needed.
- **The `std::sync::Mutex` → `tokio::sync::Mutex` bad/good pair.** It demonstrates the bad side, which the main worked example cannot show, and carries the "dropping the guard early creates a race" trap.
- **"Pick your starting shape".** A decision table where the flow genuinely branches (greenfield / existing web app / adding mobile / on v1).
- **Every rule bullet.** Each already sits next to the step it governs with a one-line *why*, which is the shape the rubric asks for — none were in an appendix rule bank.

No result-envelope block existed and none was added.

## Verification

- `bash scripts/eval-lint.sh` → `tauri PASS (should_trigger=7, should_not_trigger=5, capability=1)`
- Every `references/` file linked from the body: `security.md` ✓, `bundling-distribution.md` ✓
- Every `../<sibling>/SKILL.md` link resolves: `electron` ✓, `secure-coding` ✓
- Every eval `route_to` names a real skill: `electron`, `expo`, `rust`, `react`, `compose-multiplatform` — all present under `skills/`
- `scripts/verify.sh` is already mode `100755` and exits 0 on an empty target (gate 7)
- `manifest.json` untouched — it is derived and regenerated centrally
