### PR TITLE
refactor(together-fireworks): Claude-5-era description + drop duplicate reference index

### DIFF
--- a/skills/together-fireworks/SKILL.md
+++ b/skills/together-fireworks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: together-fireworks
-description: "Use when calling hosted open-model inference on Together AI or Fireworks AI — pointing the OpenAI SDK at api.together.ai or api.fireworks.ai, picking an open model (Llama, DeepSeek, Qwen, GPT-OSS) and what it costs, or cutting the bill with batch inference. Triggers: 'call DeepSeek/Llama on Together', 'wire the OpenAI SDK to Fireworks', 'why is my model name 404ing', 'which open-source model and how much per million tokens', 'halve my LLM bill with batch', 'move off GPT-4 to a cheaper open-weights endpoint', 'serverless vs dedicated for sustained QPS', '¿qué modelo open source uso y cuánto cuesta?', 'abaratar la factura de inferència'. NOT renting raw GPUs to self-host weights (that is runpod), NOT running a model locally with zero marginal cost (that is ollama)."
+description: "Use when calling open-weight LLMs on Together AI or Fireworks AI's OpenAI-compatible endpoints — `base_url` plus namespaced model id, the cheapest model that clears the bar, per-1M-token cost math, serverless vs batch vs dedicated. NOT renting GPUs to self-host weights (that is `runpod`), NOT running a model locally for free (that is `ollama`)."
 tags: [llm, inference, together-ai, fireworks-ai, openai-compatible, open-models, batch, cost]
 recommends: [runpod, modal, ollama, huggingface, fal, cost-tracking, llm-pipeline, prompt-engineering, embeddings-search]
 origin: risco
@@ -107,7 +107,7 @@ Fuller catalog and embedding/fine-tuning numbers: `references/models-and-pricing
 
 Decision: **real-time → serverless. Big offline job (eval, synthetic data, bulk classify) → batch. Sustained heavy traffic with an SLA → dedicated.**
 
-> **Gotcha — Together batch is NOT the OpenAI Batch endpoint.** Together's OpenAI-compat layer does **not** expose `/v1/batches`. Use Together's **native Batch API**: upload a JSONL file, default **24h** window, up to **50,000 requests/file**, up to **50% off**, separate rate-limit pool. Pointing the OpenAI Batch client at Together fails. Fireworks instead exposes Batch as a serving *path* through the one API (Serverless 2.0: Standard / Priority / Batch), batch = 50% of serverless. See `references/batch-and-tuning.md`.
+> **Gotcha — Together batch is NOT the OpenAI Batch endpoint.** Together's OpenAI-compat layer does **not** expose `/v1/batches`. Use Together's **native Batch API**: upload a JSONL file, default **24h** window, up to **50,000 requests/file**, up to **50% off**, separate rate-limit pool. Pointing the OpenAI Batch client at Together fails. Fireworks instead exposes Batch as a serving *path* through the one API (Serverless 2.0: Standard / Priority / Batch), batch = 50% of serverless. JSONL shape, the upload/poll/download flow, limits, and dedicated-deployment notes: `references/batch-and-tuning.md`.
 
 Two more Fireworks multipliers worth knowing:
 - **Cached input tokens default to 50%** of input price (text/vision models) — repeated prefixes get cheaper automatically.
@@ -172,10 +172,5 @@ Keep the id mapping in config, not in `if provider == ...` branches scattered th
 | Quoting a price/id from an aggregator | Trackers lag and mis-list — e.g. DeepSeek-V3.1 shown as live on Together when it is not on the serverless catalog | Cite together.ai/pricing or docs.fireworks.ai; confirm the id on the serverless catalog before quoting |
 | Treating these like free/local | They bill per token; ollama is the zero-marginal-cost path | If cost must be zero and weights run on your box → `../ollama/SKILL.md` |
 | Renting GPUs to "save money" then idling them | A serverless token endpoint has no idle cost | Self-host only at sustained scale → `../runpod/SKILL.md` |
-
-## References
-
-- `references/models-and-pricing.md` — fuller per-provider model + pricing tables, embeddings, fine-tuning costs, with a re-check note.
-- `references/batch-and-tuning.md` — Together native Batch API JSONL shape + upload/poll/download flow and limits; Fireworks batch path; dedicated deployment notes.
 
 Validate any inference snippet/config with `scripts/verify.sh <file-or-dir>` — a static, no-network lint for the right base URLs, namespaced model ids, and env-var keys.


### PR DESCRIPTION
## Numbers

| | Before | After |
|---|---|---|
| `description` chars | 773 | 346 |
| SKILL.md bytes | 14076 | 13404 |
| SKILL.md lines | 181 | 176 |

eval-lint: **PASS** (should_trigger=7, should_not_trigger=6, capability=1)

## What went

- The `Triggers:` list — nine quoted phrases across English, Spanish and Catalan. It sat in context on every turn the skill was installed, invoked or not, and the model routes by meaning anyway. The kept description is what it does, when to use it, and the two boundaries that discriminate: `runpod` (renting GPUs to self-host) and `ollama` (local, zero marginal cost). Both verified to exist under `skills/`.
- The trailing `## References` index. Both files were already linked inline where they are needed — `references/models-and-pricing.md` under "Pick the model", `references/batch-and-tuning.md` in the Together-batch gotcha. The only detail the tail carried that the inline mention did not (dedicated-deployment notes) was folded into the inline sentence, so every `references/` file is still linked from the body.

## What stayed, and why

- **Anti-patterns table** — every row names a concrete failure mode (bare model id 404s, OpenAI Batch client against Together, budgeting at Priority rates), not a rule restated from above. The rubric requires one.
- **Both endpoint tables** and the cross-provider id mapping — the `base_url` / namespace shapes are the whole point of the skill.
- **Serving-mode decision table** — the flow genuinely branches (serverless / batch / dedicated).
- **Dated pricing rows** with their `(projected)` tags, the "read the provider page" instruction, and the Fireworks size-tier fallback — dimension 4 material, left byte-for-byte.
- **Worked cost arithmetic** and the bad → good pairs, which teach by demonstration.

No recommendations, versions, commands, figures or claims changed — this is a context pass, not a content rewrite. `scripts/verify.sh` was already executable and makes no assertion about the description. `manifest.json` untouched.