### PR TITLE
refactor(roast-me): trigger-phrase list out of the description, intro de-duplicated

### DIFF
--- a/skills/roast-me/SKILL.md
+++ b/skills/roast-me/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roast-me
-description: "Use when you want honest, comedic feedback on how you prompt — analyzing your own past sessions to score prompt quality and compute efficiency, surface your worst habits, and generate a model-selection cheat sheet. Triggers: 'roast me', 'roast my prompting', 'audit my prompting habits', 'how good are my prompts', 'am I prompting well', 'what are my bad prompt habits', 'analiza mis prompts', 'puntua els meus prompts', 'how much am I wasting on model costs'. NOT reviewing your code or output quality (use code-review for that) and NOT a general prompt-engineering tutorial (use prompt-engineering for that)."
+description: "Use when someone wants an honest, comedic audit of their own prompting — reads their past agent transcripts, scores prompt quality and compute efficiency, names their worst habits, builds a model-selection cheat sheet. NOT reviewing code an agent produced (that is `code-review`), NOT prompting technique in general (that is `prompt-engineering`)."
 tags: [prompting, self-audit, compute-efficiency, ai-hygiene, learning]
 recommends: [prompt-engineering, code-review, context-budget]
 profiles: [full]
@@ -9,7 +9,7 @@ origin: risco
 
 # roast-me — audit your prompting, score yourself, stop burning money
 
-You are the **prompt auditor**. Your target is not the user's code — it is their *prompting behaviour*. You read their recent agent transcripts, run structured analysis passes, produce dual scores (Prompt Quality + Compute Efficiency), name the worst habits with named techniques to fix them, and track the trend over time.
+You are the **prompt auditor**. Your target is not the user's code — it is their *prompting behaviour*, read from their own recent agent transcripts.
 
 Every run follows five phases. Execute them in order.
 
@@ -115,9 +115,7 @@ Score History:
   2026-06-08  73/100 (C) +5↑   35/100 (F)            The 3W Rule
 ```
 
-Output the roast report as formatted markdown. If history exists, append the trend line.
-
-Done.
+Output the roast report as formatted markdown.
 
 ## Orientación (siempre)
 

--- a/skills/roast-me/evals/cases.yaml
+++ b/skills/roast-me/evals/cases.yaml
@@ -9,7 +9,7 @@ skill: roast-me
 
 should_trigger:
   - prompt: "Roast me."
-    why: "Canonical verbatim invocation — the skill's own trigger phrase. Must fire immediately and run the five-phase pipeline."
+    why: "Canonical invocation — the shortest possible ask for exactly this skill's job. Must fire immediately and run the five-phase pipeline."
 
   - prompt: "Audit my prompting habits over the last two weeks."
     why: "Situation-first phrasing with a custom time window — roast-me owns both the 'audit prompting' job and the --days N parameter."
@@ -18,10 +18,10 @@ should_trigger:
     why: "Dual concern (prompt quality + cost) phrased as a question — maps directly to the two scores roast-me produces. No mention of 'roast' keyword."
 
   - prompt: "Analiza mis prompts de la última semana y dime dónde soy malo."
-    why: "Spanish-language trigger — rsc users write Spanish; the description must fire on non-English phrasings. Tests the non-English trigger."
+    why: "Spanish-language request — rsc users write Spanish; routing must survive translation on meaning alone."
 
   - prompt: "Puntua els meus prompts i digue'm quins hàbits hauria de canviar."
-    why: "Catalan-language trigger — a non-obvious language variant. The description lists this phrasing explicitly."
+    why: "Catalan-language request — a non-obvious language variant that must route on meaning, with no keyword resembling the skill id."
 
   - prompt: "How much am I burning on model costs? Show me where I overspend."
     why: "Compute-efficiency angle only, no prompting-quality framing — roast-me's compute score and cheat sheet are the direct answer."


### PR DESCRIPTION
Context-engineering pass on `roast-me` per `scripts/skill-migration-brief.md` and `scripts/skill-rubric.md`.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 612 | **347** (target ≤350, hard limit 1024) |
| `SKILL.md` bytes | 5873 | **5387** |
| `SKILL.md` lines | 124 | **122** |
| `scripts/eval-lint.sh` | PASS | **PASS** (should_trigger=7, should_not_trigger=5, capability=2) |

## What went

- **The `Triggers:` list.** Nine phrases across English, Spanish and Catalan, paid for on every turn the skill is installed whether or not it fires. The model matches by meaning; the skill's own eval cases include Spanish and Catalan prompts precisely to prove routing does not need the keywords spelled out.
- **The intro sentence that re-listed the phase outputs** (dual scores, habit list with named techniques, trend over time) two lines before the five phases specify each of them. Repeating yourself across layers is the first pattern the Jul 2026 context-engineering rules name as not paying.
- **A duplicated instruction in Phase 5** — "If history exists, append the trend line" appeared again four lines after the block that already said it — plus the stray trailing `Done.`

## What stayed, deliberately

- **The whole five-phase flow** and every instruction inside it: extractor invocation and `$ARGUMENTS` parsing, the ~30-prompt batching, the impact filter, the aggregation keys, the roast subagent payload, the history JSON shape and the trend-line format. This was a format pass, not a content rewrite — no recommendation, figure, path or command changed.
- **The stance sentence** ("your target is not the user's code — it is their *prompting behaviour*"). It reads like a restatement of the boundary, but it is what keeps a loaded run from drifting into a code review, so it earns its line.
- **The `effective_error_rate` rule** — the skill's single most distinctive piece of judgment.
- **The shared `Orientación` block**, byte-identical to the one in every other migrated skill (`harness`, `implement`, `verify`, `ship`, …). Uniformity beats a local trim.

## Description, before → after

Boundary reworded into the catalog's `NOT <x> (that is `sibling`)` shape. Both siblings verified to exist: `skills/code-review/`, `skills/prompt-engineering/`.

> Use when someone wants an honest, comedic audit of their own prompting — reads their past agent transcripts, scores prompt quality and compute efficiency, names their worst habits, builds a model-selection cheat sheet. NOT reviewing code an agent produced (that is `code-review`), NOT prompting technique in general (that is `prompt-engineering`).

## evals

Three `why` fields justified their case by pointing at the trigger list that no longer exists ("the skill's own trigger phrase", "the description lists this phrasing explicitly"). Reworded to justify by meaning instead. Cases, counts and every `route_to` are untouched — and all five targets were verified real: `code-review`, `prompt-engineering`, `analyze`, `chatbot`, `llm-pipeline`. The three `recommends` ids are real too (`prompt-engineering`, `code-review`, `context-budget`).

## Notes for the orchestrator

- `roast-me` has **no `references/` directory** — its progressive-disclosure payload is `prompts/analyze.md`, `prompts/compute.md`, `prompts/roast.md`, and all three are still linked inline from the body (Phases 2, 3, 4). No `scripts/verify.sh`, so gate 7 does not apply.
- **Content gap left alone on purpose:** the body has no anti-patterns table, which rubric dimension 3 asks for. Adding one would mean inventing content in a format pass, so it is flagged rather than fixed.
- `manifest.json` untouched, per the brief.
