### PR TITLE
refactor(n8n): trim description to 355 chars, fold checklist and gotchas into one anti-patterns table

### DIFF
--- a/skills/n8n/SKILL.md
+++ b/skills/n8n/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: n8n
-description: "Use when operating a live n8n instance programmatically — driving its public REST API (`{host}/api/v1`, `X-N8N-API-KEY`) or the n8n-mcp server to create, validate, test, activate/deactivate, list, update, or delete workflows and read executions, on self-host or `*.app.n8n.cloud`. Triggers: 'deploy this workflow to my n8n over the API', 'push my workflow JSON to n8n with curl', 'I set active:true in the create call but it stays inactive', 'connect n8n-mcp / n8n_create_workflow to Claude', 'validate and autofix my n8n workflow', 'run an n8n workflow by id from a script', 'delete a workflow via the API', 'automatiza n8n por API', 'desplega el workflow a n8n.cloud'. NOT designing the flow's trigger-step-error logic or hand-building the importable workflow JSON (that is automation-flows), NOT operating Make / Zapier / Power Automate (their own skills), NOT a typed API client with auth+pagination+retry (api-connector-builder), NOT the inbound webhook receiver in your own app (webhooks)."
+description: "Use when operating a live n8n instance programmatically — its REST API (`{host}/api/v1`, `X-N8N-API-KEY`) or the n8n-mcp server — to create, validate, test, activate, update, delete workflows and read executions on self-host or n8n.cloud. NOT designing the flow or its importable JSON (that is `automation-flows`), NOT another platform (`make`, `zapier`)."
 tags: [n8n, automation, workflows, mcp, rest-api, no-code, integrations]
 recommends: [automation-flows, automation-strategy, api-connector-builder, webhooks]
 profiles: [full]
@@ -9,15 +9,11 @@ origin: risco
 
 # n8n — operate a live instance over its REST API and MCP
 
-You already have a workflow *design* (the trigger→steps→error shape and the importable JSON).
-This skill is the **operate** half: push that JSON into a running n8n, validate it, test it, flip it
-live, watch its executions, and tear it down safely — all without touching the UI. n8n has the
-richest programmatic story of the no-code platforms: a first-party REST API **plus** a mature MCP
-server, both hitting the same instance.
-
-Designing the flow itself (what fires it, how errors are handled, dedup) is **automation-flows** —
-this skill *consumes* that skill's `references/n8n-workflow-json.md` payload; it does not re-teach
-design.
+You already have a workflow *design* — the trigger→steps→error shape and the importable JSON, which is
+`automation-flows`' job and this skill does not re-teach it. This skill is the **operate** half: push
+that JSON into a running n8n, validate it, test it, flip it live, watch its executions, and tear it
+down safely — all without touching the UI. n8n has the richest programmatic story of the no-code
+platforms: a first-party REST API **plus** a mature MCP server, both hitting the same instance.
 
 ## Connect first — REST API vs MCP
 
@@ -31,10 +27,10 @@ Two ways to drive the same instance. Pick by who is at the wheel.
 | Surface | identical on self-host **and** `*.app.n8n.cloud` | same underlying API; hosted trial at `dashboard.n8n-mcp.com` |
 
 **Version reality (verify at author time — n8n moves fast):**
