### PR TITLE
refactor(react-native): Claude-5-era description + body pass

### DIFF
--- a/skills/react-native/SKILL.md
+++ b/skills/react-native/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-native
-description: "Use when writing the JS/TS code inside a React Native or Expo app — screens, navigation, lists, animation, platform-conditional UI, data/offline state, and native-module authoring — and when killing runtime jank or render bugs. Triggers: 'scaffold an Expo Router app', 'FlashList vs FlatList', 'auth-gated route groups', 'gesture reattaches every render', 're-render storm on every keystroke', 'deep link lands on the wrong screen', 'write an Expo Module wrapping a native SDK', 'la llista pateix lag quan faig scroll', 'mi app va fluida en iOS pero a tirones en Android'. NOT eas build/submit/OTA update/prebuild/config-plugin (that is expo), NOT a Dart app (that is flutter), NOT web React/DOM (that is react or nextjs)."
+description: "Use when writing the JS/TS inside a React Native or Expo app — screens, Expo Router navigation, lists, Reanimated gestures, platform forks, offline state, native modules — or killing jank and render storms. NOT eas build/submit/OTA/config-plugin (that is `expo`), NOT a Dart app (that is `flutter`), NOT web React/DOM (that is `react` or `nextjs`)."
 tags: [react-native, expo, mobile, ios, android, navigation, performance]
 recommends: [expo, react, flutter, design, debug, performance]
 origin: risco
@@ -8,11 +8,7 @@ origin: risco
 
 # React Native (app code)
 
-You write the code that runs *inside* the app: render, navigate, animate, list, persist, and author native modules. The pipeline around it — building, signing, OTA, native config — is not yours.
-
-## What this skill owns
-
-Mobile is split across two skills by **verb**. Run the verb test before doing anything:
+You write the code that runs *inside* the app: render, navigate, animate, list, persist, and author native modules. Mobile is split across two skills by **verb** — run the verb test before doing anything:
 
 | Verb in the request | Skill |
 |---|---|
