### PR TITLE
refactor(nestjs): Claude-5-era description and body pass

### DIFF
--- a/skills/nestjs/SKILL.md
+++ b/skills/nestjs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nestjs
-description: "Use when building or structuring a NestJS backend — feature modules, providers, controllers, DI wiring, and the cross-cutting layer (guards, interceptors, pipes, exception filters) — including binding-scope and request-lifecycle decisions and Nest-specific testing. Triggers: 'create a NestJS module', 'wire a custom provider with useFactory', 'APP_GUARD vs @UseGuards on the controller', 'my request-scoped provider is undefined in a guard', 'A circular dependency has been detected at bootstrap', 'mock a repository provider with overrideProvider', 'monta un módulo de Nest', 'guard de autenticación JWT en NestJS'. NOT a bare Express/Node service with no DI (that is nodejs)."
+description: "Use when building or structuring a NestJS backend — feature modules, providers and DI wiring, provider scopes and request-lifecycle order, where to bind guards/pipes/interceptors/filters, and testing with Test.createTestingModule. NOT a bare Express/Fastify service with no DI (that is `nodejs`), NOT framework-agnostic REST design (that is `api-design`)."
 tags: [nestjs, nodejs, backend, dependency-injection, guards, pipes, testing, typescript]
 recommends: [nodejs, typescript, api-design, prisma-orm, testing-web]
 origin: risco
@@ -10,15 +10,7 @@ origin: risco
 
 Build server-side Node apps the way NestJS intends: feature modules, providers wired through the DI container, controllers, and a cross-cutting layer bound at a deliberate scope. This skill is about Nest-specific mechanics — how DI scopes resolve, what order the request lifecycle runs in, where to bind guards/pipes/interceptors/filters, and how to test it with `Test.createTestingModule`.
 
-## Use this when
-
-- Scaffolding or extending a Nest app: new module, controller, provider, resolver.
-- Wiring DI: `useClass` / `useValue` / `useFactory` / `useExisting`, injection tokens, `forwardRef`, dynamic modules (`forRoot` / `forRootAsync`).
-- Adding cross-cutting behavior and deciding global vs controller vs route binding.
-- "Why is my request-scoped provider undefined" / "circular dependency detected at bootstrap".
-- Unit tests with mock providers and e2e tests with Supertest against the real Nest app.
-
-## Not this when
+## Not this — route instead
 
 - Bare Express/Fastify/`http` service, no `@Module`/`@Injectable` → `../nodejs/SKILL.md`. Nest starts the moment the DI container appears.
 - REST resource modeling, versioning, status codes, idempotency (framework-agnostic) → `../api-design/SKILL.md`. Nest is where you *implement* those decisions.


### PR DESCRIPTION
Context-engineering pass on `skills/nestjs/` against `scripts/skill-rubric.md`. No content, version, command or recommendation changed.

**Description:** 671 → 355 chars. Dropped the eight-phrase bilingual `Triggers:` list (the model matches by meaning; that list was paid for on every turn the skill is installed) and added an explicit two-way boundary: NOT a bare Express/Fastify service with no DI (`nodejs`), NOT framework-agnostic REST design (`api-design`). Both siblings verified present under `skills/`.

**Body:** 12618 → 11787 bytes (226 → 218 lines).

Removed:
- the `Triggers:` phrase list (frontmatter)
- the `## Use this when` bullet list — a third restatement of the routing signal; each bullet is already covered at point of use (provider forms in "Providers & DI", the undefined-request-scoped-provider-in-a-guard gotcha in "Provider scopes", the unit/e2e split in "Testing")

Kept, on purpose:
- the sibling routing list, retitled `## Not this — route instead` — it delegates by name with a reason, which is substance, not a description echo
- all four decision tables (custom-provider form, provider scope, cross-cutting primitive, binding scope) — the flow really branches on each, and they do not overlap
- the anti-patterns table verbatim, as the rubric requires
- every code sample and the NestJS 11 / Node 20+ / Express v5 / SWC / Vitest claims

**Verification:** `bash scripts/eval-lint.sh` → `nestjs PASS (should_trigger=5, should_not_trigger=4, capability=1)`. `scripts/verify.sh` is executable and exits 0 on an empty target. Both `references/` files (`cross-cutting.md`, `testing-recipes.md`) remain linked inline from the body. `manifest.json` untouched.