-- API base is `{host}/api/v1`. Self-host ships interactive Swagger at `/api/v1/docs`; **cloud does not**.
+- API base is `{host}/api/v1`. Self-host ships interactive Swagger at `/api/v1/docs`; **cloud does not**
+  — on cloud, work from the docs.
 - `POST /workflows/{id}/execute` (run-by-id) is **recent** (n8n PR #20234). Older instances lack it —
-  there, the only programmatic run is POSTing to a Webhook node's URL. It also takes **no custom input**.
-- The API surface is the SAME whether you self-host or run on `*.app.n8n.cloud`; only the host differs.
+  there, the only programmatic run is POSTing to a Webhook node's URL.
 
 ### `.env`
 
@@ -66,7 +62,8 @@ shapes rather than guessing — that is the single biggest reason to drive via M
 ## Dynamic lifecycle
 
 create → **validate** → test → **activate** → manage → delete. A concrete sketch per step, curl and
-n8n-mcp side by side.
+n8n-mcp side by side; every endpoint with pagination and scopes is in
+`references/rest-api-cheatsheet.md`.
 
 ### 1. Validate (do this BEFORE create)
 
@@ -107,8 +104,9 @@ n8n_test_workflow       { "id": "$ID" }
 
 ### 4. Activate — the step people miss
 
-`active` in the create/update body is **read-only and silently ignored**. Setting `"active": true`
-does nothing. You MUST call the separate endpoint:
+`active` (and `tags`) in the create/update body are **read-only and silently ignored**. Setting
+`"active": true` does nothing, which is why the workflow you just created never fires. You MUST call
+the separate endpoint:
 
 ```bash
 curl -sS -X POST "$N8N_API_URL/api/v1/workflows/$ID/activate"   -H "X-N8N-API-KEY: $N8N_API_KEY"
@@ -137,7 +135,8 @@ omitted. n8n-mcp's `n8n_update_partial_workflow` applies a targeted, atomic batc
 
 ### 6. Delete — irreversible
 
-`DELETE` is a **hard delete: no trash, no undo.** Export the current JSON first, every time.
+`DELETE` is a **hard delete: no trash, no undo**, so export the current JSON first, every time — this
+one is absolute because nothing downstream can recover the workflow if you skip it.
 
 ```bash
 curl -sS "$N8N_API_URL/api/v1/workflows/$ID" -H "X-N8N-API-KEY: $N8N_API_KEY" > backup-$ID.json  # export FIRST
@@ -147,7 +146,7 @@ curl -sS -X DELETE "$N8N_API_URL/api/v1/workflows/$ID" -H "X-N8N-API-KEY: $N8N_A
 n8n_get_workflow { "id": "$ID" }   →  save output  →  n8n_delete_workflow { "id": "$ID" }
 ```
 
-**Irreversibility rule:** never DELETE (or full-replace) a live workflow without exporting it first.
+The same applies to a full replace: export before `PUT`.
 
 ## Governance
 
@@ -156,50 +155,23 @@ If you expose n8n-mcp to an agent, lock down destructive tools with the `DISABLE
 key itself too — n8n supports scoped keys (e.g. grant `workflow:read` without `workflow:execute`).
 Details in `references/n8n-mcp-tools.md`.
 
-## Honesty / gotchas
+## Anti-patterns
 
-- **`active` and `tags` are read-only on create/update** — ignored in the body; activate/tag via the
-  dedicated endpoints. This is the #1 "why is my workflow inactive" bug.
-- **`/workflows/{id}/execute` takes no custom input** — for runtime params, trigger a Webhook workflow
-  by POSTing to its URL. Also, it is a newer endpoint; older instances 404 it.
-- **`DELETE` and `PUT` are destructive** — hard delete (no trash) and full replace. Export first; prefer
-  `n8n_update_partial_workflow` for edits.
-- **`typeVersion` must exist on the target** — a node version the instance doesn't have fails only at
-  activate/execute time, not at create. Validate (MCP) or test before activating.
-- **Credential secrets are not fully manageable over the public API** — you can reference existing
-  credentials by id/name and create some, but you cannot read secrets back; provision credentials in
-  the UI / n8n-mcp `n8n_manage_credentials` and reference them.
-- **Cloud has no Swagger** — `/api/v1/docs` is self-host only; on cloud, work from the docs.
-- **Activation can succeed via API where the UI would block it** — the public API historically skips a
-  few UI-side activation validations, so a workflow can be "active" yet non-functional. Test it live.
+| Anti-pattern | Why it bites | Do instead |
+|---|---|---|
+| `"active": true` (or `tags`) in the create/update body | Read-only fields, silently ignored — the #1 "why is my workflow inactive" bug | `POST /workflows/{id}/activate`; set tags via their own endpoint |
+| Passing runtime input to `/workflows/{id}/execute` | It accepts no custom input, and older instances 404 the endpoint entirely | Trigger a Webhook workflow by POSTing to its URL |
+| `PUT` with a partial body, or `DELETE` on a live workflow | Full replace drops every node you omitted; delete is a hard delete with no trash | GET and export first; prefer `n8n_update_partial_workflow` for edits |
+| A `typeVersion` the target instance doesn't have | Create succeeds; it fails only at activate/execute time | Validate via MCP, or test, before activating |
+| Inlining node credential secrets, or expecting to read them back | Credentials are not fully manageable over the public API — it can create some, but never returns a secret | Provision in the UI or via `n8n_manage_credentials`, then reference existing credentials by id/name |
+| Treating a successful API activation as proof it works | The public API historically skips a few UI-side activation validations, so a workflow can be "active" yet non-functional | Run it live after activating and check the execution |
 
-## Related skills
+## Route elsewhere
 
-- **automation-flows** — *design* the flow and produce the importable JSON this skill deploys. Design
-  vs operate boundary: they decide the trigger/steps/error path; you push it live. Start there if the
-  flow's logic isn't settled yet.
-- **automation-strategy** — whether n8n is even the right platform (cost model, self-host vs cloud) vs
-  Make/Zapier/Power Automate.
-- **make / zapier / power-automate** — the other platforms' operate stories (Zapier and Power Automate
-  can't create flows via API — n8n's edge).
-- **api-connector-builder** — a generic typed HTTP client with auth/pagination/backoff, when the answer
-  is real code, not a workflow.
-- **webhooks** — building the inbound receiver *in your own app*; here webhooks are just n8n triggers.
-
-## Checklist
-
-- [ ] `.env` has `N8N_API_URL`/`N8N_HOST` + `N8N_API_KEY` (key from Settings → n8n API); key not logged.
-- [ ] Payload has `name`, `nodes` (one trigger), `connections`, `settings` per automation-flows' schema;
-      node credentials referenced by store, never inlined.
-- [ ] Validated (`n8n_validate_workflow` / `n8n_autofix_workflow`) before create when MCP is available.
-- [ ] Created via `POST /workflows` or `n8n_create_workflow`; captured the returned `id`.
-- [ ] Tested — `execute`-by-id (no input) or POST to the webhook URL (with input) — and the run succeeded.
-- [ ] Activated via `POST /workflows/{id}/activate` (NOT `active:true` in the body).
-- [ ] Before any DELETE or full-replace: exported the current JSON (hard delete, no trash).
-- [ ] If MCP is exposed to an agent: `DISABLED_TOOLS` set and/or the API key scoped.
-
-## References
-
-- `references/rest-api-cheatsheet.md` — every workflow/execution endpoint with curl, pagination, scopes.
-- `references/n8n-mcp-tools.md` — the management + node-knowledge tool list, the auth split, `DISABLED_TOOLS`.
-- `references/auth-and-selfhost.md` — API-key creation, self-host vs cloud, Swagger, installing/pointing n8n-mcp.
+| If the ask is | Skill |
+|---|---|
+| Designing the flow (trigger/steps/error path, dedup) and producing the importable JSON | `automation-flows` — start there if the logic isn't settled |
+| Whether n8n is the right platform at all — cost model, self-host vs cloud | `automation-strategy` |
+| Operating a different platform | `make`, `zapier`, `power-automate` (neither Zapier nor Power Automate can create flows via API — n8n's edge) |
+| A generic typed HTTP client with auth/pagination/backoff — real code, not a workflow | `api-connector-builder` |
+| The inbound webhook receiver in your own app (here webhooks are only n8n triggers) | `webhooks` |


### PR DESCRIPTION
Context-engineering pass on `n8n` against `scripts/skill-rubric.md`. Format only — no claim, version, endpoint, or command changed.

## Numbers

| | Before | After |
|---|---|---|
| `description` | 995 chars | **355** |
| body | 12242 bytes / 206 lines | **10329 bytes / 177 lines** |
| eval-lint | — | **PASS** (should_trigger=7, should_not_trigger=5, capability=1) |

## Description

Dropped the nine-phrase `Triggers:` list (EN + ES). It is in context on every turn the skill is installed, invoked or not, and the model matches these by meaning anyway.

Kept the two boundaries that actually discriminate — `automation-flows` (design and the importable JSON) and `make` / `zapier` (other platforms) — with the siblings in backticks. The `api-connector-builder` and `webhooks` boundaries moved into the body's route table, so they are only read when the skill fires. Both siblings still appear in `recommends`.

## What went

- **The 8-item Checklist.** Every item restated a step already above it: the `.env` keys, the payload shape, validate-before-create, capture the returned id, test, activate via the endpoint, export before delete, `DISABLED_TOOLS`. The two absolutes moved to the steps they govern — `tags` is now named next to `active` in step 4, and "export before `PUT`" sits with the delete commands.
- **The "Related skills" bullet list**, re-columned as a compact `If the ask is | Skill` table. Same five routes, same "neither Zapier nor Power Automate can create flows via API" note.
- **Two within-page duplicates:** "the API surface is the same on self-host and cloud" (already a row in the REST-vs-MCP table) and the second telling of "cloud has no Swagger" (kept where the fact already lived, in Version reality).
- **The trailing References index.** `auth-and-selfhost.md` and `n8n-mcp-tools.md` were already linked at point of use; `rest-api-cheatsheet.md` now is too, from the lifecycle header. All three references remain linked — an unlinked reference never loads.

## What stayed, deliberately

- **All seven "Honesty / gotchas" facts**, re-columned as `Anti-pattern | Why it bites | Do instead` — the shape `automation-flows`, `api-connector-builder` and `cloudflare` already use. These are concrete failure modes (read-only `active`, no-input `execute`, full-replace `PUT`, a missing `typeVersion`, unreadable credential secrets, API activation skipping UI validations), not rules restated from above.
- The REST-vs-MCP decision table (the flow genuinely branches on who is driving), the full curl/MCP lifecycle, the version reality (PR #20234, `/api/v1/docs` self-host only), the `.env` block, and Governance.
- No result-envelope block was added; this skill never had one.

## Checks

- `bash scripts/eval-lint.sh` → `n8n PASS`
- Frontmatter parses as YAML; `description` 355 chars (well under the 1024 schema limit)
- Every `references/` file linked from the body; `../automation-flows/references/n8n-workflow-json.md` still resolves
- `manifest.json` untouched (derived — orchestrator regenerates)
