### PR TITLE
refactor(lead-gen): Claude-5-era description and body pass

### DIFF
--- a/skills/lead-gen/SKILL.md
+++ b/skills/lead-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lead-gen
-description: "Use when you need to find and qualify prospects, build a target list, or score and prioritize leads before anyone reaches out — defining an ICP, sourcing named accounts/contacts from Apollo/ZoomInfo/Clay, deduping against the CRM, and ranking with a fit+intent+engagement model. Triggers: 'build me a prospect list', 'who should we sell to', 'score these leads', 'which accounts do we call first', 'tighten our ICP', 'is this cold list GDPR-safe', 'necesito una lista de clientes potenciales', 'califica estos leads', 'a qui truquem primer'. NOT writing or sending the outreach (that is cold-outreach), NOT tracking the deal after first contact (that is sales-pipeline)."
+description: "Use when building and qualifying a prospect list before anyone reaches out — a falsifiable ICP, named accounts/contacts from Apollo/ZoomInfo/Clay, deduped against the CRM, tiered by fit+intent+engagement. NOT writing or sending the outreach (that is cold-outreach), NOT tracking the deal after first contact (that is sales-pipeline)."
 tags: [lead-generation, prospecting, icp, lead-scoring, sales]
 recommends: [cold-outreach, sales-pipeline, market-research, data-scraper, spreadsheet-ops, email-deliverability, gdpr-privacy]
 origin: risco
@@ -8,9 +8,7 @@ origin: risco
 
 # Lead Gen — The List and the Model That Ranks It
 
-*You turn "we sell X to Y" into a deduplicated, scored, compliance-cleared roster of named accounts and people. You define the target, you build the list, you rank it — then you stop. You do not write the email and you do not run the deal.*
-
-The identity of this skill is **the list and its scoring model**, not the messages sent to it and not the pipeline it becomes. Everything you produce is a *prioritized roster + the rationale that ranked it*. The hand-off is the finish line, not the campaign.
+*You turn "we sell X to Y" into a deduplicated, scored, compliance-cleared roster of named accounts and people. You define the target, you build the list, you rank it — then you stop. What you produce is a prioritized roster plus the rationale that ranked it; the hand-off is the finish line, not the campaign.*
 
 ## The pipeline — three phases, two gates
 
@@ -151,5 +149,3 @@ This skill stops at a scored, compliance-cleared list. From there:
 - The **A/B tiers + persona context** go to `../cold-outreach/SKILL.md` — that skill writes the message and the cadence; you do not.
 - **Accepted leads** (worked and responsive) go to `../sales-pipeline/SKILL.md` — that skill tracks stages, forecasts, and manages the deal; you do not.
 - If the request is really "how big is this market / which segment?" with no named list, that is `../market-research/SKILL.md`, not this skill.
-
-When the deliverable would be a message, a pipeline stage, or a market sizing — route. Your job ended at the ranked roster.

--- a/skills/lead-gen/evals/cases.yaml
+++ b/skills/lead-gen/evals/cases.yaml
@@ -10,9 +10,9 @@ should_trigger:
   - prompt: "Is this cold prospect list legal to email under GDPR before we send?"
     why: "The compliance gate (GDPR LIA, no scraped basis) is part of making a list ship-ready — non-obvious that lead-gen owns it, not a generic legal skill."
   - prompt: "Necesito una lista de clientes potenciales para nuestro SaaS de logística."
-    why: "Spanish core trigger — build a target list of prospects."
+    why: "Spanish-language phrasing of the core case — build a target list of prospects."
   - prompt: "A qui de la nostra base truquem primer, tenim 300 comptes sense prioritzar?"
-    why: "Catalan trigger — scoring/tiering an unprioritized account list."
+    why: "Catalan-language phrasing — scoring/tiering an unprioritized account list."
 
 should_not_trigger:
   - prompt: "Write the cold email sequence for these prospects."


### PR DESCRIPTION
Context-engineering pass on `lead-gen` against `scripts/skill-rubric.md`. Format only — no recommendations, versions, figures, commands or claims were changed.

| Metric | Before | After |
|---|---|---|
| `description` chars | 670 | 333 |
| SKILL.md bytes | 11350 | 10697 |
| SKILL.md lines | 155 | 151 |
| `scripts/eval-lint.sh` | — | **PASS** (should_trigger=6, should_not_trigger=5, capability=1) |

## What went

- **The `Triggers:` list** — nine phrases across English, Spanish and Catalan. That description is in context on every turn the skill is installed, invoked or not, so a keyword list the model does not need is pure per-turn cost. Half the budget of the field went to it.
- **A restated identity paragraph.** "The identity of this skill is **the list and its scoring model**…" repeated the italic intro one line above it; its one non-duplicated clause (roster + rationale, handoff is the finish line) was folded into the intro.
- **A trailing routing restatement.** "When the deliverable would be a message, a pipeline stage, or a market sizing — route." said exactly what the three handoff bullets immediately above it already say.

The boundary against `cold-outreach` and `sales-pipeline` was stated five times — description, intro, anti-patterns row, handoff bullets, closing line. Four remain, each doing different work.

## What stayed, deliberately

- **The anti-patterns table.** Already in the right shape (`Anti-pattern | Why it fails | Do instead`), concrete failure modes with no borrowed urgency framing — the rubric requires one.
- **The branching tables**: BANT/CHAMP/MEDDIC by deal size, the provider/waterfall comparison, and tier→SLA. These are real decision points, not padding.
- **The bad/good ICP pair**, which teaches falsifiability by demonstration rather than by rule.
- **The per-phase `*Why:** notes.** These are rules sitting next to the step they govern instead of in an appendix — the shape the brief asks for, not the shape it removes.
- **The compliance gate** (GDPR LIA / CAN-SPAM) with its dated sources, and the `scripts/verify.sh` pointer.
- Both `references/` files remain linked inline at point of use (`data-sources.md` in phase 2, `scoring-model.md` in phase 3).

No result-envelope block existed and none was invented.

## Evals

Two `why` fields framed the Spanish and Catalan cases as "triggers"; reworded to "…-language phrasing", since the keyword list they pointed at is gone. The cases themselves are unchanged. All five `route_to` targets verified to exist under `skills/`: `cold-outreach`, `sales-pipeline`, `market-research`, `data-scraper`, `email-deliverability`.

## Notes

`manifest.json` deliberately untouched — it is derived and regenerated centrally. `scripts/verify.sh` was already executable. No stray markup fragments, no overlapping rule tables, no stale "not in this catalog" claims, and no bare-backtick sibling references needing links.
