### PR TITLE
refactor(reporting): Claude-5-era description + body pass

### DIFF
--- a/skills/reporting/SKILL.md
+++ b/skills/reporting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reporting
-description: "Use when you need a recurring report that ships to stakeholders on a cadence — a weekly team digest, monthly exec pack, quarterly board summary, or recurring client performance report — and it must go out reliably without a human in the loop. Symptoms: a standing metrics email keeps breaking or shows stale numbers, the Monday digest is hand-assembled every week, leadership asks for 'the same report but every month', or a client expects a PDF on a schedule. Triggers: 'set up a weekly automated report emailed to the exec team', 'build a monthly PDF report for our biggest client on a schedule', 'send the board a quarterly summary every quarter', 'our Monday metrics email keeps going out with last week's numbers — make it reliable', 'automatiza un informe mensual para dirección', 'munta un informe setmanal automàtic per al comitè'. NOT a live screen people open to slice metrics (that is dashboard), NOT deciding which KPIs to track (that is kpi-framework), NOT a one-off investigation (that is analytics)."
+description: "Use when a recurring report must ship itself on a cadence — weekly digest, monthly exec pack, board pack — via a fetch→narrate→render→deliver pipeline with a schedule and a freshness gate. NOT a live view people slice (that is `dashboard`), NOT picking which KPIs to track (that is `kpi-framework`), NOT a one-off investigation (that is `analytics`)."
 tags: [reporting, automated-reports, recurring, stakeholder-reporting, scheduled-delivery, data-analytics]
 recommends: [dashboard, kpi-framework, analytics, automation-flows, email-connector, spreadsheet-ops, google-workspace, notion-connector, github-actions]
 origin: risco
@@ -10,9 +10,10 @@ origin: risco
 
 A report is a **push** artifact: a fixed snapshot that lands in someone's inbox or shared drive on a
 cadence, the same shape every period, with no human assembling it. That is the whole job. If a human
-opens a live view to slice numbers themselves, that is **pull** — a dashboard, not a report. Hold that
-line; almost every failed "reporting" project is a dashboard wearing a report's name, or a report
-nobody can trust because the numbers went stale and no one noticed.
+opens a live view to slice numbers themselves, that is **pull** — a
+[`dashboard`](../dashboard/SKILL.md), not a report. Hold that line; almost every failed "reporting"
+project is a dashboard wearing a report's name, or a report nobody can trust because the numbers went
+stale and no one noticed.
 
 Your deliverable is a **runnable pipeline**, not advice: a template, a generation script, a schedule,
 and a delivery step, with a freshness gate so it fails loud instead of shipping yesterday's numbers.
@@ -32,24 +33,23 @@ is a number no one can defend.
 | **Owner** | Who gets paged when it breaks | a named person, not "the team" |
 
 Rule: you **consume** an agreed metric set — you do not adjudicate which KPIs matter. If the ask is
-"which metrics should we even track?", that is kpi-framework, not this skill. The contract names the
-source and its owner so a wrong number has an address.
+"which metrics should we even track?", that is [`kpi-framework`](../kpi-framework/SKILL.md), not this
+skill. The contract names the source and its owner so a wrong number has an address.
 
 ## Decide: push report vs live dashboard (this branches — settle it first)
 
-Audiences want a consistent, citable snapshot for the period far more often than a live feed; that is
-why scheduled push beats a dashboard for exec summaries, weekly reviews, and finance close packs.
+Audiences want a citable snapshot for the period more often than a live feed — that is why push wins
+for exec summaries, weekly reviews, and finance close packs.
 
 | Signal in the ask | Route |
 | --- | --- |
 | "Same summary, every week/month/quarter" | **reporting** (here) |
 | "Consistent snapshot the board can cite in a meeting" | **reporting** (here) |
 | "It must arrive even if no one logs in" | **reporting** (here) |
-| "A screen people open to filter/drill live" | **dashboard** |
-| "Self-serve, slice by region/date on demand" | **dashboard** |
+| "A screen people open to filter/drill live" | [`dashboard`](../dashboard/SKILL.md) |
+| "Self-serve, slice by region/date on demand" | [`dashboard`](../dashboard/SKILL.md) |
 
-When both are wanted, build the report; let it link to the dashboard as a "go deeper" footer. Do not
-email a dashboard link and call it a report — see the anti-patterns table.
+When both are wanted, build the report and let it link to the dashboard as a "go deeper" footer.
 
 ## Pick the artifact format
 
@@ -120,7 +120,7 @@ Bad → Good, the difference that decides whether the report is useful:
 - **Bad:** a table row `Revenue | 248,300 | 201,400`. The reader must do the math and guess if it matters.
 - **Good:** "Revenue up 23.3% WoW (€248,300 from €201,400) — investigate: driven by the enterprise renewal that won't recur next week."
 
-Never ship a raw metric dump with no narrative. The numbers are the evidence; the sentence is the report.
+The numbers are the evidence; the sentence is the report.
 
 ## Schedule + reliability gate (where reports actually die)
 
@@ -145,7 +145,8 @@ does not teach scheduling in general. The actual transport (SMTP/Gmail send) bel
 
 - [ ] **Freshness gate before send** — assert the source is newer than the last period; if stale, do
       NOT send, raise instead. A report that consumes dirty data is not this skill's job to clean —
