### PR TITLE
refactor(prisma-orm): Claude-5-era context pass — 922→381 char description

### DIFF
--- a/skills/prisma-orm/SKILL.md
+++ b/skills/prisma-orm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prisma-orm
-description: "Use when modeling data or writing type-safe queries with Prisma ORM in TypeScript and hitting its classic problems: N+1 on relations, over-fetching with fat include, an unbounded findMany scanning the whole table, the v7 'requires either adapter or accelerateUrl' error, or a Prisma 6 to 7 upgrade. Owns schema.prisma, the prisma-client generator, prisma.config.ts, the Prisma Client query API, and Prisma Migrate. Triggers: 'PrismaClient requires either adapter or accelerateUrl', 'client is not in node_modules anymore', 'relationLoadStrategy join vs query', 'migrate dev vs migrate deploy in CI', 'findMany returns the whole table', 'modela el esquema de usuarios y pedidos con Prisma', 'migració de Prisma a la versió 7'. NOT the schema-as-TS SQL-builder ORM (that is drizzle-orm), NOT cross-cutting zero-downtime migration strategy (that is db-migrations), NOT Postgres server tuning and EXPLAIN (that is postgresdb)."
+description: "Use when modeling data or writing type-safe queries with Prisma ORM in TypeScript — `schema.prisma`, `prisma.config.ts`, the generated Prisma Client, and Prisma Migrate, including the v6 to v7 upgrade. NOT schema-as-TS with a SQL builder (that is `drizzle-orm`), NOT ORM-agnostic zero-downtime migration (that is `db-migrations`), NOT Postgres engine tuning (that is `postgresdb`)."
 tags:
   - prisma
   - prisma-orm
@@ -286,8 +286,8 @@ Rules with teeth:
 
 Failed-migration recovery, baselining an existing database, and the full Prisma 6 to 7
 upgrade are in `references/migrations-and-v7-upgrade.md`. For ORM-independent evolution
-strategy (expand/contract, dual-write, zero-downtime backfills) that is the `db-migrations`
-skill.
+strategy (expand/contract, dual-write, zero-downtime backfills) that is
+`../db-migrations/SKILL.md`.
 
 ## Anti-patterns
 
@@ -311,10 +311,3 @@ Run `scripts/verify.sh <path>` to statically check emitted artifacts: it confirm
 `prisma-client` generator + `output`, an adapter on the constructor, and flags
 `$queryRawUnsafe` injection, `binaryTargets`, unbounded `findMany`, and wrong-ORM
 contamination. Read-only; no database connection.
-
-## References
-
-- `references/queries-and-performance.md` — query cookbook, `relationLoadStrategy` matrix,
-  transactions, generated types, the perf checklist, and the raw-SQL safety matrix.
-- `references/migrations-and-v7-upgrade.md` — migrate workflow detail, failed-migration
-  recovery, baselining, and the full Prisma 6 to 7 upgrade.

--- a/skills/prisma-orm/evals/cases.yaml
+++ b/skills/prisma-orm/evals/cases.yaml
@@ -21,8 +21,8 @@ should_trigger:
     why: Non-obvious v7 change — generated output path replaces the node_modules import.
   - prompt: "Necessito fer la migració de Prisma a la versió 7, què he de canviar a schema.prisma i al client?"
     why: >
-      Catalan phrasing matching the description's stated coverage — the v6 to 7 upgrade
-      (generator rename, output, adapter, prisma.config.ts) is explicitly owned here.
+      Catalan phrasing of the v6 to 7 upgrade (generator rename, output, adapter,
+      prisma.config.ts), which this skill owns.
 
 should_not_trigger:
   - prompt: "Set up the same schema using Drizzle's pgTable and drizzle-kit"


### PR DESCRIPTION
Claude-5-era context pass on `prisma-orm`. Format only — no recommendation, version,
command or figure changed.

## Numbers

| | Before | After |
| --- | --- | --- |
| `description` | 922 chars | **381 chars** |
| body | 12891 bytes / 320 lines | **12009 bytes / 313 lines** |
| eval-lint | — | **PASS** (should_trigger=8, should_not_trigger=5, capability=1) |

## What went

- **The `Triggers:` list** — 7 phrases across English, Spanish and Catalan
  (`'PrismaClient requires either adapter or accelerateUrl'`, `'migrate dev vs migrate
  deploy in CI'`, `'modela el esquema de usuarios y pedidos con Prisma'`, …). The model
  matches by meaning, so a trilingual keyword list is pure per-turn cost, and every
  symptom it named is still in the body where it is actionable — the adapter error under
  "Instantiate the client", unbounded `findMany` under "Query safely",
  `relationLoadStrategy` under "Performance", dev-vs-deploy in the migrations table.
- **The symptom preamble and the "Owns …" sentence** in the description. "hitting its
  classic problems: N+1 …, over-fetching …, unbounded findMany …" and "Owns schema.prisma,
  the prisma-client generator, prisma.config.ts, the Prisma Client query API, and Prisma
  Migrate" said the same thing twice, and the body is where either belongs.
- **The trailing `## References` index.** Both reference files are already linked inline at
  the point of use — `queries-and-performance.md` from "Query safely", "Performance" and
  "Raw SQL safely"; `migrations-and-v7-upgrade.md` from "Migrations". The invariant holds:
  every file under `references/` is still reachable from the body.

The new description keeps the discriminating boundary against all three near siblings:
schema-as-TS with a SQL builder → `drizzle-orm`, ORM-agnostic zero-downtime migration →
`db-migrations`, Postgres engine tuning → `postgresdb`. All three exist under `skills/`.

## What stayed, and why

- **The entire body.** It already met the rubric before this pass: 313 lines, references
  linked inline, decision tables only where the flow actually branches (pagination
  offset-vs-cursor, array-vs-interactive transactions, `migrate dev` vs `migrate deploy`
  vs `db push`).
- **The anti-patterns table**, all 11 rows, unchanged. It is already
  `Anti-pattern | Why it bites | Do instead` — concrete failure modes, no borrowed urgency
  or Excuse→Reality framing to strip, so there was nothing to re-column.
- **The v7 non-negotiables**, the dated version note (7.7.0 / 2026-04-07 changelog, the
  Prisma Next Early Access caveat with its two cited posts), and every bad/good code pair.
  Dimension 4 grounding is load-bearing here and untouched.
- No result-envelope block existed, and none was invented.

## Two small correctness fixes

- `db-migrations` was named in bare backticks in the migrations section while the other two
  siblings were proper links; it is now `../db-migrations/SKILL.md`.
- One `evals/cases.yaml` `why` justified its Catalan case by "matching the description's
  stated coverage" — a claim the trimmed description no longer makes. Reworded to rest on
  the skill's ownership of the v6→v7 upgrade instead. The case itself is unchanged.

`scripts/verify.sh` was already executable and still exits 0 on an empty target.
`manifest.json` deliberately untouched — the orchestrator regenerates it.
