### PR TITLE
fix(data-scraper): robots.txt is advisory, not a blocking legal gate

### DIFF
--- a/skills/data-scraper/SKILL.md
+++ b/skills/data-scraper/SKILL.md
@@ -18,13 +18,15 @@ In 2025-2026 scrapers do not fail on parsing. They fail on a terms-of-service br
 
 Walk every item. Each ends in **proceed**, **proceed-narrowed**, or **stop**. One item at stop means the whole scrape stops until you resolve it. Depth and the case law are in `references/legal-compliance.md`.
 
+The gates below are the ones with real legal exposure — contract, data-protection law, and anti-circumvention. **robots.txt is not one of them**: it is a voluntary convention with no statutory force, so it informs the decision and never blocks it on its own.
+
 - [ ] **Is there an API?** If yes, you are in the wrong skill — never scrape what an API serves. → otherwise proceed.
 - [ ] **Did you read the ToS, and does login/auth apply?** Scraping is most exposed as *breach of contract* when you accepted terms — typically by logging in (*Meta v. Bright Data*, 2024). Logged-out public data weakens that claim. **Prefer logged-out public pages; never bypass auth.** → narrow to public, or stop.
 - [ ] **Is it personal data?** Names, emails, photos, reviews, IP addresses all count. Scraping public personal data for a *new* purpose — aggregation, resale, AI training — is a severe GDPR breach with fines into the tens of millions of EUR. You need a lawful basis (usually legitimate interest) and data minimization. Filter out special categories at the source. → proceed-narrowed (basis + minimization, see `../gdpr-privacy/SKILL.md`), or stop.
-- [ ] **robots.txt and ai.txt?** Honor disallow rules and AI-objection signals. Ignoring them is the first fact cited against you. → narrow the path set, or stop.
+- [ ] **robots.txt and ai.txt?** Read them — they are a *convention*, not law, so this item never stops a scrape on its own. A `Disallow` tells you the host would rather you did not, and `Crawl-delay` tells you its tolerance; both are useful intelligence about where you are likely to get blocked. Weigh it: honoring robots is the low-friction default and the cleanest evidence of good faith, but scraping your own site, one you have permission for, or public pages for research is legitimate whether or not robots allows it. → **advisory: note the decision and move on.**
 - [ ] **Are you about to bypass a control you were shown?** A CAPTCHA, a hard block, an enforced rate limit. *Reddit v. Perplexity AI* (2025) turns precisely on whether anti-bot measures were circumvented — a materially worse position than respectfully pacing public pages. Pacing public data is defensible; defeating a control is the frontier where you lose. → **stop. Do not solve the CAPTCHA. Do not bypass the block.**
 
-`hiQ v. LinkedIn` established that scraping *public* data is not automatically a CFAA violation — but that is the floor, not a license. Public + logged-out + robots-honored + no-personal-data is the defensible quadrant. Anything else, document why and get a human to sign off.
+`hiQ v. LinkedIn` established that scraping *public* data is not automatically a CFAA violation — but that is the floor, not a license. Public + logged-out + no-personal-data is the defensible quadrant, and honoring robots keeps it tidy without being what makes it lawful. Anything outside it, document why and get a human to sign off.
 
 ## Extraction-path decision table
 
@@ -113,7 +115,7 @@ A recurring crawler must survive crashes, redeploys, and the target's schema dri
 | Anti-pattern | Why it bites | Do instead |
 |---|---|---|
 | Scraping behind a login, then calling it "public data" | Accepting ToS at login is the breach-of-contract hook (*Meta v. Bright Data*) | Stay logged-out on public pages; never bypass auth |
-| Ignoring robots.txt / ai.txt | First fact cited against you; signals bad faith | Parse and honor both before queuing URLs |
+| Not even reading robots.txt / ai.txt | You lose free intelligence on where you will get blocked, and any good-faith story later | Parse both; honor by default, override deliberately and write down why |
 | No delay, unbounded concurrency | Hammers the host → IP ban, possible CFAA-style exposure | 1 req / 1-3s, cap 2-5 concurrent per host |
 | Selectors on `nth-child` / `.css-1a2b3c` hashes | Break on the next deploy; silent data loss | Anchor on `data-*` / semantic / text, with fallbacks |
 | Silently writing `null` on a missing field | Corrupts the dataset; discovered months later | Raise on a missing *required* field — fail loud |

