### PR TITLE
fix(huggingface): replace the dangling boundary pointer with real links

### DIFF
--- a/skills/huggingface/SKILL.md
+++ b/skills/huggingface/SKILL.md
@@ -19,8 +19,9 @@ Hugging Face is three surfaces, and you should always know which one you are on:
 
 The whole skill is choosing the right surface for the job and proving it works: a 200 router
 response, a live endpoint URL, a pushed repo commit. If the model is open and the workflow
-lives on huggingface.co, you are in the right place. If you operate the GPU yourself, or the
-vendor is not HF, stop — see the boundaries at the bottom.
+lives on huggingface.co, you are in the right place. Operating the GPU box yourself is
+[`../ollama/SKILL.md`](../ollama/SKILL.md) (your machine) or [`../runpod/SKILL.md`](../runpod/SKILL.md)
+(a rented box); training weights is [`../finetuning/SKILL.md`](../finetuning/SKILL.md).
 
 ## Decision: how should I run this model?
 


### PR DESCRIPTION
## The defect

`skills/huggingface/SKILL.md` told the reader:

> If you operate the GPU yourself, or the vendor is not HF, stop — **see the boundaries at the bottom**.

There is no boundaries section at the bottom. The document ends at `## Anti-patterns` and `## verify.sh`. The pointer sent readers to a section that does not exist.

## The fix

Name the three destinations inline, which is where the reader was supposed to end up:

- `ollama` — running the model on your own machine
- `runpod` — renting and operating a GPU box
- `finetuning` — training the weights

## How it was found

Auditing the leftover migration branches before deleting them. An agent had already fixed this on `skill/huggingface`, but `main` took a **different** agent's rewrite of the same skill, and the fix never landed — two agents migrated `huggingface`, only one of the two results survived.

Taking the one-line fix rather than merging that branch: its description is the older of the two, so merging wholesale would revert `main` to the earlier wording.

## Gates

- `npm run validate` — OK
- `npm run manifest:check` — OK (258 skills)
- `bash scripts/eval-lint.sh` — `huggingface PASS`
- `npm test` — 194 pass, 0 fail