@@ -149,7 +145,7 @@ Use Reanimated 4 CSS animations for simple declarative cases (fades, simple tran
 
 - Small forks: `Platform.select({ ios: 12, android: 8 })` or `Platform.OS === 'ios'`.
 - Whole-component forks: `Button.ios.tsx` / `Button.android.tsx` — the bundler picks the right one; import `./Button` with no extension.
-- Safe area: use `react-native-safe-area-context` insets, not hardcoded notch padding. Why: insets differ per device and orientation.
+- Safe area: use `react-native-safe-area-context` insets, not hardcoded notch padding. Why: insets differ per device and orientation. Palette, type scale and layout intent are not decided here → `../design/SKILL.md`.
 - `KeyboardAvoidingView` behaves differently per platform — `padding` on iOS, often `height` or nothing on Android; test both, don't assume the iOS behavior ports.
 - Set the status bar style explicitly per screen via `expo-status-bar`.
 
@@ -196,6 +192,7 @@ Full Expo Module (Swift + Kotlin + view), the Turbo Module codegen-spec walkthro
 - Read **Hermes** stack traces from the bottom up; the JS frame that matters is usually above the native bridge frames.
 - "Works on iOS, breaks on Android" (or vice versa) → run the platform-divergence checklist in `references/performance-debugging.md` before guessing.
 - A red screen citing the interop layer is usually an old-architecture lib running under Fabric — update the lib or find a New-Arch-ready replacement; do **not** disable New Arch.
+- A fault that resists all of the above needs systematic isolation, not more guesses → `../debug/SKILL.md`.
 
 ## Anti-patterns
 
@@ -211,10 +208,3 @@ Full Expo Module (Swift + Kotlin + view), the Turbo Module codegen-spec walkthro
 | Index as list key | Breaks recycling, reorders rows on insert | Stable domain id |
 | Doing native config / `eas.json` / OTA here | Wrong skill; this is app code | `../expo/SKILL.md` |
 | Hardcoded notch/safe-area padding | Wrong on other devices/orientations | `react-native-safe-area-context` insets |
-
-## Cross-references
-
-- Building, signing, OTA, native config → `../expo/SKILL.md`
-- Dart cross-platform alternative → `../flutter/SKILL.md`
-- Layout/visual design decisions → `../design/SKILL.md`
-- Systematic runtime fault isolation → `../debug/SKILL.md`

--- a/skills/react-native/scripts/verify.sh
+++ b/skills/react-native/scripts/verify.sh
@@ -42,6 +42,7 @@ flag() { # message + matching lines
   findings=1
   printf '%s[finding]%s %s\n' "$YELLOW" "$RESET" "$1"
   [ -n "${2:-}" ] && printf '%s\n' "$2" | sed 's/^/    /'
+  return 0 # never let a message-only finding trip set -e and skip the remaining checks
 }
 
 md_files() { # SKILL.md + every references/*.md
@@ -86,11 +87,13 @@ if [ -n "$bare" ]; then
   done < "$SKILL"
 fi
 
-# 4) Description must carry the Triggers: label and a NOT-boundary.
+# 4) Description shape: a "Use when/to" lead, a NOT-boundary, and no keyword trigger list
+#    (the model matches by meaning; a phrase list is per-turn cost for every install).
 desc="$(grep -m1 -E '^description:' "$SKILL" 2>/dev/null || true)"
 if [ -n "$desc" ]; then
-  printf '%s' "$desc" | grep -q 'Triggers:' || flag "description missing 'Triggers:' label"
+  printf '%s' "$desc" | grep -qE 'Use (when|to) ' || flag "description does not open with 'Use when/to'"
   printf '%s' "$desc" | grep -qE 'NOT ' || flag "description missing a 'NOT <x> (that is <sibling>)' boundary"
+  printf '%s' "$desc" | grep -q 'Triggers:' && flag "description carries a 'Triggers:' keyword list -> delete it, the model matches by meaning" ""
 fi
 
 # 5) No cross-ref to a sibling that does not exist on disk next to this skill.


### PR DESCRIPTION
## Numbers

| | Before | After |
|---|---|---|
| `description` | 722 chars | **348 chars** |
| Body | 12264 bytes / 220 lines | **11715 bytes / 210 lines** |
| `eval-lint` | — | **PASS** (should_trigger=6, should_not_trigger=5, capability=1) |
| `scripts/verify.sh` | exit 1 (stale check) | exit 0 on the skill and on an empty target |

## What went

- **The `Triggers:` phrase list** — 9 quoted phrases across English, Catalan and Spanish. The description is in context on every turn the skill is installed, invoked or not; the model matches by meaning, so the list was pure per-turn cost. This is the bulk of the 722 → 348 saving.
- **The trailing `## Cross-references` index.** `../expo/SKILL.md` was already stated twice inline (verb table + anti-patterns row), and the flutter boundary is in the description. The two pointers that existed *only* in the index moved to their point of use: `../design/SKILL.md` next to safe-area/layout, `../debug/SKILL.md` at the end of the debugging list. No link was dropped without a replacement.
- **The `## What this skill owns` heading** and the sentence ("the pipeline around it … is not yours") that restated what the verb table's second row already says.

## What stayed, on purpose

- **The verb table.** `react-native` vs `expo` is the boundary users actually get wrong, and it is a genuine branch — not a restatement of the description.
- **The anti-patterns table**, all ten rows, already in `Anti-pattern | Why it hurts | Do instead` shape with no borrowed urgency/rationalization framing.
- **Every load-bearing claim verbatim**: the New Architecture mandate (RN 0.82 / SDK 55), the SDK→RN map, the FlashList ~100-item threshold, Reanimated 3 vs 4, React Compiler GA in SDK 54, the router and native-module decision tables, and all bad/good code pairs. This was a context-engineering pass, not a content rewrite.

## One in-scope script fix

`scripts/verify.sh` check 4 required the description to **carry** a `Triggers:` label — it encoded the exact convention this migration removes, so it failed by design the moment the skill was migrated. It now checks the `Use when/to` lead and the `NOT … (that is <sibling>)` boundary, and flags a `Triggers:` list as the violation it now is. `flag()` also returns 0 so a message-only finding can no longer trip `set -e` and silently skip the remaining checks.

## Verified

- Both `references/` files are still linked inline from the body (`native-modules.md`, `performance-debugging.md`).
- Every `../<sibling>/SKILL.md` link resolves (`expo`, `design`, `debug`).
- Every `route_to` in `evals/cases.yaml` names a real skill (`expo`, `flutter`, `nextjs`, `ship`) — no stale "not in this catalog" claims, nothing left quoting a deleted trigger phrase.
- `manifest.json` untouched.