--- a/skills/data-scraper/references/legal-compliance.md
+++ b/skills/data-scraper/references/legal-compliance.md
@@ -4,7 +4,9 @@ Depth behind the legal gate in `../SKILL.md`. You are not a lawyer and you never
 
 ## robots.txt and ai.txt
 
-Fetch and honor both before queuing a single URL. `robots.txt` governs crawler access by user-agent and path; `ai.txt` (and the `noai` / `noimageai` signals some sites publish) is the emerging objection channel for AI training use specifically.
+Fetch both before queuing URLs. `robots.txt` states crawler preferences by user-agent and path; `ai.txt` (and the `noai` / `noimageai` signals some sites publish) is the emerging objection channel for AI training use specifically.
+
+**Neither is law.** robots.txt is a voluntary convention from 1994 with no statutory force — no jurisdiction makes a `Disallow` binding by itself, and courts treat it as evidence of the parties' expectations, not as the thing you violated. So it is input to your decision, never a hard stop. What *is* binding sits in the sections below: an accepted ToS, data-protection law, and anti-circumvention.
 
 ```python
 import urllib.robotparser, urllib.parse
@@ -19,9 +21,12 @@ def allowed(url: str, ua: str = "my-crawler") -> bool:
 
 Rules:
 
-- A `Disallow` for your path is a stop for that path, not a suggestion. Narrow the URL set.
-- Respect `Crawl-delay` if present — it is the host telling you its tolerance.
-- An `ai.txt` / `noai` objection means do not use the data for AI training, even if the page is public. Honor it; it is the cleanest evidence of good faith.
+Working defaults — deviate consciously, not by accident:
+
+- A `Disallow` for your path is the host's stated preference. Honoring it is the default and costs you little; overriding it is a judgment call you record, not a rule you break. Scraping your own property, a site you have written permission for, or public pages for research and archiving are all ordinary reasons to override.
+- Respect `Crawl-delay` if present — it is the host telling you its tolerance, and the cheapest way to not get banned.
+- An `ai.txt` / `noai` objection means the site objects to AI-training use. Honoring it is the cleanest evidence of good faith and matters most where the use is exactly what was objected to.
+- Whatever you decide, log it with the scrape. "We read robots, disallowed `/search`, proceeded anyway because X" is a defensible record; silence is not.
 
 ## ToS red flags
 


### PR DESCRIPTION
## What

The legal gate treated `robots.txt` as a blocking item that could end in **stop**, listed alongside ToS, personal data and anti-circumvention. This reclassifies it as advisory.

## Why

robots.txt is a voluntary convention from 1994 with **no statutory force**. Courts treat it as evidence of the parties' expectations, not as the thing that was violated. Listing it next to GDPR and CFAA-adjacent circumvention conflated a norm with binding law — and blocked ordinary legitimate work: scraping your own site, a site you have written permission for, or public pages for research.

## What changed

| File | Change |
|---|---|
| `SKILL.md` | Gate item is advisory ("note the decision and move on"); preamble names which gates actually bind; hiQ paragraph no longer implies robots-honored is what makes a scrape lawful; anti-pattern reframed to "not even reading it" |
| `references/legal-compliance.md` | States plainly that neither robots.txt nor ai.txt is law; rules become working defaults; adds "log the decision" |

Honoring robots stays the **default** — it is cheap, it is the cleanest good-faith evidence, and it tells you where you will get banned. Overriding is now a recorded judgment call rather than a rule violation.

## What deliberately did NOT change

The three gates with real legal exposure still end in **stop**:

- accepted-ToS / auth bypass (*Meta v. Bright Data*)
- personal data under GDPR
- circumventing a control you were shown (*Reddit v. Perplexity*)

`verify.sh` already only warned on a missing preflight (non-fatal unless `--strict`), so it was already consistent. Evals unchanged — they assert robots is *read*, never that it blocks.

## Gates

- `npm run validate` — OK
- `npm run manifest:check` — OK (258 skills)
- `bash scripts/eval-lint.sh` — `data-scraper PASS`
- `npm test` — 194 pass, 0 fail