### PR TITLE
refactor(shortform-strategy): Claude-5 rubric pass — description 971→341 chars

### DIFF
--- a/skills/shortform-strategy/SKILL.md
+++ b/skills/shortform-strategy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shortform-strategy
-description: "Use when running the durable strategy layer of a TikTok and/or Instagram Reels account — positioning, posting cadence, format mix, which trends and sounds to ride, recurring series, and the what-worked learning loop — not making one video. Use for standing up a new account before posting; diagnosing a flat or declining account (positioning, cadence, or format?); deciding whether to ride a trend or sound now; designing a recurring series; the monthly strategy review; or choosing the Reels-vs-carousel mix. Triggers: 'starting a new TikTok account, what and how often should we post', 'we post every single day and our reach is going down' (cadence-dilution symptom, no strategy word), 'should we jump on this sound or is it dead', 'we want a weekly recurring series on Reels', 'muntar l''estratègia del compte de Reels: posicionament i cadència', '¿nos subimos a esta tendencia o ya pasó?'. NOT writing the single short script or hook variants (that is video-shorts)."
+description: "Use when the unit of work is a TikTok/Reels account, not one clip: positioning, sustainable cadence and format mix, ride-or-skip on a trend or sound, recurring series, diagnosing a flat account, and the dated learning loop. NOT the single script or hook variants (that is `video-shorts`), NOT the idea backlog (that is `shortform-ideation`)."
 tags: [short-form-video, tiktok, instagram-reels, account-growth, positioning, posting-cadence, trends, series, algorithm-2026]
 recommends: [video-shorts, shortform-ideation, shortform-packaging, shortform-editing, social-publisher, content-engine, brand-voice, analytics]
 origin: risco
@@ -12,9 +12,9 @@ origin: risco
 
 Hand off downstream the moment the deliverable becomes *one video*:
 - The 15–60s script and hook variants → `../video-shorts/SKILL.md`.
-- The topic/angle backlog feeding the account → **shortform-ideation**.
-- The cover frame / on-screen title / first-frame packaging → **shortform-packaging**.
-- The cut, caption burn-in, sound sync → **shortform-editing**.
+- The topic/angle backlog feeding the account → `../shortform-ideation/SKILL.md`.
+- The cover frame / on-screen title / first-frame packaging → `../shortform-packaging/SKILL.md`.
+- The cut, caption burn-in, sound sync → `../shortform-editing/SKILL.md`.
 - Cross-platform calendar/scheduler across X/LinkedIn/Threads → `../social-publisher/SKILL.md`.
 - The top-down editorial system across all content types → `../content-engine/SKILL.md`.
 - The durable tone the account speaks in → `../brand-voice/SKILL.md`.
@@ -101,7 +101,7 @@ Design it as a *contract with the viewer*:
 - **Fix a cadence** — same slot, same rhythm (e.g. every Tuesday). A series with no schedule is just a hashtag.
 - **Pilot before committing.** Use **Trial Reels** (public IG accounts, 1,000+ followers, available since July 2025) to publish the pilot to non-followers first and read the signal before showing your existing audience — a built-in A/B surface for a format bet (later.com; socialpilot.co — accessed 2026-06-02).
 
-The hand-off: you define the series *concept, cadence, and numbering*. The episodes get ideated (shortform-ideation), scripted (`../video-shorts/SKILL.md`), and packaged (shortform-packaging) elsewhere.
+The hand-off: you define the series *concept, cadence, and numbering*. The episodes get ideated (`../shortform-ideation/SKILL.md`), scripted (`../video-shorts/SKILL.md`), and packaged (`../shortform-packaging/SKILL.md`) elsewhere.
 
 ## The learning loop — log, review, write back
 
@@ -152,21 +152,9 @@ timestamp: 2026-06-02T10:00:00Z
 
 ## Persist it
 
-Write the account's brain back so it compounds (mirrors the harness Karpathy-wiki convention). The `shortform/` wiki tree is an **OKF v0.1 bundle** shared with the `tiktok-api` and `shortform-packaging` siblings: every `.md` written here carries YAML frontmatter with a non-empty `type`, cross-references are standard markdown links (never `[[wikilinks]]`), and `decisions.md` follows the OKF newest-first append-log rule.
+Write the account's brain back so it compounds (mirrors the harness Karpathy-wiki convention). The `shortform/` wiki tree is an **OKF v0.1 bundle** shared with the `../tiktok-api/SKILL.md` and `../shortform-packaging/SKILL.md` siblings: every `.md` written here carries YAML frontmatter with a non-empty `type`, cross-references are standard markdown links (never `[[wikilinks]]`), and `decisions.md` follows the OKF newest-first append-log rule.
 
