### PR TITLE
refactor(webhooks): Claude-5 rubric pass — description 1022→350, body 246→229 lines

### DIFF
--- a/skills/webhooks/SKILL.md
+++ b/skills/webhooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webhooks
-description: "Use when building the inbound side of a webhook — the HTTP endpoint that receives events a system pushes you, proves they are authentic, refuses to process the same one twice, and acks fast. Covers the mechanics every source shares: raw-body HMAC verification, ~5-min timestamp/replay window, idempotency on a stable event id, fast-ack-then-queue, retry/poison handling. Triggers: 'receive webhooks and process them safely', 'verify an incoming webhook signature', 'my signature verification fails even though the secret is correct', 'provider keeps retrying and we process the same event twice', 'handler times out under load, ack fast and queue', 'recibir webhooks entrantes', 'verificar la firma del webhook entrante', 'evitar procesar el mismo evento dos veces'. NOT the Stripe-Signature scheme (that is stripe), NOT email bounce/suppression hooks (that is email-connector), NOT outbound clients calling a third-party API (that is api-connector-builder), NOT what runs after the event lands (that is automation-flows)."
+description: "Use when building the receiving end of a webhook — a provider-agnostic endpoint that proves pushed events are authentic and never processes one twice: raw-body HMAC, ~5-min replay window, idempotency on the event id, fast-ack-then-queue. NOT the Stripe-Signature scheme (that is stripe), NOT outbound clients you call (that is api-connector-builder)."
 tags: [webhooks, inbound-webhooks, hmac-verification, idempotency, signature-verification, queue, connectors]
 recommends: [stripe, email-connector, api-connector-builder, automation-flows, redis, secure-coding]
 profiles: []
@@ -13,14 +13,9 @@ You are building the side of a webhook that *receives*. Some external system
 pushes an HTTP POST at your endpoint; your job is to prove it is real, refuse to
 act on it twice, and answer fast. That is the whole mandate.
 
-This skill is provider-agnostic. It teaches the mechanics every webhook source
-shares, not any one vendor's event catalog. The deliverable is secret-safe
-server code plus minimal config: a handler that reads the **raw** request body
-for HMAC verification, compares signatures in **constant time**, rejects events
-outside a **timestamp tolerance**, **dedupes** on a stable event id, then
-**persists-or-enqueues before returning `2xx`**.
-
-It ends at "enqueued." What happens to the event afterward is a different job:
+This skill is provider-agnostic — it teaches the mechanics every webhook source
+shares, not any one vendor's event catalog — and it ends at "enqueued." What
+happens to the event afterward is a different job:
 
 - The Stripe-specific scheme (`Stripe-Signature`, `t=,v1=`, `stripe listen`,
   the event model) → `../stripe/SKILL.md`.
@@ -29,8 +24,10 @@ It ends at "enqueued." What happens to the event afterward is a different job:
 - The *outbound* client that calls someone else's API → `api-connector-builder`.
 - Multi-step orchestration after the event lands → `automation-flows`.
 - Broker/queue tuning (BullMQ concurrency, DLQ ops) → `redis`.
+- Constant-time compare, secret handling, supply-chain hygiene →
+  `../secure-coding/SKILL.md`.
 
-## The pipeline — non-negotiable order
+## The pipeline
 
 These five stages run in exactly this order. Each one exists to protect the one
 after it; reorder them and you either trust forged data or waste work.
@@ -43,13 +40,9 @@ after it; reorder them and you either trust forged data or waste work.
 | 4 | **Dedupe** on the event id | At-least-once delivery means duplicates are normal. Mark it seen before doing work, not after. |
 | 5 | **Persist/enqueue → `2xx`** | Hand the event to durable storage, then ack. The ack means "I own this now." |
 
-Two facts make this order non-negotiable:
-
-- **Delivery is at-least-once, never exactly-once.** Every major provider
-  retries on non-2xx or timeout, so duplicate deliveries are normal traffic.
-  Idempotency is required, not a nice-to-have.
-- **The handler must be fast.** Heavy synchronous work inside it causes provider
-  timeouts and a storm of retries. Verify, dedupe, enqueue, ack — then work.
+**Delivery is at-least-once, never exactly-once.** Every major provider retries
+on non-2xx or timeout, so duplicate deliveries are normal traffic and idempotency
+is required, not a nice-to-have.
 
 ## Verify the signature
 
@@ -180,8 +173,10 @@ it?" check and both run. Let the UNIQUE constraint (or `NX`) be the lock.
 
 ## Fast-ack & queue
 
-Return `2xx` as soon as the event is durably stored or enqueued, then do the
-real work in a background worker. The status code is a contract with the sender:
+Heavy synchronous work inside the handler causes provider timeouts and a storm
+of retries. Return `2xx` as soon as the event is durably stored or enqueued,
+then do the real work in a background worker. The status code is a contract with
+the sender:
 
 | You return | Meaning to the provider | Use it when |
 |------------|-------------------------|-------------|
