### PR TITLE
refactor(llm-pipeline): Claude-5-era rubric pass

### DIFF
--- a/skills/llm-pipeline/SKILL.md
+++ b/skills/llm-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-pipeline
-description: "Use when wiring several LLM calls into one production flow, when random 429s/timeouts/provider outages take a feature down, when adding a fallback model or a gateway in front of OpenAI/Claude, or when the bill explodes from uncached or flagship-everywhere calls. Triggers: 'chain these LLM calls', 'step 1 extracts step 2 summarizes', 'add a fallback if GPT fails use Claude', 'route easy requests to Haiku escalate to Opus', 'put a LiteLLM gateway in front', 'our bill tripled because we re-call the model on every request', 'semantic cache the responses', 'encadenar llamadas y cachear respuestas', 'cadena de crides a l'LLM amb fallback'. NOT prompt wording (that is prompt-engineering)."
+description: "Use when wiring several LLM calls into a production flow: typed contracts between steps, a router/gateway so 429s, timeouts and outages fail over instead of taking you down, and cost control via caching, model tiers and abort caps. NOT single-prompt wording (that is `prompt-engineering`), NOT a model-driven tool loop (that is `building-agents`)."
 tags: [llm-orchestration, llm-gateway, fallbacks, prompt-caching, cost-control, litellm, reliability]
 recommends: [prompt-engineering, structured-extraction, building-agents, cost-tracking, agent-eval, rag, observability, parallel]
 origin: risco
@@ -10,14 +10,7 @@ origin: risco
 
 Wire multiple LLM calls into a reliable, controllable production pipeline. You chain steps where one call's validated output feeds the next, put a router in front of providers so an outage fails over instead of taking you down, and engineer the cross-cutting concerns: timeouts, bounded retries, fallbacks, caching, and cost caps.
 
-## Core stance
-
-Treat the LLM as an unreliable network dependency, not a local function call. Everything below follows from that.
-
-- **Every call gets a hard timeout and bounded retries.** Providers have outages, rate limits, and latency tails; a naked call can hang your whole request behind one slow upstream.
-- **Steps pass validated structured objects, not free text.** The output of step N is a contract you assert on before it becomes step N+1's input — a parse failure is caught at the seam, not three steps later.
-- **A router sits in front of every provider.** One model's 429/500/timeout fails over to another; no single provider is a single point of failure.
-- **Cache and tier before you tune prompts.** The cheapest, fastest, most reliable call is the one you never made. Prompt wording is the last lever, not the first.
+Treat the LLM as an unreliable network dependency, not a local function call. Every rule below follows from that: providers have outages, rate limits, and latency tails, so no single provider is a single point of failure and no call is allowed to run unbounded.
 
 ## Do you even need a pipeline?
 
@@ -115,6 +108,8 @@ except Exception:
 ```
 
 ## Caching: two distinct layers
+
+The cheapest, fastest, most reliable call is the one you never made — so cache and tier before you tune prompts. Wording is the last lever, not the first.
 
 | Layer | What it matches | Safety | Enable when |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## What

Context-engineering pass on `llm-pipeline` per `scripts/skill-migration-brief.md`. No content rewrite: no recommendation, version, price, command or figure changed.

| | Before | After |
|---|---|---|
| `description` chars | 690 | 347 |
| body bytes | 12782 | 12023 |
| body lines | 155 | 151 |
| eval-lint | — | **PASS** (should_trigger=6, should_not_trigger=5, capability=1) |

## Description

Removed the nine-phrase `Triggers:` list (EN/ES/CA). It is in context on every turn the skill is installed, invoked or not, and the model matches by meaning anyway. Rewrote to what-it-does / when / boundary, and made the boundary discriminate against **two** real siblings instead of one:

> Use when wiring several LLM calls into a production flow: typed contracts between steps, a router/gateway so 429s, timeouts and outages fail over instead of taking you down, and cost control via caching, model tiers and abort caps. NOT single-prompt wording (that is `prompt-engineering`), NOT a model-driven tool loop (that is `building-agents`).

`building-agents` is the near-miss this skill is most often confused with (fixed DAG vs. the model picking its own next step), and it was missing from the old boundary.

## Body — what went

- **The "Core stance" bullet bank.** Three of its four rules were restated in full, with more detail, by the sections that own them: timeout + bounded retries in *Reliability mechanics*, the step-N → step-N+1 structured contract in *Design the chain as a typed DAG*, router-in-front in *Put a gateway/router in front*. Repeating a rule in a preamble and again at point of use is the "repeating yourself across layers" pattern the brief targets.
- The fourth bullet — *cache and tier before you tune prompts* / *the cheapest call is the one you never made* — was **not** restated anywhere, so it was preserved and moved to the head of the caching section, where it governs.
- The stance sentence itself survives, folded into the intro together with the outage / rate-limit / latency-tail rationale the deleted bullets carried.

## Body — what stayed, and why

- **The eight-row anti-patterns table.** Required by the rubric, and a different animal from a rationalization bank: every row names a concrete failure mode (naked call, `while True` retry, retrying a side-effecting step, weak-embedder semantic cache, schema-valid ≠ correct) with the bite and the fix. Already framed as `Anti-pattern | Why it bites | Do instead` — no STOP / excuse wrapper to strip.
- **The "Do you even need a pipeline?" routing table.** The flow genuinely branches, and this table is what keeps the skill out of `rag` / `building-agents` / `structured-extraction` / `cost-tracking` territory.
- The two-layer caching table (prefix vs. semantic is the skill's central distinction), both bad/good code pairs, the LiteLLM `v1.83.3-stable` and Anthropic Haiku/Sonnet/Opus price anchors, the observability field list, and the Verify block.

## Checks

- `bash scripts/eval-lint.sh` → `llm-pipeline PASS`.
- All 5 `route_to` targets exist under `skills/` (`prompt-engineering`, `structured-extraction`, `rag`, `building-agents`, `cost-tracking`); so do all 8 `recommends` and every `../<sibling>/SKILL.md` link.
- Both `references/` files still linked inline at point of use (`references/litellm-router.md`, `references/caching-layers.md`).
- `scripts/verify.sh` already executable; exits 0 on an empty target.
- `manifest.json` untouched — the orchestrator regenerates it.