-- `02-DOCS/wiki/shortform/strategy.md` — positioning, cadence/mix, KPI, length bands, current series. Lead with frontmatter; the body keeps the H1 + sections the linter checks:
-
-  ```markdown
-  ---
-  type: shortform-strategy
-  title: Shortform account strategy
-  tags: [shortform, strategy, positioning, cadence]
-  timestamp: 2026-06-02T10:00:00Z
-  ---
-  # Shortform account strategy
-  ...
-  ```
-
+- `02-DOCS/wiki/shortform/strategy.md` — positioning, cadence/mix, KPI, length bands, current series. Same frontmatter shape as above with `type: shortform-strategy`, then the H1 (`# Shortform account strategy`) and the sections the linter checks.
 - `02-DOCS/wiki/shortform/decisions.md` — the dated decision log, OKF append-log (`type: shortform-decision-log`, newest block on top; format above).
 - `02-DOCS/raw/shortform/metrics.csv` — the per-post ledger (schema in `references/learning-loop-template.md`). This is `raw/`, not `wiki/` — a CSV, no frontmatter.
 


### PR DESCRIPTION
Claude-5-era rubric pass on `shortform-strategy`. The body already met the rubric, so this is
a small honest diff: the description is the real change, plus two duplication/consistency fixes.

## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 971 | **341** |
| SKILL.md bytes | 14356 | **13651** |
| SKILL.md lines | 173 | **161** |
| `scripts/eval-lint.sh` | — | **PASS** (should_trigger=7, should_not_trigger=6, capability=1) |

## What went

- **The `Triggers:` list** — six phrases across English, Catalan and Spanish, ~630 chars that sat
  in context on every turn the skill was installed whether or not it fired. The model matches by
  meaning; a keyword list in three languages buys nothing and is paid for by everyone.
- **A duplicated OKF frontmatter block.** "Persist it" re-showed the same five-key frontmatter
  example for `strategy.md` ten lines after showing it for `decisions.md`. Collapsed to one line
  that keeps both load-bearing facts: `type: shortform-strategy` and the required H1.

Rewritten description:

> Use when the unit of work is a TikTok/Reels account, not one clip: positioning, sustainable
> cadence and format mix, ride-or-skip on a trend or sound, recurring series, diagnosing a flat
> account, and the dated learning loop. NOT the single script or hook variants (that is
> `video-shorts`), NOT the idea backlog (that is `shortform-ideation`).

The boundary now names **two** siblings instead of one — `shortform-ideation` is the nearest
confusable neighbour (it owns the idea backlog and consumes this skill's pillars/cadence), so
naming it is what makes the description discriminative rather than merely descriptive. Both ids
verified present under `skills/`.

Sibling mentions in the body that were bold text, bare parentheticals or bare backticks are now
resolvable links — `../shortform-ideation/SKILL.md`, `../shortform-packaging/SKILL.md`,
`../shortform-editing/SKILL.md`, `../tiktok-api/SKILL.md` — matching the links already sitting
next to them in the same hand-off list.

## What stayed, and why

- **All four tables.** Positioning signal/diagnosis/move, cadence per platform, and length bands
  are genuine decision branches, not restated prose — and the capability eval asserts their exact
  figures (3–5 TikTok / 4–7 Reels, 7–30s vs 30–90s) in the produced strategy doc.
- **The eight-row anti-patterns table**, already `Anti-pattern | Why it fails | Do instead` with no
  borrowed urgency framing. Nothing to re-column here.
- **The inline dated citations.** `references/platform-signals-2026.md` is the sourced home for
  these figures, and stripping the body's per-claim sources was tempting as cross-layer repetition
  — but it would leave 2026 algorithm numbers ungrounded in the file a reviewer reads first, which
  the rubric's heaviest dimension penalises. Kept as the cheaper of the two costs.
- **The bad/good cadence pair, the three-gate ride-or-skip block, and the decision-record format.**
  The record format is an output contract the skill already had; it was not invented here.
- **No rule bank to remove** — this skill never had an "iron rules" or rationalisation appendix.

## Verification

- `bash scripts/eval-lint.sh` → `shortform-strategy PASS (7/6/1)`.
- Frontmatter parses as YAML; `name` matches the directory, `origin: risco` intact.
- Both `references/` files still linked from the body (`platform-signals-2026.md` at the figures,
  `learning-loop-template.md` at the review ritual and the metrics ledger).
- `scripts/verify.sh` was already executable; untouched.
- `evals/cases.yaml` needed no edit: seven trigger cases, six `should_not_trigger` whose `route_to`
  targets (`video-shorts`, `shortform-ideation`, `shortform-packaging`, `shortform-editing`,
  `social-publisher`, `brand-voice`) all exist, and no `why` quoted a deleted trigger phrase.
- `manifest.json` untouched (derived; the orchestrator regenerates it).
- No substance changed: no figure, source, date, path, command or recommendation altered.
