### PR TITLE
refactor(gdpr-privacy): migrate to the Claude-5-era skill rubric

### DIFF
--- a/skills/gdpr-privacy/SKILL.md
+++ b/skills/gdpr-privacy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gdpr-privacy
-description: "Use when getting a product or website into practical GDPR shape: a privacy policy that matches what the product actually does, a cookie/consent banner, a defensible lawful basis per processing activity, a Record of Processing Activities, an Article 28 data-processing agreement with a vendor, an international-transfer mechanism (SCCs), or a working data-subject-rights flow. Triggers: 'write a GDPR privacy policy', 'is our cookie banner compliant', 'consent or legitimate interest for product emails', 'write the LIA', 'review this vendor DPA', 'we send data to a US sub-processor what mechanism', 'build our ROPA', 'how do we handle a DSAR / right to erasure', 'do we need a DPIA', 'redacta nuestra política de privacidad RGPD', 'revisa el banner de cookies perquè el rebuig sigui tan fàcil com acceptar'. NOT internal data retention/classification rules (that is data-policy) and NOT the consumer Terms of Service contract (that is terms-conditions)."
+description: "Use when producing the GDPR artifacts a product publishes or hands over: a privacy policy true to what it processes, a cookie/consent banner, a lawful basis per purpose, an Art. 28 DPA, an SCC transfer mechanism, or a DSAR flow. Drafts for counsel review. NOT internal retention rules (that is `data-policy`), NOT consumer ToS (that is `terms-conditions`)."
 tags: [gdpr, privacy, data-protection, cookies, consent, lawful-basis, dpa, scc, dsar, ropa, dpia, rgpd]
 recommends: [data-policy, terms-conditions, contracts, compliance, secure-coding, email-deliverability]
 origin: risco
@@ -128,9 +128,7 @@ Per-right runbook: `references/dsar-and-consent.md`.
 - **DPIA (Art. 35):** mandatory *before* any processing "likely to result in a high risk." Trigger checklist — do a DPIA if any apply: large-scale processing of special categories (Art. 9 data), systematic monitoring of a public area, or novel/high-risk technology (e.g. new biometric or AI-driven profiling). When in doubt, do it.
 - **Breach (Art. 33/34):** notify the supervisory authority **within 72 hours** of becoming aware, unless the breach is unlikely to result in risk; notify affected individuals when the risk to them is high. Have the contact and the template ready *before* a breach, not during.
 
-## The legal boundary (non-negotiable)
-
-This skill drafts artifacts and flags issues. It is **not legal advice**. Emit the counsel/DPO-review line before anything is published or relied on — every time, no exceptions.
+## Stakes, and what isn't yours
 
 The fines make the stakes concrete: up to **€20M or 4% of global annual turnover** (whichever is higher) for the most serious infringements, €10M / 2% for the lesser tier; cumulative GDPR fines already exceed €7.1B. This is not a Big-Tech-only risk.
 
@@ -158,10 +156,4 @@ Hand off what isn't yours:
 | "Industry-standard security" with no Art. 32 reference | Cite Article 32 and describe the actual measures |
 | Says it's giving legal advice / the policy is safe to publish unreviewed | Flag for qualified privacy counsel / DPO every time |
 
-## References
-
-- `references/privacy-policy-blueprint.md` — Art. 13/14 mandatory-disclosure sections as `[BRACKET]` fill-ins, each with a "why required" line.
-- `references/dpa-and-transfers.md` — Art. 28 demand/offer clause table, 2021 SCC module picker, TIA skeleton, DPF note, sub-processor change-notice clause.
-- `references/dsar-and-consent.md` — data-subject-rights runbook, the LIA three-part template, a compliant cookie-banner config shape, and the `verify.sh` banlist rationale.
-
-Run `scripts/verify.sh <artifact-file>` over any policy/banner/DPA you emit to catch missing Art. 13/14 tokens, placeholder leftovers, boilerplate-lies, and a banner missing its reject control.
+Run `scripts/verify.sh <artifact-file>` over any policy/banner/DPA you emit to catch missing Art. 13/14 tokens, placeholder leftovers, boilerplate-lies, and a banner missing its reject control (banlist rationale in `references/dsar-and-consent.md`).