-      that is data-cleaning; this gate only refuses to ship known-stale numbers.
+      that is [`data-cleaning`](../data-cleaning/SKILL.md); this gate only refuses to ship
+      known-stale numbers.
 - [ ] **Fail loud** — on any error, alert the owner (the report not arriving is itself a silent failure).
 - [ ] **Idempotent run** — re-running for the same period produces the same artifact, no duplicate send.
 - [ ] **Dead-report cleanup** — if no one opened the last N editions, kill the schedule. Unread reports
@@ -161,18 +162,15 @@ does not teach scheduling in general. The actual transport (SMTP/Gmail send) bel
 | Raw metric dump, no narrative | Reader does the math, misses what changed, stops opening it | Exec summary + 3 takeaways + a "so what" per section |
 | Schedule with no failure alert | A broken job is invisible for weeks; the report just stops | Fail loud to the named owner on any error |
 | A template forked per recipient | Layout change must be made N times; they drift | Single template scoped by `params` |
-| Redefining KPIs inside the report | The report quietly becomes the metric authority, numbers diverge | Consume an agreed set; defer definition to kpi-framework |
+| Redefining KPIs inside the report | The report quietly becomes the metric authority, numbers diverge | Consume an agreed set; defer definition to [`kpi-framework`](../kpi-framework/SKILL.md) |
 | Unpinned WeasyPrint / render lib | A minor bump reflows the board pack with no warning | Pin (WeasyPrint 68.1) and re-check PyPI before changing |
 | Hand-assembling the digest weekly | It breaks the week the owner is on leave | Automate the pipeline end to end; a human only reads it |
 
 ## Verify
 
 Run `scripts/verify.sh` (read-only; pass a path to a generated pipeline directory, or run in it). It
-confirms a Jinja2 template exists and renders against a sample context without error, that the
-generation script produces a non-empty PDF/HTML artifact, that a schedule definition exists (a crontab
-line or a `.github/workflows/*.yml` with a `schedule:` block), and that a delivery step is wired. It
-soft-warns if no freshness/failure gate is detected. On an empty/clean target it exits 0 — nothing to
-check is not a failure.
-
-References: [`pipeline.md`](references/pipeline.md) — full template, chart embed, per-recipient loop,
-GitHub Actions `schedule:` YAML, freshness gate, and failure alert.
+confirms a Jinja2 template renders against a sample context without error, the generation script
+produces a non-empty PDF/HTML artifact, a schedule definition exists (a crontab line or a
+`.github/workflows/*.yml` with a `schedule:` block), and a delivery step is wired. It soft-warns if no
+freshness/failure gate is detected, and exits 0 on an empty/clean target — nothing to check is not a
+failure.


### PR DESCRIPTION
Migrates `reporting` to the `scripts/skill-rubric.md` rubric. Context-engineering pass only — no recommendation, version, figure or command changed.

## Numbers

| | Before | After |
|---|---|---|
| `description` | 1014 chars | **350 chars** |
| `SKILL.md` | 11695 bytes / 178 lines | **10841 bytes / 176 lines** |
| eval-lint | — | **PASS** (should_trigger=6, should_not_trigger=6, capability=1) |

## Description

Was a Symptoms paragraph plus a six-phrase trilingual `Triggers:` list — paid for on every turn the skill is installed, invoked or not, to do a keyword job the model already does by meaning. Now: what it does, when it fires, and three boundaries against siblings that exist under `skills/` (`dashboard`, `kpi-framework`, `analytics`).

> Use when a recurring report must ship itself on a cadence — weekly digest, monthly exec pack, board pack — via a fetch→narrate→render→deliver pipeline with a schedule and a freshness gate. NOT a live view people slice (that is `dashboard`), NOT picking which KPIs to track (that is `kpi-framework`), NOT a one-off investigation (that is `analytics`).

The trilingual eval prompts (`automatiza un informe mensual para dirección`, `munta un informe setmanal automàtic per al comitè`) are kept — they now test the semantic matching the skill relies on instead of a literal string it carried in context.

## Removed from the body

- The trailing `References:` index. `references/pipeline.md` is already linked inline at both points of use, so the tail entry was a duplicate link; the invariant that every `references/` file stays reachable from the body holds.
- Two sentences that restated anti-patterns rows word for word: "Do not email a dashboard link and call it a report" and "Never ship a raw metric dump with no narrative". The non-duplicated halves next to them survive.
- One clause of padding in the push-vs-dashboard rationale, and prose in `## Verify` — every check `verify.sh` actually performs is still named.

## Kept deliberately

- **The nine-row anti-patterns table, whole.** Required by dimension 3, and it is the real article rather than the rationalization variant: concrete failure modes (unpinned WeasyPrint reflowing a board pack, a template forked per recipient, an unread report left on a schedule), already columned `Anti-pattern | Why it bites | Do instead`, no STOP/excuse framing to strip.
- The four branching tables — report contract, push-vs-pull routing, artifact format, scheduler choice.
- The bad/good narrative pair, which teaches the judgment by demonstration.
- No result-envelope block was added; this skill never had one.

## Also fixed

`dashboard`, `kpi-framework` and `data-cleaning` were named as routes in bare prose. Now linked, so the handoff the text promises can be taken. All nine `../<sibling>/SKILL.md` links resolve.

`manifest.json` untouched (derived). `npm test` / `npm run validate` not run — no `node_modules` in the worktree, per the brief.