@@ -229,18 +224,6 @@ Capturing the raw body is framework-specific and is the usual culprit behind
 
 `scripts/verify.sh` is a read-only heuristic linter. Run it from the root of the
 project that contains your handler; it scans candidate files and prints
-PASS/WARN/FAIL for each invariant (raw-body verify, constant-time compare,
-timestamp check, secret-from-env, dedupe-on-event-id). It is advisory, not a
-compiler — a WARN means "I could not find evidence," which on a clean/empty tree
-is expected and exits `0`.
-
-## Cross-references
-
-- Stripe's exact scheme and event model → `../stripe/SKILL.md`
-- Email bounce/complaint suppression webhooks → `../email-connector/SKILL.md`
-- The outbound API client (auth, pagination, retries you initiate) →
-  `api-connector-builder`
-- Orchestrating what happens after the event lands → `automation-flows`
-- Queue/broker concurrency and DLQ operations → `redis`
-- Constant-time compare, secret handling, supply-chain hygiene →
-  `../secure-coding/SKILL.md`
+PASS/WARN/FAIL per invariant (raw-body verify, constant-time compare, timestamp
+check, secret-from-env, dedupe-on-event-id). A WARN means "I could not find
+evidence," which on a clean tree is expected and exits `0`.


### PR DESCRIPTION
Context-engineering pass on `skills/webhooks/` against `scripts/skill-rubric.md`. No content rewrite — every technical claim, figure, command and code block is unchanged.

## Numbers

| | Before | After |
|---|---|---|
| `description` | 1022 chars | **350 chars** |
| `SKILL.md` | 13,869 bytes / 246 lines | **12,312 bytes / 229 lines** |
| eval-lint | — | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

## Description

Removed the eight-phrase trilingual `Triggers:` list. It sat at 1022 chars — one char under the schema limit — and is in context on every turn the skill is installed, invoked or not, while the model routes by meaning anyway.

Kept the two boundaries that carry discriminative weight: `stripe` (the provider-specific scheme vs. the generic mechanics) and `api-connector-builder` (inbound receiver vs. the outbound client you write). `email-connector` and `automation-flows` were dropped from the description only — both still appear in the body's delegation list, and both still have `should_not_trigger` cases in `evals/cases.yaml`.

## What went

- **The duplicate cross-reference index.** The intro delegation list and the trailing `## Cross-references` section named the same five siblings twice. Merged into one list at the top; the one row the tail had that the intro did not (`secure-coding`) moved up, so nothing was lost.
- **An intro paragraph** that restated the five-stage pipeline three lines before the pipeline table itself.
- **"The handler must be fast"** as a standalone bullet — folded into the Fast-ack section, which owns the timeout → retry-storm → duplicate-processing chain. It was previously asserted in both places.
- **"non-negotiable"** from the pipeline heading and lead-in. The table's *"Why it precedes the next"* column already gives the reason each stage is ordered; the label added urgency, not information.

## What stayed, on purpose

- **The anti-patterns table** (9 rows). Required by dimension 7, and these are concrete failure modes with a *why it bites* column — not rules already stated above, so the hybrid rationalization-table treatment does not apply here. It was already in `Anti-pattern | Why it bites | Do instead` form.
- **The pipeline ordering table** and the **status-code contract table** — the flow genuinely branches at both.
- **Both bad/good code pairs** (parsed-body vs. raw-buffer HMAC; insert-then-process) — they teach the judgment by demonstration.
- **Every load-bearing fact**: the ~5-min tolerance window, the Standard Webhooks scheme and space-separated rotation signatures, `timingSafeEqual`/`compare_digest`, the dedupe-TTL-outlives-retry-window rule, the framework raw-body recipes.
- **No result-envelope block was added** — this skill never had one.

## Gates

- Both `references/` files (`signature-schemes.md`, `framework-raw-body.md`) are linked inline from the body.
- All `../<sibling>/SKILL.md` links resolve: `stripe`, `email-connector`, `secure-coding`. All six `recommends` ids exist.
- `scripts/verify.sh` was **already** executable (`100755`) and exits `0` on a clean tree — verified, no change needed.
- `manifest.json` untouched. `npm test` / `npm run validate` not run (no `node_modules` in the worktree) — for the global post-merge pass.

## Notes for the orchestrator

- No stale "not in this collection" claims in this skill — all five `route_to` targets in `evals/cases.yaml` (`stripe`, `email-connector`, `api-connector-builder`, `automation-flows`, `redis`) name real skills.
- The two overlapping structures here were cross-reference *lists*, not rule tables; handled by the same merge rule (one list, every distinct row preserved).