--- a/skills/gdpr-privacy/evals/cases.yaml
+++ b/skills/gdpr-privacy/evals/cases.yaml
@@ -14,9 +14,9 @@ should_trigger:
   - prompt: "Someone emailed asking us to delete all their data — what's our deadline and process?"
     why: DSAR/erasure flow and the one-month statutory clock with exceptions.
   - prompt: "Redacta nuestra política de privacidad conforme al RGPD."
-    why: Spanish trigger — drafting the privacy policy under GDPR.
+    why: Drafting the privacy policy under GDPR, asked in Spanish — matched by meaning, not keyword.
   - prompt: "Revisa el banner de cookies del web perquè el rebuig sigui tan fàcil com acceptar."
-    why: Catalan trigger — cookie-banner review with the reject-parity rule.
+    why: Cookie-banner review against the reject-parity rule, asked in Catalan.
 
 should_not_trigger:
   - prompt: "Define our internal data retention schedule and data-classification tiers."


### PR DESCRIPTION
Migrates `gdpr-privacy` to the Claude-5-era rubric (`scripts/skill-rubric.md`, applied per `scripts/skill-migration-brief.md`). Format/context pass only — no legal substance changed.

## Numbers

| | Before | After |
|---|---|---|
| description | 954 chars | **356 chars** |
| SKILL.md | 15346 bytes / 167 lines | **14116 bytes / 159 lines** |
| eval-lint | — | **PASS** (should_trigger=8, should_not_trigger=5, capability=1) |

## What went

- **The `Triggers:` list** — eleven quoted phrases across English, Spanish and Catalan, paid for on every turn the skill is installed. Routing is by meaning; the Spanish and Catalan eval cases remain, so that match is still graded.
- **The duplicated counsel/DPO paragraph** under "The legal boundary (non-negotiable)". Standing rule 3 states it at the top, where it governs every task, and the closing anti-pattern row backs it. The section kept only the fines, so it is now "Stakes, and what isn't yours".
- **The trailing `## References` index.** All three reference files were already linked inline at point of use — `privacy-policy-blueprint.md` in the Art. 13/14 section, `dpa-and-transfers.md` in DPAs & transfers, `dsar-and-consent.md` in three places (LIA, banner config, per-right runbook). The only detail the index alone carried, that the `verify.sh` banlist rationale lives in `dsar-and-consent.md`, moved into the `verify.sh` line. All three references remain linked.
- **Two eval `why` fields** that described their prompts as "Spanish trigger" / "Catalan trigger" — a pointer to the phrase list that no longer exists.

## What stayed, and why

- **The anti-patterns table, all ten rows.** Concrete failure modes (boilerplate-lie policy, trackers firing on page load, legitimate interest with no LIA, silent DSAR extension), not a restatement of rules above it. The rubric requires one, and this one was never a borrowed rationalization block.
- **The request → artifact routing table.** The flow genuinely branches: seven request shapes, seven different artifacts, each with its load-bearing rule and reference.
- **The bad/good consent-vs-legitimate-interest pair** — it teaches the judgment call by demonstration, which prose does not.
- **The three standing rules** and every legal figure, date and citation: the Digital Omnibus as a 19-Nov-2025 proposal rather than law, the ePrivacy Regulation withdrawn Feb 2025, the 2021 SCCs, the CNIL Google/Shein fines, the 72-hour breach clock, the one-month DSAR clock, the €20M/4% ceiling.

## Boundary

The new description discriminates against `data-policy` — this skill produces what a product publishes or hands over (policy, banner, lawful basis, Art. 28 DPA, SCC transfer, DSAR), `data-policy` owns internal retention and classification. Both `NOT` boundaries name real skills, and `../<sibling>/SKILL.md` handoff links all resolve.

Not touched: `manifest.json` (derived), `references/`, `scripts/verify.sh` (already executable, 0755).
