### PR TITLE
refactor(notion-connector): Claude-5-era rubric pass — 865→347 char description

### DIFF
--- a/skills/notion-connector/SKILL.md
+++ b/skills/notion-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notion-connector
-description: "Use when wiring an app, cron job, or service to Notion as an ops backend over the official HTTP API — pushing rows into a Notion database, mirroring a database into your app, syncing both ways without duplicates, building or reading page block content, or fixing an integration that broke after the 2025-09-03 data-source split. Triggers: 'store our tasks in a Notion database from code', 'use Notion as a CRM/content calendar', 'sync our CRM into Notion nightly without duplicates', 'why does POST /v1/databases/:id/query return 404 now', 'integration broke after a teammate added a second data source', 'guardar registros en una base de datos de Notion desde código', 'desar files a una base de dades de Notion'. NOT a generic call-any-REST-API integration (that is api-connector-builder), NOT receiving/verifying inbound Notion webhook events (that is webhooks)."
+description: "Use when wiring server code or a cron job to Notion as an ops backend over its HTTP API: pushing or mirroring database rows, two-way sync without duplicates, page blocks, or an integration broken by the 2025-09-03 data-source split. NOT generic REST wiring (that is `api-connector-builder`), NOT inbound Notion webhook events (that is `webhooks`)."
 tags: [notion, ops-backend, api-integration, databases, sync]
 recommends: [api-connector-builder, webhooks, automation-flows, spreadsheet-ops, secure-coding]
 origin: risco
@@ -14,24 +14,7 @@ write page blocks. This skill owns the **outbound** Notion API surface only —
 the database/data-source data model, property-type write shapes, and the
 rate-limit/pagination discipline that the API forces on you.
 
-## The one rule
-
-**Pin the `Notion-Version` per request, and resolve the data source before you
-query.** Post `2025-09-03` a database is a *container* of one or more data
-sources — not a queryable table. Skip either half and you get silent 404s on
-code that worked last year.
-
-- Current major version: **`2025-09-03`** (the SDK default). Latest: **`2026-03-11`**.
-- Behavior differs across versions; an unpinned client drifts when the default moves.
-
-## When to use / when NOT to use
-
-**Use when:** treating a Notion database as a CRM / task tracker / content
-calendar from code; pushing or pulling rows on a schedule; two-way sync that
-must not duplicate on re-run; building or reading page block content; migrating
-a `2022-06-28` integration that broke when someone added a second data source.
-
-**Route elsewhere:**
+## Route elsewhere
 
 | Situation | Route to |
 |---|---|
@@ -50,10 +33,12 @@ a `2022-06-28` integration that broke when someone added a second data source.
 3. **Share the target database/page with the integration** in the Notion UI
    (the page `•••` menu → Connections). *Skip this and every call 404s or
    returns empty* — the integration sees nothing it was not explicitly granted.
-4. **Construct the SDK client with a pinned version.** Official JS SDK is
-   `@notionhq/client` v5.12.0+ (latest 5.22.0, 2026-05-19); its default
-   `notionVersion` is `2025-09-03`, and it supports `2026-03-11` if you opt in.
-   The default and method names below are stable across the whole 5.x line.
+4. **Construct the SDK client with a pinned `Notion-Version`.** Official JS SDK
+   is `@notionhq/client` v5.12.0+ (latest 5.22.0, 2026-05-19); its default
+   `notionVersion` is the current major **`2025-09-03`**, and it supports the
+   latest **`2026-03-11`** if you opt in. The default and method names below are
+   stable across the whole 5.x line. Behavior differs across versions, so pin it
+   per client (or per request) — an unpinned client drifts when the default moves.
 
 ```ts
 import { Client } from "@notionhq/client"; // v5.12.0+ (latest 5.22.0)
@@ -66,9 +51,11 @@ const notion = new Client({
 
 ## The database → data source model (biggest gotcha)
 
-A database now holds a `data_sources` array; each data source has its **own
-schema**. One database can have several. You query and read schema against the
-*data source*, not the database.
+Post `2025-09-03` a database is a **container** of one or more data sources, not
+a queryable table: it holds a `data_sources` array and each data source has its
+**own schema**. Resolve the data source *before* you query — query and read
+schema against it, not against the database, or code that worked last year 404s
+silently.
 
 | You have… | Do this |
 |---|---|


### PR DESCRIPTION
Claude-5-era rubric pass on `notion-connector`. Format/context-engineering only — no recommendation, version, command, endpoint or figure was changed.

| | Before | After |
|---|---|---|
| `description` | 865 chars | **347 chars** |
| body | 10800 bytes / 234 lines | **9797 bytes / 221 lines** |
| `scripts/eval-lint.sh` | — | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

## What went

**The `Triggers:` list.** Seven phrases across English, Spanish and Catalan, in context on every turn this skill is installed whether or not it fires. The model matches by meaning; the list was pure per-turn cost. The two `NOT` boundaries stay and got tighter — `api-connector-builder` (generic REST wiring) and `webhooks` (inbound events), both verified present under `skills/`.

**`## When to use / when NOT to use`.** Its `Use when:` paragraph was the description restated one screen later. Deleted. The routing table beneath it is a real branch, not a restatement, so it survives intact as `## Route elsewhere` — all five rows, all five sibling links.

**`## The one rule` as a standalone block.** It asserted the two things that matter, and then setup step 4 asserted the pinning half again and the data-source section asserted the resolution half again. That is the repeat-across-layers pattern the rubric names. Both halves moved next to the step they govern rather than being deleted:

- the version facts — current major `2025-09-03` is the SDK default, latest is `2026-03-11`, behavior differs across versions so pin per client or per request, an unpinned client drifts when the default moves — now sit in setup step 4, at the line where the client is actually constructed;
- *a database is a container of one or more data sources, not a queryable table; resolve it before you query or last year's code 404s silently* now opens `## The database → data source model`, the section that explains it.

No claim was dropped in the move.

## What stayed, deliberately

- **The 10-row anti-patterns table, including its `Why it bites` column.** Not a rationalization table wearing a different hat: every row names a concrete failure mode and the symptom it produces (404 on the retired `databases/:id/query` path, silently dropped rows past 100, duplicate rows from a blind `pages.create`, `archived` vs `in_trash`). The symptom column is what makes it diagnostic rather than a restatement of the steps.
- **Every decision table.** `database_id` → `data_source_id` resolution, the property write shapes, and the version-migration diffs all branch genuinely.
- **No result-envelope block was added.** This skill never had one; inventing it would be a content change.
- All three `references/` files remain linked inline from the body (`property-shapes.md` ×2, `api-versions.md` ×2, `sync-patterns.md`), so nothing in the package went dead.

`scripts/verify.sh` was already executable and untouched. `manifest.json` deliberately not edited — it is derived and regenerated centrally.
