### PR TITLE
refactor(performance): migrate to the Claude-5-era skill rubric

### DIFF
--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance
-description: "Use when one page or route is slow for a single user and the fix has to start with a measurement — failing Core Web Vitals (LCP, INP, CLS), a bloated JS bundle, too many re-renders, slow hydration, or a profiler showing where the time actually goes. Triggers: 'my LCP is 4 seconds', 'the page feels janky, typing lags', 'First Load JS is huge', 'INP is failing in Search Console', the non-obvious 'we import the whole library for one function' and 'a use client boundary is shipping the server tree to the browser', and Catalan/Spanish 'la pàgina carrega lenta i no passa els Core Web Vitals' / 'el bundle pesa demasiado, hay que analizarlo antes de tocar nada'. NOT surviving a concurrent traffic spike with caches, replicas and load tests (that is scaling), NOT fixing the slow SQL query or N+1 itself (that is postgresdb)."
+description: "Use when a page or interaction is slow for one user and the fix starts from a measurement — a failing Core Web Vital (LCP, INP, CLS), a heavy JS bundle, wasted re-renders, an over-broad client boundary: profile, attribute the cost to one phase, fix it, re-measure. NOT surviving concurrent load (that is `scaling`), NOT the slow query (that is `postgresdb`)."
 tags: [performance, core-web-vitals, lcp, inp, cls, bundle-size, profiling, react, web-vitals]
 recommends: [scaling, postgresdb, redis, nextjs, react, observability, monitoring]
 profiles: []
@@ -15,12 +15,7 @@ The whole job in one line: **measure with a profiler → attribute the cost to o
 
 **Prime directive: no fix without a profile first.** A waterfall, a flame chart, a bundle treemap, or a field CWV number comes before you touch code. The fix you guess is almost never the fix the measurement points at, and a "fast" change that moves a phase nobody was waiting on is wasted work that you then have to maintain.
 
-Where the deep fix lives elsewhere — cross-reference, don't duplicate:
-
-- TTFB is the bottleneck because of a slow query or an N+1 → name it here, fix it in `../postgresdb/SKILL.md`.
-- You decided *what* to cache to cut a phase, now make the cache race-free → `../redis/SKILL.md`.
-- The problem only appears under concurrent load → `../scaling/SKILL.md`.
-- You need the canonical App-Router / component data pattern, not the perf loop → `../nextjs/SKILL.md`, `../react/SKILL.md`.
+Cross-reference, don't duplicate: the last column of the table below names where each deep fix lives. The one case it has no row for — you decided *what* to cache to cut a phase and now need that cache race-free — is `../redis/SKILL.md`.
 
 ## Decision table — symptom to first move
 


### PR DESCRIPTION
Migrates `performance` to the Claude-5-era rubric (`scripts/skill-rubric.md`, applied per `scripts/skill-migration-brief.md`).

The body already met the rubric — 221 lines against a 400-line ceiling, tables only where the flow branches, every `references/` file linked inline, an anti-patterns table in the correct form. So this is a small, honest diff: almost all of the cost was in the description.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 825 | 358 |
| SKILL.md bytes | 15491 | 14775 |
| SKILL.md lines | 221 | 217 |
| eval-lint | PASS | PASS |

## What went

- **The `Triggers:` phrase list** (~470 chars, English + Catalan + Spanish). The description is in context on every turn the skill is installed, invoked or not, so its length is a cost with no offsetting credit — and the body instructs semantic attribution right next to the enumeration, so the list was contradicting the skill it advertised. The boundary now names two real siblings in backticks, matching the migrated catalog: `NOT surviving concurrent load (that is scaling), NOT the slow query (that is postgresdb)`.
- **The "where the deep fix lives elsewhere" bullet list**, collapsed to one line. Four of its five pointers (postgresdb, scaling, nextjs, react) were restated in the decision table's "Deep fix lives in" column six lines below it — the repeat-across-layers pattern this migration exists to remove. The redis pointer is the only one the table has no row for, so it stays in prose. Every routing target and every link survives.

## What stayed, on purpose

- **The anti-patterns table**, all ten rows. It was already `Anti-pattern | Why it's wrong | Do instead` with no borrowed-urgency wrapper to strip — the rubric requires this table, and these rows name concrete failure modes rather than restating rules.
- **The three data tables**: symptom-to-first-move (the flow genuinely branches), the LCP subpart breakdown (each subpart has a different fix — that is the skill's core teaching), and the CWV field-p75 thresholds (load-bearing numbers).
- **The bad/good code pairs** for LCP, INP, CLS, bundle imports and the `'use client'` boundary — they teach the judgment by demonstration.
- **"Prime directive" and "Stop rule"** as prose. Neither is a rule bank in an appendix: each sits next to the step it governs and states its own why, which is what the rubric asks for.
- No result-envelope block was added — this skill never had one.

## Verification

- `bash scripts/eval-lint.sh` → `performance PASS (should_trigger=8, should_not_trigger=5, capability=1)`.
- All five `route_to` ids (`scaling`, `postgresdb`, `redis`, `nextjs`, `react`) resolve to real skills; so do all `../<sibling>/SKILL.md` links in the body and every `recommends` id.
- `references/profiling-playbook.md` is still linked from the body; `scripts/verify.sh` is executable and unchanged.
- `manifest.json` untouched (derived — the orchestrator regenerates it).
- No content change: no recommendation, version, figure, command or claim was altered.

## Notes for the orchestrator

Nothing blocking. `evals/README.md` still describes the Catalan/Spanish cases as phrasings "the description and body must claim" — accurate as written (they must still match semantically), so left alone rather than reworded around a deleted quote.
