### PR TITLE
feat(sello): review receipts — the approval is bound to the exact bytes it approved

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -6,20 +6,33 @@ import { readState } from './lib/state.js';
 import { loadManifest } from './lib/manifest.js';
 import { listBackups } from './lib/backups.js';
 import { SDD_GATE_TEXT } from '../targets/hook-once.mjs';
-import { isEnabled, checkSello, readSello, countFindings } from '../targets/sello.mjs';
+import { isEnabled, checkSello, readSello, countFindings, readConfig, validateRiskConfig } from '../targets/sello.mjs';
 
 // The sello's health, surfaced where the user already looks (spec: non-blocking
 // findings live in the project and are SUMMARIZED here, never nagged about).
+// An INERT gate must never read as an armed one — a config that silently disables
+// enforcement is reported here, loudly.
 function selloStatus(root) {
   try {
     if (!isEnabled(root)) return { enabled: false };
     const sello = readSello(root);
-    return {
+    const verdict = checkSello(root);
+    const out = {
       enabled: true,
-      check: checkSello(root).code,
+      check: verdict.code,
       status: sello.missing ? 'none' : sello.corrupt ? 'corrupt' : sello.status,
       nonBlockingFindings: countFindings(root),
     };
+    if (verdict.warning) out.warning = verdict.warning;
+    if (verdict.code === 'no-trunk') out.inert = 'no-trunk';
+    if (existsSync(join(root, '.rsc', '.no-ship-guard'))) {
+      out.note = 'ship-guard branch-hygiene rules are opted out (.rsc/.no-ship-guard); the sello itself still enforces.';
+    }
+    try {
+      const { lowered } = validateRiskConfig(readConfig(root) || {});
+      if (lowered.length) out.loweredClasses = lowered;
+    } catch (e) { out.configError = e.message; }
+    return out;
   } catch { return { enabled: false }; }
 }
 

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -6,6 +6,22 @@ import { readState } from './lib/state.js';
 import { loadManifest } from './lib/manifest.js';
 import { listBackups } from './lib/backups.js';
 import { SDD_GATE_TEXT } from '../targets/hook-once.mjs';
+import { isEnabled, checkSello, readSello, countFindings } from '../targets/sello.mjs';
+
+// The sello's health, surfaced where the user already looks (spec: non-blocking
+// findings live in the project and are SUMMARIZED here, never nagged about).
+function selloStatus(root) {
+  try {
+    if (!isEnabled(root)) return { enabled: false };
+    const sello = readSello(root);
+    return {
+      enabled: true,
+      check: checkSello(root).code,
+      status: sello.missing ? 'none' : sello.corrupt ? 'corrupt' : sello.status,
+      nonBlockingFindings: countFindings(root),
+    };
+  } catch { return { enabled: false }; }
+}
 
 export function doctor({ target, home, cwd }) {
   const root = cwd || process.cwd();
@@ -25,6 +41,7 @@ export function doctor({ target, home, cwd }) {
       latest: backups[0]?.id || null,
     },
     contextBudget: contextBudget({ target, home, cwd }),
+    sello: selloStatus(root),
   };
   for (const [id, e] of Object.entries(state.skills)) {
     for (const f of e.files) if (!existsSync(f)) report.missing.push(`${id}:${f}`);

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -62,6 +62,7 @@ function generatedHookFiles({ target, cwd }) {
     join(cwd, '.rsc', 'danger-guard.mjs'),
     join(cwd, '.rsc', 'userprompt-gate.mjs'),
     join(cwd, '.rsc', 'hook-once.mjs'),
+    join(cwd, '.rsc', 'sello.mjs'),
   ];
 }
 

--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -327,6 +327,116 @@ async function main() {
       say('Use: npx @ericrisco/rsc registry refresh | registry status');
       return;
     }
+    case 'sello': {
+      // Deterministic transitions of the sello (review receipt). The `review` skill
+      // orchestrates the lenses; every state change and every check runs HERE, token-free.
+      const S = await import('../targets/sello.mjs');
+      const root = process.cwd();
+      const sub = argv[1];
+      const paths = S.selloPaths(root);
+      switch (sub) {
+        case 'on':
+        case 'off': {
+          const cfg = S.readConfig(root) || {};
+          try { S.validateRiskConfig(cfg); } catch (e) { say(e.message); process.exitCode = 1; return; }
+          const { writeFileSync, mkdirSync } = await import('node:fs');
+          const { dirname } = await import('node:path');
+          mkdirSync(dirname(paths.config), { recursive: true });
+          writeFileSync(paths.config, JSON.stringify({ ...cfg, enabled: sub === 'on' }, null, 2) + '\n');
+          say(sub === 'on'
+            ? '✅ sello ON for this project. Risk-0 changes (docs/copy) still pass silently; everything else needs a review before commit/push/PR.'
+            : '✅ sello OFF for this project. Delivery behaves exactly as before.');
+          return;
+        }
+        case 'freeze': {
+          const candidate = S.computeCandidate(root);
+          if (!candidate) { say(S.MESSAGES.riskUnknown()); process.exitCode = 1; return; }
+          const paths2 = Object.keys(candidate.files);
+          if (!paths2.length) { say('sello: nothing to freeze — the working tree matches the trunk base.'); return; }
+          let risk;
+          try { risk = S.classifyRisk(paths2, S.readConfig(root)); }
+          catch (e) { say(e.message); process.exitCode = 1; return; }
+          S.writeSello(root, { status: 'frozen', ...candidate, risk, lenses: [], createdAt: new Date().toISOString() });
+          const lenses = risk.tier === 0 ? 0 : risk.tier === 1 ? 1 : 3;
+          say(`🧊 frozen: ${paths2.length} file(s), risk tier ${risk.tier} → ${lenses} lens(es) required.`);
+          for (const [p, c] of Object.entries(risk.classes)) if (c !== 'default' && c !== 'docs') say(`   ${p} → ${c}`);
+          return;
+        }
+        case 'approve':
+        case 'block': {
+          const sello = S.readSello(root);
+          if (sello.missing || sello.corrupt || !sello.status) { say(S.MESSAGES.notFrozen()); process.exitCode = 1; return; }
+          const current = S.computeCandidate(root);
+          const changed = current && Object.keys({ ...sello.files, ...current.files })
+            .some((p) => sello.files[p] !== current.files[p]);
+          if (sub === 'approve' && (changed || sello.base !== current?.base)) {
+            say(S.MESSAGES.staleFreeze()); process.exitCode = 1; return;
+          }
+          const lenses = (flag('lenses') || '').split(',').filter(Boolean);
+          const notes = (flag('note') ? [String(flag('note'))] : []);
+          if (notes.length) S.appendFindings(root, notes.map((n) => `${new Date().toISOString().slice(0, 10)} ${n}`));
+          S.writeSello(root, { ...sello, status: sub === 'approve' ? 'approved' : 'blocked', lenses, reason: flag('reason') });
+          say(sub === 'approve' ? `✅ sealed (${lenses.length ? lenses.join(', ') : 'no lenses recorded'}).` : '⛔ blocked — fix and re-review.');
+          return;
+        }
+        case 'budget': {
+          const sello = S.readSello(root);
+          if (sello.missing || sello.corrupt) { say(S.MESSAGES.notFrozen()); process.exitCode = 1; return; }
+          const lines = Number(flag('lines'));
+          if (!Number.isFinite(lines) || lines <= 0) { say('Use: rsc sello budget --lines <N>'); process.exitCode = 1; return; }
+          S.writeSello(root, { ...sello, budget: { lines, declaredAt: new Date().toISOString() } });
+          say(`📏 fix budget declared: ${lines} line(s). budget-check will hold the fix to it.`);
+          return;
+        }
+        case 'budget-check': {
+          const sello = S.readSello(root);
+          if (sello.missing || sello.corrupt || !sello.budget) { say('sello: no declared budget. Recover: run `rsc sello budget --lines <N>` BEFORE fixing.'); process.exitCode = 1; return; }
+          const current = S.computeCandidate(root);
+          const spent = S.budgetSpent(sello, current || { numstat: {} });
+          if (spent <= sello.budget.lines) { say(`✅ within budget: ~${spent}/${sello.budget.lines} line(s).`); return; }
+          const justify = flag('justify');
+          if (typeof justify === 'string' && justify.trim()) {
+            S.writeSello(root, { ...sello, budget: { ...sello.budget, exceeded: spent, justification: justify } });
+            S.appendFindings(root, [`budget exceeded (~${spent}/${sello.budget.lines}): ${justify}`]);
+            say(`⚠️ over budget (~${spent}/${sello.budget.lines}) — justification recorded.`);
+            return;
+          }
+          say(S.MESSAGES.overBudget(spent, sello.budget.lines));
+          process.exitCode = 1;
+          return;
+        }
+        case 'check': {
+          const verdict = S.checkSello(root);
+          if (verdict.ok) { say(`✅ sello check: ${verdict.code}`); return; }
+          say(verdict.message);
+          process.exitCode = 1;
+          return;
+        }
+        case 'report': {
+          const { existsSync, readFileSync } = await import('node:fs');
+          say(existsSync(paths.findings) ? readFileSync(paths.findings, 'utf8') : '(no non-blocking findings recorded)');
+          return;
+        }
+        case 'status': {
+          const enabled = S.isEnabled(root);
+          const verdict = S.checkSello(root);
+          const sello = S.readSello(root);
+          say(JSON.stringify({
+            enabled,
+            check: verdict.code,
+            status: sello.missing ? 'none' : sello.corrupt ? 'corrupt' : sello.status,
+            risk: sello.risk?.tier,
+            lenses: sello.lenses,
+            budget: sello.budget,
+            nonBlockingFindings: S.countFindings(root),
+          }, null, 2));
+          return;
+        }
+        default:
+          say('Use: npx @ericrisco/rsc sello on|off|status|freeze|approve --lenses a,b|block --reason "…"|budget --lines N|budget-check [--justify "…"]|check|report');
+          return;
+      }
+    }
     case 'uninstall': {
       const dry = argv.includes('--dry-run');
       // `uninstall --all` is an alias for a full purge.
@@ -339,7 +449,7 @@ async function main() {
       return void (await runPurge(argv.includes('--dry-run'), argv.includes('--with-docs')));
     default:
       say(`rsc: unknown command '${cmd}'.`);
-      say('Use: npx @ericrisco/rsc | add <id...> | install --profile <p> | consult "<text>" | list | audit | registry refresh | doctor | sync | backups | restore <id|latest> | upgrade | uninstall <id> | purge');
+      say('Use: npx @ericrisco/rsc | add <id...> | install --profile <p> | consult "<text>" | list | audit | registry refresh | doctor | sync | sello <on|off|status|…> | backups | restore <id|latest> | upgrade | uninstall <id> | purge');
   }
 }
 

--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -331,14 +331,21 @@ async function main() {
       // Deterministic transitions of the sello (review receipt). The `review` skill
       // orchestrates the lenses; every state change and every check runs HERE, token-free.
       const S = await import('../targets/sello.mjs');
-      const root = process.cwd();
+      const root = S.resolveRoot(process.cwd());
       const sub = argv[1];
       const paths = S.selloPaths(root);
+      // flag() yields boolean true for a valueless flag; every string flag below
+      // goes through this so `--lenses` with no value is a usage error, not a crash.
+      const str = (name) => { const v = flag(name); return typeof v === 'string' ? v : undefined; };
       switch (sub) {
         case 'on':
         case 'off': {
           const cfg = S.readConfig(root) || {};
-          try { S.validateRiskConfig(cfg); } catch (e) { say(e.message); process.exitCode = 1; return; }
+          // `off` never validates: it is the recovery advertised by every deny
+          // message, so a broken config must not be able to lock it away.
+          if (sub === 'on') {
+            try { S.validateRiskConfig(cfg); } catch (e) { say(e.message); process.exitCode = 1; return; }
+          }
           const { writeFileSync, mkdirSync } = await import('node:fs');
           const { dirname } = await import('node:path');
           mkdirSync(dirname(paths.config), { recursive: true });
@@ -349,34 +356,51 @@ async function main() {
           return;
         }
         case 'freeze': {
-          const candidate = S.computeCandidate(root);
-          if (!candidate) { say(S.MESSAGES.riskUnknown()); process.exitCode = 1; return; }
+          const cfg = S.readConfig(root);
+          const candidate = S.computeCandidate(root, cfg);
+          if (!candidate) { say(S.MESSAGES.noTrunk()); process.exitCode = 1; return; }
           const paths2 = Object.keys(candidate.files);
           if (!paths2.length) { say('sello: nothing to freeze — the working tree matches the trunk base.'); return; }
-          let risk;
-          try { risk = S.classifyRisk(paths2, S.readConfig(root)); }
-          catch (e) { say(e.message); process.exitCode = 1; return; }
-          S.writeSello(root, { status: 'frozen', ...candidate, risk, lenses: [], createdAt: new Date().toISOString() });
-          const lenses = risk.tier === 0 ? 0 : risk.tier === 1 ? 1 : 3;
-          say(`🧊 frozen: ${paths2.length} file(s), risk tier ${risk.tier} → ${lenses} lens(es) required.`);
+          const risk = S.classifyRisk(paths2, cfg);
+          if (risk.configError) say(`⚠️  ${risk.configError}\n   (using the default risk table until it is fixed)`);
+          const required = S.lensesRequired(risk.tier, cfg);
+          S.writeSello(root, { status: 'frozen', ...candidate, risk, required, lenses: [], createdAt: new Date().toISOString() });
+          say(`🧊 frozen: ${paths2.length} file(s), risk tier ${risk.tier} → ${required} lens(es) required.`);
           for (const [p, c] of Object.entries(risk.classes)) if (c !== 'default' && c !== 'docs') say(`   ${p} → ${c}`);
+          if (risk.lowered?.length) say(`   (lowered by config: ${risk.lowered.join(', ')})`);
           return;
         }
         case 'approve':
         case 'block': {
           const sello = S.readSello(root);
           if (sello.missing || sello.corrupt || !sello.status) { say(S.MESSAGES.notFrozen()); process.exitCode = 1; return; }
-          const current = S.computeCandidate(root);
+          const cfg = S.readConfig(root);
+          const current = S.computeCandidate(root, cfg);
           const changed = current && Object.keys({ ...sello.files, ...current.files })
             .some((p) => sello.files[p] !== current.files[p]);
           if (sub === 'approve' && (changed || sello.base !== current?.base)) {
             say(S.MESSAGES.staleFreeze()); process.exitCode = 1; return;
           }
-          const lenses = (flag('lenses') || '').split(',').filter(Boolean);
-          const notes = (flag('note') ? [String(flag('note'))] : []);
-          if (notes.length) S.appendFindings(root, notes.map((n) => `${new Date().toISOString().slice(0, 10)} ${n}`));
-          S.writeSello(root, { ...sello, status: sub === 'approve' ? 'approved' : 'blocked', lenses, reason: flag('reason') });
-          say(sub === 'approve' ? `✅ sealed (${lenses.length ? lenses.join(', ') : 'no lenses recorded'}).` : '⛔ blocked — fix and re-review.');
+          const lenses = (str('lenses') || '').split(',').map((s) => s.trim()).filter(Boolean);
+          const required = sello.required ?? S.lensesRequired(sello.risk?.tier ?? 1, cfg);
+          // An incomplete panel must not seal silently (spec error path): the user
+          // may still accept the gap, but only on purpose.
+          if (sub === 'approve' && lenses.length < required && !argv.includes('--accept-partial-lenses')) {
+            say(S.MESSAGES.partialLenses(lenses.length, required)); process.exitCode = 1; return;
+          }
+          const note = str('note');
+          if (note) S.appendFindings(root, [`${new Date().toISOString().slice(0, 10)} ${note}`]);
+          const status = sub === 'approve' ? 'approved' : 'blocked';
+          const next = { ...sello, status, lenses, reason: str('reason') };
+          S.writeSello(root, next);
+          S.appendLog(root, {
+            at: new Date().toISOString(), status, base: sello.base, risk: sello.risk?.tier,
+            files: Object.keys(sello.files).length, lenses, digest: S.candidateDigest(sello),
+            partialLenses: lenses.length < required || undefined, reason: str('reason'),
+          });
+          say(sub === 'approve'
+            ? `✅ sealed with ${lenses.length}/${required} lens(es)${lenses.length ? `: ${lenses.join(', ')}` : ''}.`
+            : '⛔ blocked — fix and re-review.');
           return;
         }
         case 'budget': {
@@ -391,10 +415,10 @@ async function main() {
         case 'budget-check': {
           const sello = S.readSello(root);
           if (sello.missing || sello.corrupt || !sello.budget) { say('sello: no declared budget. Recover: run `rsc sello budget --lines <N>` BEFORE fixing.'); process.exitCode = 1; return; }
-          const current = S.computeCandidate(root);
+          const current = S.computeCandidate(root, S.readConfig(root));
           const spent = S.budgetSpent(sello, current || { numstat: {} });
           if (spent <= sello.budget.lines) { say(`✅ within budget: ~${spent}/${sello.budget.lines} line(s).`); return; }
-          const justify = flag('justify');
+          const justify = str('justify');
           if (typeof justify === 'string' && justify.trim()) {
             S.writeSello(root, { ...sello, budget: { ...sello.budget, exceeded: spent, justification: justify } });
             S.appendFindings(root, [`budget exceeded (~${spent}/${sello.budget.lines}): ${justify}`]);
@@ -407,6 +431,7 @@ async function main() {
         }
         case 'check': {
           const verdict = S.checkSello(root);
+          if (verdict.warning) say(`⚠️  ${verdict.warning}`);
           if (verdict.ok) { say(`✅ sello check: ${verdict.code}`); return; }
           say(verdict.message);
           process.exitCode = 1;
@@ -418,22 +443,35 @@ async function main() {
           return;
         }
         case 'status': {
+          const { existsSync } = await import('node:fs');
+          const { join } = await import('node:path');
           const enabled = S.isEnabled(root);
           const verdict = S.checkSello(root);
           const sello = S.readSello(root);
+          const cfg = S.readConfig(root);
+          let lowered = [];
+          let configError;
+          try { ({ lowered } = S.validateRiskConfig(cfg || {})); } catch (e) { configError = e.message; }
           say(JSON.stringify({
             enabled,
             check: verdict.code,
+            // An inert gate must never look armed: name every reason it is standing down.
+            inert: enabled && ['no-trunk', 'disabled'].includes(verdict.code) ? verdict.code : undefined,
+            shipGuardOptOut: existsSync(join(root, '.rsc', '.no-ship-guard')) || undefined,
+            warning: verdict.warning,
+            configError,
+            loweredClasses: lowered.length ? lowered : undefined,
             status: sello.missing ? 'none' : sello.corrupt ? 'corrupt' : sello.status,
             risk: sello.risk?.tier,
             lenses: sello.lenses,
+            lensesRequired: sello.required,
             budget: sello.budget,
             nonBlockingFindings: S.countFindings(root),
           }, null, 2));
           return;
         }
         default:
-          say('Use: npx @ericrisco/rsc sello on|off|status|freeze|approve --lenses a,b|block --reason "…"|budget --lines N|budget-check [--justify "…"]|check|report');
+          say('Use: npx @ericrisco/rsc sello on|off|status|freeze|approve --lenses a,b [--accept-partial-lenses]|block --reason "…"|budget --lines N|budget-check [--justify "…"]|check|report');
           return;
       }
     }

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -104,8 +104,14 @@ End every review you give with one of three, and nothing mushy in between:
 
 ### The sello — when this project opted in
 
-If `.rsc/sello-config.json` has `enabled: true`, the review's verdict becomes **binding**: it is
-sealed to the exact bytes reviewed, and the ship gate refuses commit/push/PR on anything else.
+If `.rsc/sello-config.json` has `enabled: true`, the review's verdict is **sealed to the exact
+bytes reviewed**, and the ship gate refuses commit/push/PR on anything else.
+
+**What the sello does and does not prove.** It binds bytes, not intent: it guarantees *what ships
+is what was reviewed*, never *the review was good*. You are the one calling `sello approve`, so it
+is self-attested — drift protection between review and delivery, not tamper-evidence. Sealing
+without actually running the lenses produces a valid sello and a worthless one.
+
 Every state transition is deterministic CLI, never tokens:
 
 ```text
@@ -114,6 +120,10 @@ Every state transition is deterministic CLI, never tokens:
 3a. approved → npx @ericrisco/rsc sello approve --lenses correctness,security,tests
 3b. blocked  → npx @ericrisco/rsc sello block --reason "<the blocking finding>"
 ```
+
+`approve` refuses to seal with fewer lenses than the tier requires — pass them all, or accept the
+gap deliberately with `--accept-partial-lenses` (it is recorded). Every approval also appends to
+`.rsc/sello-log.jsonl`, so what shipped under which verdict survives the next freeze.
 
 **Lenses by risk tier** — tier 0 never reaches you (the gate passes docs/copy silently);
 tier 1 → run the single most relevant pass from the table above yourself; tier 2 → dispatch

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -102,6 +102,41 @@ End every review you give with one of three, and nothing mushy in between:
 - **`APPROVE WITH NITS`** — mergeable; the nits are the author's call.
 - **`CHANGES REQUESTED`** — one or more blockers/should-fix. List exactly what unblocks it.
 
+### The sello — when this project opted in
+
+If `.rsc/sello-config.json` has `enabled: true`, the review's verdict becomes **binding**: it is
+sealed to the exact bytes reviewed, and the ship gate refuses commit/push/PR on anything else.
+Every state transition is deterministic CLI, never tokens:
+
+```text
+1. npx @ericrisco/rsc sello freeze      → hashes the candidate, prints risk tier + lens count
+2. Run the lenses (below), filter findings, decide
+3a. approved → npx @ericrisco/rsc sello approve --lenses correctness,security,tests
+3b. blocked  → npx @ericrisco/rsc sello block --reason "<the blocking finding>"
+```
+
+**Lenses by risk tier** — tier 0 never reaches you (the gate passes docs/copy silently);
+tier 1 → run the single most relevant pass from the table above yourself; tier 2 → dispatch
+**three parallel fresh-context subagents** (correctness · security · tests-as-evidence), each
+given only the diff and told to *refute* readiness, not confirm it. Fresh context is the point:
+a reviewer who inherits the implementer's context inherits its blind spots.
+
+**A finding blocks only if it survives all three filters** — no exceptions, and eagerness to
+find something is not evidence:
+
+1. **Causal** — introduced by *this* change. Pre-existing defects → note with
+   `--note "<finding>"` (they land in `.rsc/sello-findings.md`, surfaced by `doctor`) and
+   suggest an issue; they never block this delivery.
+2. **Severity** — only `blocker` blocks. `should-fix`/`nit` → `--note`.
+3. **Evidence** — a `repro` or a concrete failure scenario. A suspicion without one is a
+   `[question]`, and questions don't block.
+
+**Fixing a blocker is budgeted, one attempt.** Before touching anything: estimate the fix and
+declare it — `npx @ericrisco/rsc sello budget --lines <N>`. After the fix:
+`sello budget-check` (over budget → justify with `--justify "…"` or shrink; an unexplained
+overrun is how over-engineering enters disguised as a fix). Then `sello freeze` + re-review
+**only the divergence**, and approve. Still broken after one attempt → stop, hand it to the human.
+
 ---
 
 ## RECEIVING a review

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -77,7 +77,9 @@ with `enabled: true`): commit, push and PR are denied unless the change's exact 
 sealed, approved review — one byte of drift, a moved base, or a missing review on a risk>0 change
 all block, and every denial names its way out (re-run `review`, or `npx @ericrisco/rsc sello off`).
 Risk-0 changes (docs/copy) always pass silently. Off by default; the flow lives in the `review`
-skill.
+skill. Note `.rsc/.no-ship-guard` opts out of the branch-hygiene rules above but **not** of the
+sello, which has its own switch. The sello binds bytes, not intent — it proves what ships is what
+was reviewed, never that the review was any good.
 
 ## The three landing options — always present exactly three
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -72,6 +72,13 @@ the command), and can be disabled per project with `.rsc/.no-ship-guard`. It gua
 commit → push step; opening the PR is still this skill's job (and its hard rule). If the guard
 blocks you, do not work around it — run ship.
 
+The same guard also enforces the **sello** where the project opted in (`.rsc/sello-config.json`
+with `enabled: true`): commit, push and PR are denied unless the change's exact bytes match the
+sealed, approved review — one byte of drift, a moved base, or a missing review on a risk>0 change
+all block, and every denial names its way out (re-run `review`, or `npx @ericrisco/rsc sello off`).
+Risk-0 changes (docs/copy) always pass silently. Off by default; the flow lives in the `review`
+skill.
+
 ## The three landing options — always present exactly three
 
 This mirrors the harness "siempre 3 opciones" pattern. Gather the one fact that changes the answer (does this repo use PRs / require review on `main`?), then present **exactly three** with an honest recommendation matched to the workflow and the accompaniment level.

--- a/targets/claude.js
+++ b/targets/claude.js
@@ -90,6 +90,9 @@ export function wireHook(paths) {
   // (non-rsc) PreToolUse hooks are preserved.
   const sgDest = join(paths.projectRoot, '.rsc', 'ship-guard.mjs');
   copyFileSync(join(HERE, 'ship-guard.mjs'), sgDest);
+  // sello.mjs is ship-guard's sibling import (hooks are materialized file-by-file,
+  // so the deterministic sello core must land next to the guard that loads it).
+  copyFileSync(join(HERE, 'sello.mjs'), join(paths.projectRoot, '.rsc', 'sello.mjs'));
   const sgCmd = `node "${sgDest}" "${paths.projectRoot}"`;
   settings.hooks.PreToolUse ||= [];
   settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(

--- a/targets/sello.mjs
+++ b/targets/sello.mjs
@@ -1,0 +1,281 @@
+// sello.mjs — the deterministic core of the "sello" (review receipt) system.
+//
+// A sello binds a review verdict to the EXACT bytes that were reviewed. The ship
+// gate (ship-guard.mjs) refuses to commit/push/PR anything whose bytes differ from
+// what was sealed. Opt-in per project via .rsc/sello-config.json — absent or
+// disabled, nothing here runs and the harness behaves exactly as before.
+//
+// Design rules (constitution):
+//  - P1: everything in this file is an algorithm — no tokens, no judgment.
+//  - P2: every gate has a test (tests/sello.test.js), including the risk table itself.
+//  - P4: the sello is the artifact that makes a human approval binding.
+//  - P6: every deny message carries its own `Recover:` line, asserted by test.
+//  - P7: risk-0 changes (docs/copy) pass in complete silence.
+//
+// Materialized to .rsc/sello.mjs as a sibling of ship-guard.mjs (hooks are copied
+// file-by-file, so imports must be sibling-relative — same pattern as hook-once.mjs).
+
+import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+
+// ---------------------------------------------------------------- paths & config
+
+export function selloPaths(root) {
+  return {
+    config: join(root, '.rsc', 'sello-config.json'),
+    state: join(root, '.rsc', 'sello.json'),
+    findings: join(root, '.rsc', 'sello-findings.md'),
+  };
+}
+
+export function readConfig(root) {
+  try {
+    const cfg = JSON.parse(readFileSync(selloPaths(root).config, 'utf8'));
+    return cfg && typeof cfg === 'object' ? cfg : null;
+  } catch { return null; }
+}
+
+export function isEnabled(root) {
+  const cfg = readConfig(root);
+  return !!(cfg && cfg.enabled === true);
+}
+
+// ---------------------------------------------------------------- risk table
+//
+// Risk is classified by WHAT a path touches, never by how many lines changed.
+// Tiers: 0 = nulo (docs/copy — silent), 1 = normal (one lens), 2 = alto (full panel).
+// The FLOOR_CLASSES can never be lowered to 0 by any project override — secrets and
+// the harness's own configuration stay guarded no matter what.
+
+export const RISK_TABLE = [
+  { class: 'docs', tier: 0, pattern: '(^|/)(docs|doc)/|\\.(md|mdx|markdown|txt|rst)$|(^|/)LICENSE$|(^|/)CHANGELOG' },
+  { class: 'secrets', tier: 2, pattern: '(^|/)\\.env(\\.|$)|(^|/)(secrets?|credentials?)(/|\\.|$)|\\.(pem|key|p12|pfx)$' },
+  { class: 'auth', tier: 2, pattern: '(^|/)(auth|authn|authz|login|session|oauth|sso)(/|\\.|-)' },
+  { class: 'ci', tier: 2, pattern: '(^|/)\\.github/workflows/|(^|/)\\.gitlab-ci\\.yml$|(^|/)Jenkinsfile$' },
+  { class: 'migrations', tier: 2, pattern: '(^|/)migrations?/' },
+  { class: 'billing', tier: 2, pattern: '(^|/)(billing|payments?|checkout|stripe)(/|\\.|-)' },
+  { class: 'harness', tier: 2, pattern: '(^|/)\\.rsc/|(^|/)\\.claude/' },
+];
+export const FLOOR_CLASSES = ['secrets', 'harness'];
+export const DEFAULT_TIER = 1;
+
+// A project override may RAISE freely (add patterns at a tier, or lift a class) and
+// may LOWER only explicitly (naming the class), never below tier 1, and never a
+// floor class. Returns the effective table or throws with a recoverable message.
+export function validateRiskConfig(cfg) {
+  const risk = cfg?.risk;
+  if (!risk) return { table: RISK_TABLE, lowered: [] };
+  const lowered = [];
+  const extra = [];
+  for (const r of risk.raise || []) {
+    if (!r?.pattern) throw new Error(`sello: raise entry without pattern. ${MESSAGES.badRiskConfig}`);
+    new RegExp(r.pattern); // throws on an uncompilable pattern
+    extra.push({ class: r.class || 'custom', tier: 2, pattern: r.pattern });
+  }
+  for (const l of risk.lower || []) {
+    const cls = typeof l === 'string' ? l : l?.class;
+    if (FLOOR_CLASSES.includes(cls)) {
+      throw new Error(`sello: the "${cls}" class can never be lowered — secrets and the harness's own configuration keep their risk tier under every configuration. ${MESSAGES.badRiskConfig}`);
+    }
+    if (!RISK_TABLE.some((row) => row.class === cls)) {
+      throw new Error(`sello: cannot lower unknown class "${cls}". ${MESSAGES.badRiskConfig}`);
+    }
+    lowered.push(cls);
+  }
+  const table = [
+    ...extra,
+    ...RISK_TABLE.map((row) => (lowered.includes(row.class) ? { ...row, tier: 1 } : row)),
+  ];
+  return { table, lowered };
+}
+
+// → {tier, classes: {path: class}} — tier is the max across all paths; a path with
+// no match lands on DEFAULT_TIER. Unreadable config falls back to the default table
+// upstream (checkSello never silently lowers risk — spec's error path).
+export function classifyRisk(paths, cfg = null) {
+  const { table } = validateRiskConfig(cfg || {});
+  const classes = {};
+  let tier = 0;
+  for (const p of paths) {
+    const row = table.find((r) => new RegExp(r.pattern).test(p));
+    const t = row ? row.tier : DEFAULT_TIER;
+    classes[p] = row ? row.class : 'default';
+    if (t > tier) tier = t;
+  }
+  return { tier, classes };
+}
+
+// ---------------------------------------------------------------- candidate
+
+function git(root, ...args) {
+  const r = spawnSync('git', ['-C', root, ...args], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  return r.status === 0 ? (r.stdout || '').trimEnd() : null;
+}
+
+function trunkRef(root) {
+  for (const ref of ['origin/main', 'origin/master', 'main', 'master']) {
+    if (git(root, 'rev-parse', '--verify', '--quiet', ref) !== null) return ref;
+  }
+  return null;
+}
+
+// The candidate is the change vs the trunk merge-base: every path that differs
+// between that base and the working tree (committed on the branch, staged, unstaged
+// or untracked), each hashed byte-for-byte. Deleted paths hash to "D". One byte of
+// difference anywhere → a different candidate.
+export function computeCandidate(root) {
+  const trunk = trunkRef(root);
+  if (!trunk) return null;
+  const head = git(root, 'rev-parse', 'HEAD');
+  const base = head ? git(root, 'merge-base', 'HEAD', trunk) : null;
+  if (!base) return null;
+
+  const names = new Set();
+  for (const line of (git(root, 'diff', '--name-only', base) || '').split('\n')) {
+    if (line) names.add(line);
+  }
+  // Untracked files join the candidate EXCEPT the harness's own .rsc/ state — the
+  // sello's config/state/findings live there, and sealing them would make writing
+  // the sello mutate the very candidate it seals (the system would invalidate
+  // itself). Tracked .rsc/ changes committed on the branch still count above:
+  // deliberate harness-config changes are content; local state is not.
+  for (const line of (git(root, 'ls-files', '--others', '--exclude-standard') || '').split('\n')) {
+    if (line && !line.startsWith('.rsc/')) names.add(line);
+  }
+
+  const files = {};
+  const numstat = {};
+  for (const name of [...names].sort()) {
+    const abs = join(root, name);
+    if (existsSync(abs)) {
+      files[name] = createHash('sha256').update(readFileSync(abs)).digest('hex');
+    } else {
+      files[name] = 'D';
+    }
+  }
+  for (const line of (git(root, 'diff', '--numstat', base) || '').split('\n')) {
+    const m = /^(\d+|-)\t(\d+|-)\t(.+)$/.exec(line);
+    if (m) numstat[m[3]] = (m[1] === '-' ? 0 : Number(m[1])) + (m[2] === '-' ? 0 : Number(m[2]));
+  }
+  return { base, files, numstat };
+}
+
+// ---------------------------------------------------------------- sello state
+
+export function readSello(root) {
+  const p = selloPaths(root).state;
+  if (!existsSync(p)) return { missing: true };
+  try {
+    const s = JSON.parse(readFileSync(p, 'utf8'));
+    if (!s || typeof s !== 'object' || !s.files || !s.base) return { corrupt: true };
+    return s;
+  } catch { return { corrupt: true }; }
+}
+
+export function writeSello(root, sello) {
+  writeFileSync(selloPaths(root).state, JSON.stringify(sello, null, 2) + '\n');
+}
+
+export function appendFindings(root, lines) {
+  if (!lines?.length) return;
+  const p = selloPaths(root).findings;
+  const header = existsSync(p) ? '' : '# sello — hallazgos no bloqueantes\n\nSe acumulan aquí; `rsc sello report` los muestra. No interrumpen nada.\n';
+  appendFileSync(p, header + lines.map((l) => `- ${l}`).join('\n') + '\n');
+}
+
+export function countFindings(root) {
+  const p = selloPaths(root).findings;
+  if (!existsSync(p)) return 0;
+  return readFileSync(p, 'utf8').split('\n').filter((l) => l.startsWith('- ')).length;
+}
+
+// ---------------------------------------------------------------- messages (P6)
+//
+// Every message that can DENY an action carries a `Recover:` line naming the exact
+// way out. tests/sello.test.js asserts this for every entry — a block without its
+// recovery is the one thing this system is not allowed to produce.
+
+export const MESSAGES = {
+  noReview: (tier) =>
+    `sello: this change is risk tier ${tier} and has no review. ` +
+    `Recover: run the \`review\` skill (it freezes, reviews and approves the sello), or \`npx @ericrisco/rsc sello off\` to turn the sello off for this project.`,
+  diverged: (paths) =>
+    `sello: the change no longer matches what was reviewed — ${paths.slice(0, 5).join(', ')}${paths.length > 5 ? ` (+${paths.length - 5} more)` : ''} differ from the sealed bytes. ` +
+    `Recover: re-run the \`review\` skill on the divergence (only what changed is re-reviewed), or \`npx @ericrisco/rsc sello off\` for this project.`,
+  baseMoved: () =>
+    `sello: the branch base moved (rebase/merge) since the review — the same diff on a new base is a new candidate. ` +
+    `Recover: re-run the \`review\` skill (only the divergence is re-reviewed), or \`npx @ericrisco/rsc sello off\` for this project.`,
+  corrupt: () =>
+    `sello: the sello file is unreadable, which counts as "no review" — nothing is ever approved by default. ` +
+    `Recover: re-run the \`review\` skill to produce a fresh sello, or \`npx @ericrisco/rsc sello off\` for this project.`,
+  blocked: (reason) =>
+    `sello: the review left this change BLOCKED${reason ? ` (${reason})` : ''}. ` +
+    `Recover: fix the blocking findings and re-run the \`review\` skill, or \`npx @ericrisco/rsc sello off\` for this project.`,
+  notFrozen: () =>
+    `sello: nothing is frozen yet, so there is nothing to approve. ` +
+    `Recover: run \`npx @ericrisco/rsc sello freeze\` first, then review, then approve.`,
+  staleFreeze: () =>
+    `sello: the change mutated after it was frozen — approving now would seal bytes nobody reviewed. ` +
+    `Recover: run \`npx @ericrisco/rsc sello freeze\` again and re-review the divergence.`,
+  overBudget: (spent, budget) =>
+    `sello: the fix touched ~${spent} line(s) but the declared budget was ${budget} — an unexplained overrun is how over-engineering gets in. ` +
+    `Recover: re-run with --justify "<why the budget was not enough>" to record the reason, or shrink the fix.`,
+  badRiskConfig:
+    'Recover: fix .rsc/sello-config.json — "raise" entries need a valid pattern; "lower" only accepts known classes and never "secrets" or "harness".',
+  riskUnknown: () =>
+    `sello: the risk of this change could not be evaluated, so it is treated as risk tier 1 (never silently as 0). ` +
+    `Recover: check that this is a git repository with a reachable trunk (origin/main or main), then retry.`,
+};
+
+// ---------------------------------------------------------------- the check
+//
+// The single verdict function the guard, the CLI and the tests all share.
+// → {ok: true, code} | {ok: false, code, message}
+
+export function checkSello(root) {
+  const cfg = readConfig(root);
+  if (!cfg || cfg.enabled !== true) return { ok: true, code: 'disabled' };
+
+  const candidate = computeCandidate(root);
+  if (!candidate) return { ok: true, code: 'no-repo' }; // fail-open: nothing to measure
+
+  const paths = Object.keys(candidate.files);
+  if (paths.length === 0) return { ok: true, code: 'clean' };
+
+  let risk;
+  try { risk = classifyRisk(paths, cfg); }
+  catch { risk = { tier: DEFAULT_TIER, classes: {} }; } // spec: never silently down to 0
+
+  const sello = readSello(root);
+  if (sello.missing) {
+    if (risk.tier === 0) return { ok: true, code: 'risk0' }; // P7: silence for docs/copy
+    return { ok: false, code: 'no-review', message: MESSAGES.noReview(risk.tier) };
+  }
+  if (sello.corrupt) return { ok: false, code: 'corrupt', message: MESSAGES.corrupt() };
+  if (sello.status === 'blocked') return { ok: false, code: 'blocked', message: MESSAGES.blocked(sello.reason) };
+  if (sello.status !== 'approved') {
+    if (risk.tier === 0) return { ok: true, code: 'risk0' };
+    return { ok: false, code: 'no-review', message: MESSAGES.noReview(risk.tier) };
+  }
+  if (sello.base !== candidate.base) return { ok: false, code: 'base-moved', message: MESSAGES.baseMoved() };
+
+  const diverged = [];
+  const sealed = sello.files || {};
+  for (const p of new Set([...Object.keys(sealed), ...paths])) {
+    if (sealed[p] !== candidate.files[p]) diverged.push(p);
+  }
+  if (diverged.length) return { ok: false, code: 'diverged', message: MESSAGES.diverged(diverged) };
+  return { ok: true, code: 'sealed' };
+}
+
+// Fix-budget accounting: |numstat delta| vs the frozen totals, plus new files.
+export function budgetSpent(frozen, current) {
+  let spent = 0;
+  const all = new Set([...Object.keys(frozen.numstat || {}), ...Object.keys(current.numstat || {})]);
+  for (const p of all) {
+    spent += Math.abs((current.numstat?.[p] || 0) - (frozen.numstat?.[p] || 0));
+  }
+  return spent;
+}

--- a/targets/sello.mjs
+++ b/targets/sello.mjs
@@ -5,28 +5,45 @@
 // what was sealed. Opt-in per project via .rsc/sello-config.json — absent or
 // disabled, nothing here runs and the harness behaves exactly as before.
 //
+// TRUST MODEL — read this before believing a sello. It binds BYTES, not intent:
+// it proves "what ships is what was reviewed", never "the review was any good".
+// `sello approve` is an unauthenticated local command and the reviewing agent is
+// the one that calls it, so the sello is SELF-ATTESTED: it is drift protection
+// between review and delivery, not tamper-evidence against the agent or the user.
+// Anyone who can write .rsc/ can seal anything — which is why `sello off` is a
+// documented one-liner rather than something to defeat.
+//
 // Design rules (constitution):
 //  - P1: everything in this file is an algorithm — no tokens, no judgment.
 //  - P2: every gate has a test (tests/sello.test.js), including the risk table itself.
-//  - P4: the sello is the artifact that makes a human approval binding.
+//  - P4: the sello is the artifact that makes an approval binding to a candidate.
 //  - P6: every deny message carries its own `Recover:` line, asserted by test.
 //  - P7: risk-0 changes (docs/copy) pass in complete silence.
 //
 // Materialized to .rsc/sello.mjs as a sibling of ship-guard.mjs (hooks are copied
 // file-by-file, so imports must be sibling-relative — same pattern as hook-once.mjs).
 
-import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, lstatSync, readFileSync, readlinkSync, writeFileSync, appendFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 
 // ---------------------------------------------------------------- paths & config
+
+// The sello's own state can never be part of the candidate it seals: writing the
+// sello would mutate the change being sealed, so `freeze` → `approve` could never
+// converge (a permanent, unrecoverable delivery lockout). Excluded whether the
+// project tracks .rsc/ or not.
+export const SELLO_STATE_PATHS = [
+  '.rsc/sello.json', '.rsc/sello-config.json', '.rsc/sello-findings.md', '.rsc/sello-log.jsonl',
+];
 
 export function selloPaths(root) {
   return {
     config: join(root, '.rsc', 'sello-config.json'),
     state: join(root, '.rsc', 'sello.json'),
     findings: join(root, '.rsc', 'sello-findings.md'),
+    log: join(root, '.rsc', 'sello-log.jsonl'),
   };
 }
 
@@ -42,37 +59,60 @@ export function isEnabled(root) {
   return !!(cfg && cfg.enabled === true);
 }
 
+// The CLI can run from any subdirectory; the guard always runs from the project
+// root. Both must compute the same candidate, so both resolve to the git toplevel.
+export function resolveRoot(root) {
+  const r = spawnSync('git', ['-C', root, 'rev-parse', '--show-toplevel'], { encoding: 'utf8' });
+  return r.status === 0 ? (r.stdout || '').trim() || root : root;
+}
+
 // ---------------------------------------------------------------- risk table
 //
 // Risk is classified by WHAT a path touches, never by how many lines changed.
 // Tiers: 0 = nulo (docs/copy — silent), 1 = normal (one lens), 2 = alto (full panel).
-// The FLOOR_CLASSES can never be lowered to 0 by any project override — secrets and
-// the harness's own configuration stay guarded no matter what.
+// A path is scored by the HIGHEST tier of every row it matches — first-match-wins
+// would let the docs row shadow a floor class (`credentials.txt`, `.claude/CLAUDE.md`)
+// and hand a silent pass to exactly what the floor exists to guard.
 
 export const RISK_TABLE = [
   { class: 'docs', tier: 0, pattern: '(^|/)(docs|doc)/|\\.(md|mdx|markdown|txt|rst)$|(^|/)LICENSE$|(^|/)CHANGELOG' },
-  { class: 'secrets', tier: 2, pattern: '(^|/)\\.env(\\.|$)|(^|/)(secrets?|credentials?)(/|\\.|$)|\\.(pem|key|p12|pfx)$' },
+  { class: 'secrets', tier: 2, pattern: '(^|/)\\.env(\\.|$)|(^|/)(secrets?|credentials?)(/|\\.|-|$)|\\.(pem|key|p12|pfx)$|(^|/)[^/]*(secret|credential)[^/]*$' },
   { class: 'auth', tier: 2, pattern: '(^|/)(auth|authn|authz|login|session|oauth|sso)(/|\\.|-)' },
   { class: 'ci', tier: 2, pattern: '(^|/)\\.github/workflows/|(^|/)\\.gitlab-ci\\.yml$|(^|/)Jenkinsfile$' },
   { class: 'migrations', tier: 2, pattern: '(^|/)migrations?/' },
   { class: 'billing', tier: 2, pattern: '(^|/)(billing|payments?|checkout|stripe)(/|\\.|-)' },
-  { class: 'harness', tier: 2, pattern: '(^|/)\\.rsc/|(^|/)\\.claude/' },
+  { class: 'harness', tier: 2, pattern: '(^|/)\\.rsc/|(^|/)\\.claude/|(^|/)CLAUDE\\.md$' },
 ];
 export const FLOOR_CLASSES = ['secrets', 'harness'];
 export const DEFAULT_TIER = 1;
+// User-supplied patterns are compiled inside a PreToolUse hook, so a catastrophic
+// one would hang the user's own delivery. Bounded, not sandboxed — the same file
+// holds the kill switch, so this is a foot-gun guard, not a security boundary.
+export const MAX_PATTERN_LEN = 200;
+export const MAX_RAISE_RULES = 64;
 
-// A project override may RAISE freely (add patterns at a tier, or lift a class) and
-// may LOWER only explicitly (naming the class), never below tier 1, and never a
-// floor class. Returns the effective table or throws with a recoverable message.
+// A project override may RAISE freely and may LOWER only explicitly (naming a known
+// class), never below tier 1, and never a floor class. Throws with a recoverable
+// message; callers fall back to the DEFAULT table, never to a flat tier.
 export function validateRiskConfig(cfg) {
   const risk = cfg?.risk;
   if (!risk) return { table: RISK_TABLE, lowered: [] };
   const lowered = [];
   const extra = [];
-  for (const r of risk.raise || []) {
-    if (!r?.pattern) throw new Error(`sello: raise entry without pattern. ${MESSAGES.badRiskConfig}`);
-    new RegExp(r.pattern); // throws on an uncompilable pattern
-    extra.push({ class: r.class || 'custom', tier: 2, pattern: r.pattern });
+  const raise = risk.raise || [];
+  if (raise.length > MAX_RAISE_RULES) {
+    throw new Error(`sello: too many "raise" rules (${raise.length} > ${MAX_RAISE_RULES}). ${MESSAGES.badRiskConfig}`);
+  }
+  for (const r of raise) {
+    if (!r?.pattern || typeof r.pattern !== 'string') {
+      throw new Error(`sello: a "raise" entry has no pattern. ${MESSAGES.badRiskConfig}`);
+    }
+    if (r.pattern.length > MAX_PATTERN_LEN) {
+      throw new Error(`sello: pattern longer than ${MAX_PATTERN_LEN} chars. ${MESSAGES.badRiskConfig}`);
+    }
+    try { new RegExp(r.pattern); }
+    catch (e) { throw new Error(`sello: uncompilable pattern ${JSON.stringify(r.pattern)} (${e.message}). ${MESSAGES.badRiskConfig}`); }
+    extra.push({ class: r.class || 'custom', tier: r.tier === 1 ? 1 : 2, pattern: r.pattern });
   }
   for (const l of risk.lower || []) {
     const cls = typeof l === 'string' ? l : l?.class;
@@ -91,31 +131,55 @@ export function validateRiskConfig(cfg) {
   return { table, lowered };
 }
 
-// → {tier, classes: {path: class}} — tier is the max across all paths; a path with
-// no match lands on DEFAULT_TIER. Unreadable config falls back to the default table
-// upstream (checkSello never silently lowers risk — spec's error path).
+// → {tier, classes: {path: class}, lowered, configError} — a path scores the MAX
+// tier of every row it matches; unmatched paths land on DEFAULT_TIER.
 export function classifyRisk(paths, cfg = null) {
-  const { table } = validateRiskConfig(cfg || {});
+  let table = RISK_TABLE;
+  let lowered = [];
+  let configError = null;
+  try { ({ table, lowered } = validateRiskConfig(cfg || {})); }
+  catch (e) { configError = e.message; table = RISK_TABLE; lowered = []; }
+
+  const compiled = table.map((r) => ({ ...r, re: new RegExp(r.pattern) }));
   const classes = {};
   let tier = 0;
   for (const p of paths) {
-    const row = table.find((r) => new RegExp(r.pattern).test(p));
-    const t = row ? row.tier : DEFAULT_TIER;
-    classes[p] = row ? row.class : 'default';
-    if (t > tier) tier = t;
+    let best = -1;
+    let cls = 'default';
+    for (const row of compiled) {
+      if (row.re.test(p) && row.tier > best) { best = row.tier; cls = row.class; }
+    }
+    if (best < 0) { best = DEFAULT_TIER; cls = 'default'; }
+    classes[p] = cls;
+    if (best > tier) tier = best;
   }
-  return { tier, classes };
+  return { tier, classes, lowered, configError };
+}
+
+// How many lenses a tier requires (capped by an explicit config knob, floor 1).
+export function lensesRequired(tier, cfg = null) {
+  const base = tier === 0 ? 0 : tier === 1 ? 1 : 3;
+  const cap = Number(cfg?.lenses);
+  if (base > 0 && Number.isFinite(cap) && cap >= 1) return Math.min(base, Math.floor(cap));
+  return base;
 }
 
 // ---------------------------------------------------------------- candidate
 
+// core.quotePath makes git escape non-ASCII paths ("caf\303\251.js"); the escaped
+// name matches no file on disk, so the file would hash as deleted and any later
+// mutation of it would sail through the gate. -z gives raw NUL-separated paths.
 function git(root, ...args) {
-  const r = spawnSync('git', ['-C', root, ...args], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
-  return r.status === 0 ? (r.stdout || '').trimEnd() : null;
+  const r = spawnSync('git', ['-C', root, '-c', 'core.quotePath=false', ...args], {
+    encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
+  });
+  return r.status === 0 ? (r.stdout || '') : null;
 }
+const nulList = (out) => (out || '').split('\0').filter(Boolean);
 
-function trunkRef(root) {
-  for (const ref of ['origin/main', 'origin/master', 'main', 'master']) {
+export function trunkRef(root, cfg = null) {
+  const configured = typeof cfg?.trunk === 'string' ? [cfg.trunk, `origin/${cfg.trunk}`] : [];
+  for (const ref of [...configured, 'origin/main', 'origin/master', 'main', 'master']) {
     if (git(root, 'rev-parse', '--verify', '--quiet', ref) !== null) return ref;
   }
   return null;
@@ -123,49 +187,62 @@ function trunkRef(root) {
 
 // The candidate is the change vs the trunk merge-base: every path that differs
 // between that base and the working tree (committed on the branch, staged, unstaged
-// or untracked), each hashed byte-for-byte. Deleted paths hash to "D". One byte of
-// difference anywhere → a different candidate.
-export function computeCandidate(root) {
-  const trunk = trunkRef(root);
+// or untracked), each hashed byte-for-byte. Deleted paths hash to "D". Symlinks hash
+// their target string, never the pointed-at bytes (an out-of-repo link must not be
+// read, and a link to a FIFO would hang the hook).
+export function computeCandidate(rawRoot, cfg = null) {
+  const root = resolveRoot(rawRoot);
+  const trunk = trunkRef(root, cfg);
   if (!trunk) return null;
   const head = git(root, 'rev-parse', 'HEAD');
-  const base = head ? git(root, 'merge-base', 'HEAD', trunk) : null;
+  const base = head ? (git(root, 'merge-base', 'HEAD', trunk) || '').trim() : null;
   if (!base) return null;
 
   const names = new Set();
-  for (const line of (git(root, 'diff', '--name-only', base) || '').split('\n')) {
-    if (line) names.add(line);
-  }
-  // Untracked files join the candidate EXCEPT the harness's own .rsc/ state — the
-  // sello's config/state/findings live there, and sealing them would make writing
-  // the sello mutate the very candidate it seals (the system would invalidate
-  // itself). Tracked .rsc/ changes committed on the branch still count above:
-  // deliberate harness-config changes are content; local state is not.
-  for (const line of (git(root, 'ls-files', '--others', '--exclude-standard') || '').split('\n')) {
-    if (line && !line.startsWith('.rsc/')) names.add(line);
-  }
+  for (const n of nulList(git(root, 'diff', '--name-only', '-z', base))) names.add(n);
+  for (const n of nulList(git(root, 'ls-files', '--others', '--exclude-standard', '-z'))) names.add(n);
+  for (const p of SELLO_STATE_PATHS) names.delete(p);
 
   const files = {};
   const numstat = {};
   for (const name of [...names].sort()) {
     const abs = join(root, name);
-    if (existsSync(abs)) {
+    let st = null;
+    try { st = lstatSync(abs); } catch { st = null; }
+    if (!st) { files[name] = 'D'; continue; }
+    if (st.isSymbolicLink()) {
+      files[name] = 'L:' + createHash('sha256').update(readlinkSync(abs)).digest('hex');
+    } else if (st.isFile()) {
       files[name] = createHash('sha256').update(readFileSync(abs)).digest('hex');
     } else {
-      files[name] = 'D';
+      files[name] = 'S'; // socket/fifo/device — never read, but its presence counts
     }
   }
   for (const line of (git(root, 'diff', '--numstat', base) || '').split('\n')) {
     const m = /^(\d+|-)\t(\d+|-)\t(.+)$/.exec(line);
     if (m) numstat[m[3]] = (m[1] === '-' ? 0 : Number(m[1])) + (m[2] === '-' ? 0 : Number(m[2]));
   }
+  // Untracked files never appear in numstat, so a fix hidden in a new file would
+  // cost zero budget. Count their lines.
+  for (const n of nulList(git(root, 'ls-files', '--others', '--exclude-standard', '-z'))) {
+    if (SELLO_STATE_PATHS.includes(n) || numstat[n] !== undefined) continue;
+    try {
+      const st = lstatSync(join(root, n));
+      if (st.isFile()) numstat[n] = readFileSync(join(root, n), 'utf8').split('\n').length;
+    } catch { /* unreadable → not counted */ }
+  }
   return { base, files, numstat };
+}
+
+export function candidateDigest(candidate) {
+  const body = Object.keys(candidate.files).sort().map((p) => `${p}:${candidate.files[p]}`).join('\n');
+  return createHash('sha256').update(`${candidate.base}\n${body}`).digest('hex');
 }
 
 // ---------------------------------------------------------------- sello state
 
 export function readSello(root) {
-  const p = selloPaths(root).state;
+  const p = selloPaths(resolveRoot(root)).state;
   if (!existsSync(p)) return { missing: true };
   try {
     const s = JSON.parse(readFileSync(p, 'utf8'));
@@ -174,28 +251,60 @@ export function readSello(root) {
   } catch { return { corrupt: true }; }
 }
 
-export function writeSello(root, sello) {
-  writeFileSync(selloPaths(root).state, JSON.stringify(sello, null, 2) + '\n');
+export function writeSello(rawRoot, sello) {
+  const p = selloPaths(resolveRoot(rawRoot)).state;
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(sello, null, 2) + '\n');
 }
 
-export function appendFindings(root, lines) {
+// A durable record of what was delivered under which verdict — the sello file
+// itself is overwritten by the next freeze, so without this the trail dies.
+export function appendLog(rawRoot, entry) {
+  const p = selloPaths(resolveRoot(rawRoot)).log;
+  mkdirSync(dirname(p), { recursive: true });
+  appendFileSync(p, JSON.stringify(entry) + '\n');
+}
+
+export function appendFindings(rawRoot, lines) {
   if (!lines?.length) return;
-  const p = selloPaths(root).findings;
+  const p = selloPaths(resolveRoot(rawRoot)).findings;
+  mkdirSync(dirname(p), { recursive: true });
   const header = existsSync(p) ? '' : '# sello — hallazgos no bloqueantes\n\nSe acumulan aquí; `rsc sello report` los muestra. No interrumpen nada.\n';
-  appendFileSync(p, header + lines.map((l) => `- ${l}`).join('\n') + '\n');
+  const flat = lines.map((l) => `- ${String(l).replace(/\s*\n\s*/g, ' ')}`);
+  appendFileSync(p, header + flat.join('\n') + '\n');
 }
 
-export function countFindings(root) {
-  const p = selloPaths(root).findings;
+export function countFindings(rawRoot) {
+  const p = selloPaths(resolveRoot(rawRoot)).findings;
   if (!existsSync(p)) return 0;
   return readFileSync(p, 'utf8').split('\n').filter((l) => l.startsWith('- ')).length;
+}
+
+// ---------------------------------------------------------------- delivery detection
+//
+// Does this shell command actually DELIVER? Two failure modes to avoid, both real:
+// denying `grep -rn "git push" docs/` (the words inside a string are not a delivery)
+// and allowing `git -C . commit` (a first-class agent pattern — cwd resets between
+// Bash calls, so agents pass -C routinely).
+// Flags that may sit between the binary and the subcommand: --long, --long=value,
+// and single-letter flags that take a separate value (-C path, -c k=v, -R owner/repo).
+const GIT_OPTS = '(?:-{1,2}[\\w-]+(?:=\\S+)?\\s+|-[A-Za-z]\\s+\\S+\\s+)*';
+const GIT_DELIVERY = new RegExp(`\\bgit\\s+${GIT_OPTS}(?:commit|push)(?![\\w-])`);
+const GH_DELIVERY = new RegExp(`\\bgh\\s+${GIT_OPTS}pr\\s+${GIT_OPTS}(?:create|merge)(?![\\w-])`);
+
+export function isDeliveryCommand(command) {
+  if (typeof command !== 'string' || !command) return false;
+  // Blank out quoted strings so a command that merely MENTIONS the words is not
+  // mistaken for one that runs them.
+  const bare = command.replace(/'[^']*'/g, "''").replace(/"[^"]*"/g, '""');
+  return GIT_DELIVERY.test(bare) || GH_DELIVERY.test(bare);
 }
 
 // ---------------------------------------------------------------- messages (P6)
 //
 // Every message that can DENY an action carries a `Recover:` line naming the exact
-// way out. tests/sello.test.js asserts this for every entry — a block without its
-// recovery is the one thing this system is not allowed to produce.
+// way out. tests/sello.test.js iterates MESSAGES and asserts this for every entry —
+// a block without its recovery is the one thing this system may never produce.
 
 export const MESSAGES = {
   noReview: (tier) =>
@@ -205,7 +314,7 @@ export const MESSAGES = {
     `sello: the change no longer matches what was reviewed — ${paths.slice(0, 5).join(', ')}${paths.length > 5 ? ` (+${paths.length - 5} more)` : ''} differ from the sealed bytes. ` +
     `Recover: re-run the \`review\` skill on the divergence (only what changed is re-reviewed), or \`npx @ericrisco/rsc sello off\` for this project.`,
   baseMoved: () =>
-    `sello: the branch base moved (rebase/merge) since the review — the same diff on a new base is a new candidate. ` +
+    `sello: the sello belongs to a different base — the branch was rebased/merged, or this sello was left over from a change that already shipped. Either way nothing has reviewed the current candidate. ` +
     `Recover: re-run the \`review\` skill (only the divergence is re-reviewed), or \`npx @ericrisco/rsc sello off\` for this project.`,
   corrupt: () =>
     `sello: the sello file is unreadable, which counts as "no review" — nothing is ever approved by default. ` +
@@ -222,11 +331,17 @@ export const MESSAGES = {
   overBudget: (spent, budget) =>
     `sello: the fix touched ~${spent} line(s) but the declared budget was ${budget} — an unexplained overrun is how over-engineering gets in. ` +
     `Recover: re-run with --justify "<why the budget was not enough>" to record the reason, or shrink the fix.`,
+  partialLenses: (given, required) =>
+    `sello: risk tier needs ${required} lens(es) but only ${given} were recorded — an incomplete panel must not seal silently. ` +
+    `Recover: run the missing lenses and pass them all to --lenses, or accept the gap on purpose with --accept-partial-lenses.`,
   badRiskConfig:
-    'Recover: fix .rsc/sello-config.json — "raise" entries need a valid pattern; "lower" only accepts known classes and never "secrets" or "harness".',
+    'Recover: fix .rsc/sello-config.json — "raise" entries need a valid pattern under 200 chars; "lower" only accepts known classes and never "secrets" or "harness". `npx @ericrisco/rsc sello off` always works, even with a broken config.',
   riskUnknown: () =>
     `sello: the risk of this change could not be evaluated, so it is treated as risk tier 1 (never silently as 0). ` +
-    `Recover: check that this is a git repository with a reachable trunk (origin/main or main), then retry.`,
+    `Recover: check that this is a git repository with a reachable trunk (origin/main, main, or "trunk" in .rsc/sello-config.json), then retry.`,
+  noTrunk: () =>
+    `sello: no trunk branch found (looked for origin/main, origin/master, main, master), so the gate cannot compute what changed and is standing down. ` +
+    `Recover: set {"trunk": "<your branch>"} in .rsc/sello-config.json so the sello knows what to diff against.`,
 };
 
 // ---------------------------------------------------------------- the check
@@ -234,31 +349,31 @@ export const MESSAGES = {
 // The single verdict function the guard, the CLI and the tests all share.
 // → {ok: true, code} | {ok: false, code, message}
 
-export function checkSello(root) {
+export function checkSello(rawRoot) {
+  const root = resolveRoot(rawRoot);
   const cfg = readConfig(root);
   if (!cfg || cfg.enabled !== true) return { ok: true, code: 'disabled' };
 
-  const candidate = computeCandidate(root);
-  if (!candidate) return { ok: true, code: 'no-repo' }; // fail-open: nothing to measure
+  const candidate = computeCandidate(root, cfg);
+  if (!candidate) {
+    // Fail open, but never silently: doctor/status surface this so an inert gate
+    // in a develop-based repo cannot masquerade as an armed one.
+    return { ok: true, code: 'no-trunk', warning: MESSAGES.noTrunk() };
+  }
 
   const paths = Object.keys(candidate.files);
   if (paths.length === 0) return { ok: true, code: 'clean' };
 
-  let risk;
-  try { risk = classifyRisk(paths, cfg); }
-  catch { risk = { tier: DEFAULT_TIER, classes: {} }; } // spec: never silently down to 0
+  const risk = classifyRisk(paths, cfg);
+  // P7 first, before any sello state is consulted: a docs-only change must never
+  // be blocked by a leftover sello from some other change.
+  if (risk.tier === 0) return { ok: true, code: 'risk0' };
 
   const sello = readSello(root);
-  if (sello.missing) {
-    if (risk.tier === 0) return { ok: true, code: 'risk0' }; // P7: silence for docs/copy
-    return { ok: false, code: 'no-review', message: MESSAGES.noReview(risk.tier) };
-  }
+  if (sello.missing) return { ok: false, code: 'no-review', message: MESSAGES.noReview(risk.tier) };
   if (sello.corrupt) return { ok: false, code: 'corrupt', message: MESSAGES.corrupt() };
   if (sello.status === 'blocked') return { ok: false, code: 'blocked', message: MESSAGES.blocked(sello.reason) };
-  if (sello.status !== 'approved') {
-    if (risk.tier === 0) return { ok: true, code: 'risk0' };
-    return { ok: false, code: 'no-review', message: MESSAGES.noReview(risk.tier) };
-  }
+  if (sello.status !== 'approved') return { ok: false, code: 'no-review', message: MESSAGES.noReview(risk.tier) };
   if (sello.base !== candidate.base) return { ok: false, code: 'base-moved', message: MESSAGES.baseMoved() };
 
   const diverged = [];
@@ -270,7 +385,9 @@ export function checkSello(root) {
   return { ok: true, code: 'sealed' };
 }
 
-// Fix-budget accounting: |numstat delta| vs the frozen totals, plus new files.
+// Fix-budget accounting: |numstat delta| vs the frozen totals (untracked files
+// included — see computeCandidate). Approximate by construction: a same-size
+// rewrite costs 0 and a moved hunk double-counts. It bounds sprawl, not edits.
 export function budgetSpent(frozen, current) {
   let spent = 0;
   const all = new Set([...Object.keys(frozen.numstat || {}), ...Object.keys(current.numstat || {})]);

--- a/targets/ship-guard.mjs
+++ b/targets/ship-guard.mjs
@@ -42,6 +42,22 @@ if ((input.tool_name || input.toolName) !== 'Bash') allow();
 const command = input.tool_input?.command || input.toolInput?.command || '';
 if (typeof command !== 'string' || !command) allow();
 
+// ---- sello gate (opt-in) ----------------------------------------------------
+// When the sello is ON for this project, delivery commands (commit, push, PR)
+// must match the sealed bytes. OFF (the default) → this block is a no-op and the
+// guard behaves exactly as before. checkSello itself fails open on environment
+// problems and denies only on real divergence/no-review/corruption (spec).
+const DELIVERY = /\bgit\s+commit\b|\bgit\s+push\b|\bgh\s+pr\s+(?:create|merge)\b/;
+if (DELIVERY.test(command)) {
+  try {
+    const { checkSello, isEnabled } = await import(new URL('./sello.mjs', import.meta.url));
+    if (isEnabled(root)) {
+      const verdict = checkSello(root);
+      if (!verdict.ok) deny(verdict.message);
+    }
+  } catch { /* sello lib missing/unloadable → nothing to enforce, fail open */ }
+}
+
 // Does this command try to land on / move to the trunk?
 const TRUNK = /\bgit\s+(?:checkout|switch)\s+(?:-{1,2}\S+\s+)*(?:main|master)\b/;
 const MERGE = /\bgit\s+merge\b/;

--- a/targets/ship-guard.mjs
+++ b/targets/ship-guard.mjs
@@ -31,8 +31,9 @@ function deny(reason) {
   process.exit(0);
 }
 
-// Opt-out and "not a git repo" both mean: nothing to enforce.
-if (existsSync(join(root, '.rsc', '.no-ship-guard'))) allow();
+// "Not a git repo" means: nothing to enforce. (The .no-ship-guard opt-out is checked
+// AFTER the sello below — it opts out of THIS guard's branch-hygiene rules, not of a
+// different feature that happens to share the hook. The sello has its own switch.)
 if (!existsSync(join(root, '.git'))) allow();
 
 // Read the tool call. Only Bash commands can move branches.
@@ -47,16 +48,18 @@ if (typeof command !== 'string' || !command) allow();
 // must match the sealed bytes. OFF (the default) → this block is a no-op and the
 // guard behaves exactly as before. checkSello itself fails open on environment
 // problems and denies only on real divergence/no-review/corruption (spec).
-const DELIVERY = /\bgit\s+commit\b|\bgit\s+push\b|\bgh\s+pr\s+(?:create|merge)\b/;
-if (DELIVERY.test(command)) {
-  try {
-    const { checkSello, isEnabled } = await import(new URL('./sello.mjs', import.meta.url));
-    if (isEnabled(root)) {
-      const verdict = checkSello(root);
-      if (!verdict.ok) deny(verdict.message);
-    }
-  } catch { /* sello lib missing/unloadable → nothing to enforce, fail open */ }
-}
+// Deliberately BEFORE the .no-ship-guard opt-out: that file disables this guard's
+// branch-hygiene rules; the sello is a separate opt-in with its own `sello off`.
+try {
+  const { checkSello, isEnabled, isDeliveryCommand } = await import(new URL('./sello.mjs', import.meta.url));
+  if (isDeliveryCommand(command) && isEnabled(root)) {
+    const verdict = checkSello(root);
+    if (!verdict.ok) deny(verdict.message);
+  }
+} catch { /* sello lib missing/unloadable → nothing to enforce, fail open */ }
+
+// Ship-guard's own opt-out (branch hygiene only — the sello above already ran).
+if (existsSync(join(root, '.rsc', '.no-ship-guard'))) allow();
 
 // Does this command try to land on / move to the trunk?
 const TRUNK = /\bgit\s+(?:checkout|switch)\s+(?:-{1,2}\S+\s+)*(?:main|master)\b/;

--- a/tests/sello.test.js
+++ b/tests/sello.test.js
@@ -1,0 +1,264 @@
+// sello.test.js — the tests the constitution demands for the sello:
+//  P2: every gate proves it gates (no decorative gates — this repo already paid for four).
+//  P6: every deny message carries its `Recover:` line, asserted here, not assumed.
+//  P7: risk-0 changes pass in silence; kill-switch parity is byte-exact.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import {
+  MESSAGES, RISK_TABLE, FLOOR_CLASSES, classifyRisk, validateRiskConfig,
+  computeCandidate, checkSello, writeSello, readSello, budgetSpent,
+  isEnabled, selloPaths, appendFindings, countFindings,
+} from '../targets/sello.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SHIP_GUARD = join(HERE, '..', 'targets', 'ship-guard.mjs');
+
+// --- fixture: a real git repo with a trunk and a feature branch -----------------
+
+function sh(root, cmd, args) {
+  const r = spawnSync(cmd, args, { cwd: root, encoding: 'utf8' });
+  assert.equal(r.status, 0, `${cmd} ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+const g = (root, ...args) => sh(root, 'git', args);
+
+function makeRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'rsc-sello-'));
+  g(root, 'init', '-b', 'main');
+  g(root, 'config', 'user.email', 'test@example.com');
+  g(root, 'config', 'user.name', 'Test');
+  writeFileSync(join(root, 'app.js'), 'export const x = 1;\n');
+  writeFileSync(join(root, 'README.md'), '# readme\n');
+  g(root, 'add', '.');
+  g(root, 'commit', '-m', 'init');
+  g(root, 'checkout', '-b', 'feature');
+  mkdirSync(join(root, '.rsc'), { recursive: true });
+  return root;
+}
+function enable(root, extra = {}) {
+  writeFileSync(selloPaths(root).config, JSON.stringify({ enabled: true, ...extra }));
+}
+function freezeApprove(root) {
+  const c = computeCandidate(root);
+  writeSello(root, { status: 'approved', ...c, risk: classifyRisk(Object.keys(c.files)), lenses: ['correctness'] });
+}
+
+// Run the real ship-guard binary the way Claude Code does (stdin hook JSON).
+function runGuard(root, command) {
+  const input = JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
+  const r = spawnSync('node', [SHIP_GUARD, root], { encoding: 'utf8', input });
+  try { return JSON.parse(r.stdout).hookSpecificOutput?.permissionDecision === 'deny' ? JSON.parse(r.stdout) : null; }
+  catch { return null; } // empty stdout = allow
+}
+
+// --- P6: every deny message carries its recovery ---------------------------------
+
+test('sello: every message names its recovery action', () => {
+  const rendered = [
+    MESSAGES.noReview(1), MESSAGES.diverged(['a', 'b']), MESSAGES.baseMoved(),
+    MESSAGES.corrupt(), MESSAGES.blocked('x'), MESSAGES.notFrozen(),
+    MESSAGES.staleFreeze(), MESSAGES.overBudget(10, 5), MESSAGES.badRiskConfig,
+    MESSAGES.riskUnknown(),
+  ];
+  assert.equal(rendered.length, Object.keys(MESSAGES).length, 'every MESSAGES entry is asserted here — add new ones to this list');
+  for (const m of rendered) {
+    assert.match(m, /Recover:/, `message lacks its recovery: ${m}`);
+  }
+});
+
+// --- risk table: integrity + classification --------------------------------------
+
+test('sello: default risk table is intact (patterns compile, tiers valid, floor present)', () => {
+  for (const row of RISK_TABLE) {
+    assert.ok(row.class && typeof row.class === 'string');
+    assert.ok([0, 1, 2].includes(row.tier), `bad tier for ${row.class}`);
+    assert.doesNotThrow(() => new RegExp(row.pattern), `uncompilable pattern for ${row.class}`);
+  }
+  for (const cls of FLOOR_CLASSES) {
+    assert.ok(RISK_TABLE.some((r) => r.class === cls && r.tier === 2), `floor class ${cls} missing or lowered in the default table`);
+  }
+});
+
+test('sello: risk classifies by what is touched, not how much', () => {
+  assert.equal(classifyRisk(['README.md', 'docs/guide.md']).tier, 0);
+  assert.equal(classifyRisk(['src/feature.js']).tier, 1);
+  assert.equal(classifyRisk(['.github/workflows/ci.yml']).tier, 2);
+  assert.equal(classifyRisk(['src/auth/login.js']).tier, 2);
+  assert.equal(classifyRisk(['.env.production']).tier, 2);
+  assert.equal(classifyRisk(['README.md', 'src/x.js', 'migrations/001.sql']).tier, 2, 'tier is the max across files');
+});
+
+test('sello: overrides raise freely, lower explicitly, and never lower the floor', () => {
+  const raised = classifyRisk(['src/pricing-engine.js'], { risk: { raise: [{ class: 'pricing', pattern: 'pricing' }] } });
+  assert.equal(raised.tier, 2);
+  const lowered = classifyRisk(['migrations/001.sql'], { risk: { lower: ['migrations'] } });
+  assert.equal(lowered.tier, 1, 'lowering lands on 1, never 0');
+  assert.throws(() => validateRiskConfig({ risk: { lower: ['secrets'] } }), /never be lowered/);
+  assert.throws(() => validateRiskConfig({ risk: { lower: ['harness'] } }), /never be lowered/);
+  assert.throws(() => validateRiskConfig({ risk: { lower: ['nope'] } }), /unknown class/);
+  assert.throws(() => validateRiskConfig({ risk: { raise: [{ pattern: '(' }] } }));
+});
+
+// --- candidate: byte-exact ---------------------------------------------------------
+
+test('sello: one byte of change produces a different candidate', () => {
+  const root = makeRepo();
+  writeFileSync(join(root, 'app.js'), 'export const x = 2;\n');
+  const a = computeCandidate(root);
+  assert.ok(a.files['app.js']);
+  writeFileSync(join(root, 'app.js'), 'export const x = 3;\n');
+  const b = computeCandidate(root);
+  assert.notEqual(a.files['app.js'], b.files['app.js']);
+  assert.equal(a.base, b.base);
+});
+
+// --- the check: every spec path -----------------------------------------------------
+
+test('sello: disabled → everything passes (kill-switch parity)', () => {
+  const root = makeRepo();
+  writeFileSync(join(root, 'src.js'), 'unreviewed\n');
+  assert.equal(checkSello(root).ok, true);
+  assert.equal(checkSello(root).code, 'disabled');
+  writeFileSync(selloPaths(root).config, JSON.stringify({ enabled: false }));
+  assert.equal(checkSello(root).code, 'disabled');
+});
+
+test('sello: enabled + docs-only change → silent pass (risk 0)', () => {
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, 'README.md'), '# changed docs\n');
+  const v = checkSello(root);
+  assert.equal(v.ok, true);
+  assert.equal(v.code, 'risk0');
+});
+
+test('sello: enabled + code change without review → deny with recovery', () => {
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, 'app.js'), 'changed\n');
+  const v = checkSello(root);
+  assert.equal(v.ok, false);
+  assert.equal(v.code, 'no-review');
+  assert.match(v.message, /Recover:/);
+});
+
+test('sello: sealed bytes pass; a single mutated byte denies', () => {
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, 'app.js'), 'export const x = 2;\n');
+  freezeApprove(root);
+  assert.equal(checkSello(root).code, 'sealed');
+  writeFileSync(join(root, 'app.js'), 'export const x = 2;;\n'); // one byte
+  const v = checkSello(root);
+  assert.equal(v.code, 'diverged');
+  assert.match(v.message, /app\.js/);
+  assert.match(v.message, /Recover:/);
+});
+
+test('sello: a moved base invalidates the sello (rebase rule)', () => {
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, 'app.js'), 'export const x = 2;\n');
+  g(root, 'add', '.'); g(root, 'commit', '-m', 'feature work');
+  freezeApprove(root);
+  assert.equal(checkSello(root).code, 'sealed');
+  // trunk advances; the branch rebases onto it → same diff, new base, new candidate
+  g(root, 'checkout', 'main');
+  writeFileSync(join(root, 'other.js'), 'trunk moved\n');
+  g(root, 'add', '.'); g(root, 'commit', '-m', 'trunk');
+  g(root, 'checkout', 'feature');
+  g(root, 'rebase', 'main');
+  const v = checkSello(root);
+  assert.equal(v.code, 'base-moved');
+  assert.match(v.message, /Recover:/);
+});
+
+test('sello: corrupt sello counts as no review — never approved by default', () => {
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, 'app.js'), 'changed\n');
+  writeFileSync(selloPaths(root).state, '{not json');
+  const v = checkSello(root);
+  assert.equal(v.code, 'corrupt');
+  assert.match(v.message, /Recover:/);
+});
+
+test('sello: a blocked verdict blocks delivery', () => {
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, 'app.js'), 'changed\n');
+  const c = computeCandidate(root);
+  writeSello(root, { status: 'blocked', ...c, reason: 'authz gap' });
+  const v = checkSello(root);
+  assert.equal(v.code, 'blocked');
+  assert.match(v.message, /authz gap/);
+});
+
+// --- the guard: the gate fires on delivery commands, and only when enabled ----------
+
+test('ship-guard: sello OFF → commit/push/PR flow untouched (parity)', () => {
+  const root = makeRepo();
+  writeFileSync(join(root, 'app.js'), 'unreviewed\n');
+  assert.equal(runGuard(root, 'git commit -m "x"'), null);
+  assert.equal(runGuard(root, 'git push origin feature'), null);
+  assert.equal(runGuard(root, 'gh pr create --title x'), null);
+});
+
+test('ship-guard: sello ON denies unreviewed delivery on all three commands, with recovery', () => {
+  const root = makeRepo();
+  enable(root);
+  // sello.mjs must sit next to the guard exactly as materialization places it —
+  // run the guard from a copy of both, like a real install.
+  writeFileSync(join(root, 'app.js'), 'unreviewed\n');
+  for (const cmd of ['git commit -m "x"', 'git push', 'gh pr create']) {
+    const denial = runGuard(root, cmd);
+    assert.ok(denial, `expected a deny for: ${cmd}`);
+    assert.match(denial.hookSpecificOutput.permissionDecisionReason, /Recover:/);
+  }
+});
+
+test('ship-guard: sello ON + sealed bytes → delivery allowed', () => {
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, 'app.js'), 'reviewed\n');
+  freezeApprove(root);
+  assert.equal(runGuard(root, 'git commit -m "x"'), null);
+});
+
+test('ship-guard: non-delivery commands never consult the sello', () => {
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, 'app.js'), 'unreviewed\n');
+  assert.equal(runGuard(root, 'ls -la'), null);
+  assert.equal(runGuard(root, 'git status'), null);
+});
+
+// --- fix budget ----------------------------------------------------------------------
+
+test('sello: budget accounting measures the fix delta', () => {
+  const root = makeRepo();
+  writeFileSync(join(root, 'app.js'), 'line1\nline2\n');
+  const frozen = computeCandidate(root);
+  writeFileSync(join(root, 'app.js'), 'line1\nline2\nline3\nline4\nline5\n');
+  const current = computeCandidate(root);
+  const spent = budgetSpent(frozen, current);
+  assert.ok(spent >= 3, `expected >=3 lines spent, got ${spent}`);
+  assert.equal(budgetSpent(frozen, frozen), 0, 'no fix → zero spent');
+});
+
+// --- findings artifact ------------------------------------------------------------------
+
+test('sello: non-blocking findings accumulate in a readable artifact', () => {
+  const root = makeRepo();
+  assert.equal(countFindings(root), 0);
+  appendFindings(root, ['pre-existing: N+1 in listUsers', 'nit: rename x']);
+  appendFindings(root, ['pre-existing: missing index on orders.user_id']);
+  assert.equal(countFindings(root), 3);
+  const text = readFileSync(selloPaths(root).findings, 'utf8');
+  assert.match(text, /N\+1/);
+});

--- a/tests/sello.test.js
+++ b/tests/sello.test.js
@@ -4,19 +4,22 @@
 //  P7: risk-0 changes pass in silence; kill-switch parity is byte-exact.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   MESSAGES, RISK_TABLE, FLOOR_CLASSES, classifyRisk, validateRiskConfig,
-  computeCandidate, checkSello, writeSello, readSello, budgetSpent,
-  isEnabled, selloPaths, appendFindings, countFindings,
+  computeCandidate, checkSello, writeSello, budgetSpent, lensesRequired,
+  selloPaths, appendFindings, countFindings, isDeliveryCommand, SELLO_STATE_PATHS,
 } from '../targets/sello.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const SHIP_GUARD = join(HERE, '..', 'targets', 'ship-guard.mjs');
+const REPO = join(HERE, '..');
+const SHIP_GUARD = join(REPO, 'targets', 'ship-guard.mjs');
+const RSC = join(REPO, 'scripts', 'rsc.js');
 
 // --- fixture: a real git repo with a trunk and a feature branch -----------------
 
@@ -49,25 +52,28 @@ function freezeApprove(root) {
 }
 
 // Run the real ship-guard binary the way Claude Code does (stdin hook JSON).
+// A crash must NOT read as "allow" — otherwise the parity tests would pass on a
+// guard that merely fell over.
 function runGuard(root, command) {
   const input = JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
   const r = spawnSync('node', [SHIP_GUARD, root], { encoding: 'utf8', input });
-  try { return JSON.parse(r.stdout).hookSpecificOutput?.permissionDecision === 'deny' ? JSON.parse(r.stdout) : null; }
-  catch { return null; } // empty stdout = allow
+  assert.equal(r.status, 0, `guard crashed (exit ${r.status}): ${r.stderr}`);
+  assert.equal(r.stderr.trim(), '', `guard wrote to stderr: ${r.stderr}`);
+  if (!r.stdout.trim()) return null; // silence = allow
+  const parsed = JSON.parse(r.stdout); // a non-JSON body is a bug, let it throw
+  return parsed.hookSpecificOutput?.permissionDecision === 'deny' ? parsed : null;
 }
+const runCli = (root, ...args) => spawnSync('node', [RSC, 'sello', ...args], { cwd: root, encoding: 'utf8' });
 
 // --- P6: every deny message carries its recovery ---------------------------------
 
 test('sello: every message names its recovery action', () => {
-  const rendered = [
-    MESSAGES.noReview(1), MESSAGES.diverged(['a', 'b']), MESSAGES.baseMoved(),
-    MESSAGES.corrupt(), MESSAGES.blocked('x'), MESSAGES.notFrozen(),
-    MESSAGES.staleFreeze(), MESSAGES.overBudget(10, 5), MESSAGES.badRiskConfig,
-    MESSAGES.riskUnknown(),
-  ];
-  assert.equal(rendered.length, Object.keys(MESSAGES).length, 'every MESSAGES entry is asserted here — add new ones to this list');
-  for (const m of rendered) {
-    assert.match(m, /Recover:/, `message lacks its recovery: ${m}`);
+  // Iterate the object itself — a new message cannot be added without being checked.
+  const sample = { noReview: [1], diverged: [['a', 'b']], blocked: ['x'], overBudget: [10, 5], partialLenses: [1, 3] };
+  for (const [key, value] of Object.entries(MESSAGES)) {
+    const rendered = typeof value === 'function' ? value(...(sample[key] || [])) : value;
+    assert.equal(typeof rendered, 'string', `MESSAGES.${key} did not render to a string`);
+    assert.match(rendered, /Recover:/, `MESSAGES.${key} lacks its recovery: ${rendered}`);
   }
 });
 
@@ -252,6 +258,240 @@ test('sello: budget accounting measures the fix delta', () => {
 });
 
 // --- findings artifact ------------------------------------------------------------------
+
+// --- regressions found by the adversarial review panel ---------------------------
+// Each of these shipped as a passing implementation and was refuted by a lens.
+
+test('sello: a floor class wins over the docs row even when both match (B1)', () => {
+  // First-match-wins let `.claude/CLAUDE.md`, `credentials.txt` and `docs/prod.pem`
+  // classify as docs/tier-0 — a silent pass for exactly what the floor guards.
+  for (const p of ['.claude/CLAUDE.md', 'CLAUDE.md', 'credentials.txt', 'docs/prod.pem', 'docs/.env', 'secrets/README.md', '.rsc/policy.md']) {
+    assert.equal(classifyRisk([p]).tier, 2, `${p} must not be risk-0`);
+  }
+  assert.equal(classifyRisk(['docs/guide.md']).tier, 0, 'plain docs stay silent');
+});
+
+test('sello: paths git would quote are hashed for real, not as deleted (B2)', () => {
+  // core.quotePath turns café.js into "caf\303\251.js"; the escaped name matches no
+  // file, so both freeze and check saw "D" and any later mutation passed as sealed.
+  const root = makeRepo();
+  enable(root);
+  const name = 'facturación.js';
+  writeFileSync(join(root, name), 'const a = 1;\n');
+  const c = computeCandidate(root);
+  assert.ok(c.files[name], `expected a raw key for ${name}, got ${JSON.stringify(Object.keys(c.files))}`);
+  assert.notEqual(c.files[name], 'D', 'an existing file must never hash as deleted');
+  freezeApprove(root);
+  assert.equal(checkSello(root).code, 'sealed');
+  writeFileSync(join(root, name), 'const a = BACKDOOR;\n');
+  assert.equal(checkSello(root).code, 'diverged', 'a mutation of an accented path must be caught');
+});
+
+test('sello: its own state never enters the candidate, tracked or not (B3)', () => {
+  // With .rsc/ tracked, writing the sello mutated the candidate it sealed →
+  // staleFreeze forever → permanent delivery lockout whose documented recovery looped.
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, 'app.js'), 'work\n');
+  g(root, 'add', '-A'); g(root, 'commit', '-m', 'track .rsc too');
+  const c1 = computeCandidate(root);
+  for (const p of SELLO_STATE_PATHS) {
+    assert.equal(c1.files[p], undefined, `${p} must never be part of the candidate`);
+  }
+  freezeApprove(root);
+  const c2 = computeCandidate(root);
+  assert.equal(c1.base, c2.base);
+  assert.deepEqual(Object.keys(c1.files), Object.keys(c2.files), 'writing the sello must not change the candidate');
+  assert.equal(checkSello(root).code, 'sealed', 'freeze→approve must converge with .rsc/ tracked');
+});
+
+test('sello: risk-0 passes even with a stale blocked/corrupt sello left over (B4)', () => {
+  const root = makeRepo();
+  enable(root);
+  // A previous change was blocked; it is fully reverted and only docs change now.
+  writeFileSync(join(root, 'app.js'), 'risky\n');
+  const c = computeCandidate(root);
+  writeSello(root, { status: 'blocked', ...c, reason: 'authz gap' });
+  writeFileSync(join(root, 'app.js'), 'export const x = 1;\n'); // reverted to trunk content
+  writeFileSync(join(root, 'README.md'), '# docs only now\n');
+  assert.equal(checkSello(root).code, 'risk0', 'a docs-only change must not inherit an old verdict');
+  writeFileSync(selloPaths(root).state, '{not json');
+  assert.equal(checkSello(root).code, 'risk0', 'nor a corrupt leftover');
+});
+
+test('sello: delivery detection resists both evasion and false positives (B5)', () => {
+  for (const c of [
+    'git commit -m x', 'git -C /some/path commit -m x', 'git -c user.name=x commit -m x',
+    'git --no-pager commit', 'git push', 'git -C . push origin feature',
+    'gh pr create --title x', 'gh pr merge --squash', 'gh -R o/r pr create',
+  ]) assert.equal(isDeliveryCommand(c), true, `should be a delivery: ${c}`);
+
+  for (const c of [
+    'grep -rn "git push" docs/', "grep -rn 'git commit' .", 'echo "remember to git commit later"',
+    'git log --grep="git push"', 'git status', 'git commit-tree abc', 'git commit-graph write',
+    'ls -la', 'git merge-base HEAD main',
+  ]) assert.equal(isDeliveryCommand(c), false, `should NOT be a delivery: ${c}`);
+});
+
+test('ship-guard: .no-ship-guard opts out of branch hygiene but NOT of the sello (B6)', () => {
+  const root = makeRepo();
+  enable(root);
+  writeFileSync(join(root, '.rsc', '.no-ship-guard'), '');
+  writeFileSync(join(root, 'app.js'), 'unreviewed\n');
+  const denial = runGuard(root, 'git commit -m x');
+  assert.ok(denial, 'the sello must still enforce when only ship-guard is opted out');
+  assert.match(denial.hookSpecificOutput.permissionDecisionReason, /sello/);
+});
+
+test('sello: a non-main trunk is honored via config, and an inert gate says so (B7)', () => {
+  const root = mkdtempSync(join(tmpdir(), 'rsc-sello-dev-'));
+  g(root, 'init', '-b', 'develop');
+  g(root, 'config', 'user.email', 't@t'); g(root, 'config', 'user.name', 'T');
+  writeFileSync(join(root, 'app.js'), 'x\n');
+  g(root, 'add', '.'); g(root, 'commit', '-m', 'init');
+  g(root, 'checkout', '-b', 'feature');
+  mkdirSync(join(root, '.rsc'), { recursive: true });
+  writeFileSync(join(root, 'src.js'), 'unreviewed\n');
+  // No trunk configured → stands down, but LABELS itself instead of lying.
+  enable(root);
+  const inert = checkSello(root);
+  assert.equal(inert.code, 'no-trunk');
+  assert.match(inert.warning, /Recover:/);
+  // Configured → the gate works normally.
+  enable(root, { trunk: 'develop' });
+  assert.equal(checkSello(root).code, 'no-review');
+});
+
+test('sello: a broken risk config falls back to the DEFAULT table, never a flat tier (B8)', () => {
+  const root = makeRepo();
+  enable(root, { risk: { raise: [{ pattern: '(' }] } });
+  writeFileSync(join(root, '.env.production'), 'SECRET=1\n');
+  const risk = classifyRisk(['.env.production'], { risk: { raise: [{ pattern: '(' }] } });
+  assert.equal(risk.tier, 2, 'the floor must survive a malformed config');
+  assert.match(risk.configError, /Recover:/);
+  assert.equal(checkSello(root).code, 'no-review');
+});
+
+test('sello: `off` works even when the config is malformed (B9)', () => {
+  const root = makeRepo();
+  writeFileSync(selloPaths(root).config, JSON.stringify({ enabled: true, risk: { raise: [{ pattern: '(' }] } }));
+  const r = runCli(root, 'off');
+  assert.equal(r.status, 0, `sello off must never be locked away by a broken config: ${r.stdout}${r.stderr}`);
+  assert.equal(checkSello(root).code, 'disabled');
+});
+
+test('sello: symlinks hash their target, never the pointed-at bytes (B10)', () => {
+  const root = makeRepo();
+  const outside = join(root, '..', `sello-outside-${process.pid}`);
+  writeFileSync(outside, 'SECRET MATERIAL\n');
+  symlinkSync(outside, join(root, 'link.txt'));
+  const c = computeCandidate(root);
+  assert.match(c.files['link.txt'], /^L:/, 'a symlink must be marked and hashed by target');
+  const secretHash = createHash('sha256').update(readFileSync(outside)).digest('hex');
+  assert.notEqual(c.files['link.txt'], secretHash, 'out-of-repo content must never be read into the sello');
+});
+
+// --- CLI: the 100+ lines the panel proved were entirely untested --------------------
+
+test('sello CLI: full lifecycle on/freeze/approve/check/status/report', () => {
+  const root = makeRepo();
+  assert.equal(runCli(root, 'on').status, 0);
+  writeFileSync(join(root, 'app.js'), 'changed\n');
+  assert.equal(runCli(root, 'check').status, 1, 'unreviewed risk>0 must fail the check');
+  assert.match(runCli(root, 'freeze').stdout, /risk tier 1 → 1 lens/);
+  const ok = runCli(root, 'approve', '--lenses', 'correctness');
+  assert.equal(ok.status, 0, ok.stdout + ok.stderr);
+  assert.equal(runCli(root, 'check').status, 0);
+  const status = JSON.parse(runCli(root, 'status').stdout);
+  assert.equal(status.enabled, true);
+  assert.equal(status.check, 'sealed');
+  assert.equal(status.lensesRequired, 1);
+  // The durable trail survives the next freeze (spec: "saber después qué se entregó").
+  const log = readFileSync(selloPaths(root).log, 'utf8').trim().split('\n').map((l) => JSON.parse(l));
+  assert.equal(log.length, 1);
+  assert.equal(log[0].status, 'approved');
+  assert.ok(log[0].digest);
+});
+
+test('sello CLI: a tier-2 change cannot be sealed with zero lenses', () => {
+  const root = makeRepo();
+  runCli(root, 'on');
+  mkdirSync(join(root, '.github', 'workflows'), { recursive: true });
+  writeFileSync(join(root, '.github/workflows/ci.yml'), 'on: push\n');
+  assert.match(runCli(root, 'freeze').stdout, /risk tier 2 → 3 lens/);
+  const bare = runCli(root, 'approve');
+  assert.equal(bare.status, 1, 'an empty panel must not seal a tier-2 change');
+  assert.match(bare.stdout, /Recover:/);
+  const partial = runCli(root, 'approve', '--lenses', 'correctness', '--accept-partial-lenses');
+  assert.equal(partial.status, 0, 'the gap may be accepted on purpose');
+  assert.equal(JSON.parse(readFileSync(selloPaths(root).log, 'utf8').trim()).partialLenses, true);
+});
+
+test('sello CLI: valueless flags are usage errors, not crashes', () => {
+  const root = makeRepo();
+  runCli(root, 'on');
+  writeFileSync(join(root, 'app.js'), 'changed\n');
+  runCli(root, 'freeze');
+  const r = runCli(root, 'approve', '--lenses');
+  assert.equal(r.status, 1);
+  assert.doesNotMatch(r.stdout + r.stderr, /is not a function|TypeError/);
+});
+
+test('sello CLI: freeze works from a subdirectory and from a repo with no .rsc yet', () => {
+  const root = makeRepo();
+  runCli(root, 'on');
+  mkdirSync(join(root, 'src', 'deep'), { recursive: true });
+  writeFileSync(join(root, 'src', 'deep', 'mod.js'), 'x\n');
+  const r = spawnSync('node', [RSC, 'sello', 'freeze'], { cwd: join(root, 'src', 'deep'), encoding: 'utf8' });
+  assert.equal(r.status, 0, r.stdout + r.stderr);
+  // The path must be repo-root-relative, or the guard's candidate would never match.
+  const sealed = JSON.parse(readFileSync(selloPaths(root).state, 'utf8'));
+  assert.ok(sealed.files['src/deep/mod.js'], `expected repo-relative key, got ${JSON.stringify(Object.keys(sealed.files))}`);
+});
+
+test('sello CLI: budget-check denies an unexplained overrun and records a justified one', () => {
+  const root = makeRepo();
+  runCli(root, 'on');
+  writeFileSync(join(root, 'app.js'), 'a\n');
+  runCli(root, 'freeze');
+  runCli(root, 'budget', '--lines', '2');
+  writeFileSync(join(root, 'app.js'), Array.from({ length: 40 }, (_, i) => `line${i}`).join('\n'));
+  const denied = runCli(root, 'budget-check');
+  assert.equal(denied.status, 1);
+  assert.match(denied.stdout, /Recover:/);
+  const justified = runCli(root, 'budget-check', '--justify', 'the fix needed a new helper');
+  assert.equal(justified.status, 0);
+  assert.match(readFileSync(selloPaths(root).findings, 'utf8'), /budget exceeded/);
+});
+
+test('sello: a fix hidden in a new untracked file still costs budget', () => {
+  const root = makeRepo();
+  writeFileSync(join(root, 'app.js'), 'a\n');
+  const frozen = computeCandidate(root);
+  writeFileSync(join(root, 'sneaky-fix.js'), Array.from({ length: 50 }, () => 'x').join('\n'));
+  assert.ok(budgetSpent(frozen, computeCandidate(root)) >= 40, 'new files must not be free');
+});
+
+test('sello: lens requirements scale with tier and honor the config cap', () => {
+  assert.equal(lensesRequired(0), 0);
+  assert.equal(lensesRequired(1), 1);
+  assert.equal(lensesRequired(2), 3);
+  assert.equal(lensesRequired(2, { lenses: 2 }), 2, 'config may cap the panel');
+  assert.equal(lensesRequired(2, { lenses: 0 }), 3, 'but never below one lens');
+});
+
+// --- the gate's production wiring (a decorative gate is the defect we already paid for)
+
+test('materialization: the guard and its sello core are installed together', async () => {
+  const { readFileSync: rf } = await import('node:fs');
+  const claude = rf(join(REPO, 'targets', 'claude.js'), 'utf8');
+  assert.match(claude, /copyFileSync\(join\(HERE, 'sello\.mjs'\)/, 'wireHook must materialize sello.mjs next to ship-guard');
+  const apply = rf(join(REPO, 'scripts', 'install-apply.js'), 'utf8');
+  assert.match(apply, /'sello\.mjs'/, 'sello.mjs must be in generatedHookFiles or restore cannot recover it');
+  // And the guard must actually reach it as a sibling.
+  const guard = rf(join(REPO, 'targets', 'ship-guard.mjs'), 'utf8');
+  assert.match(guard, /new URL\('\.\/sello\.mjs', import\.meta\.url\)/, 'the guard must import its sibling, not a package path');
+});
 
 test('sello: non-blocking findings accumulate in a readable artifact', () => {
   const root = makeRepo();


### PR DESCRIPTION
Implements the approved spec `review-receipt-gate` (WHAT/WHY in `02-DOCS/wiki/sdd/specs/`, local-only). Adopts the deterministic spine of Gentleman Programming's "RDD" and deliberately drops its ceremony.

## The problem this closes

Nothing tied *what was reviewed* to *what ships*. This repo already paid for it: during the Claude-5 migration two agents migrated `huggingface`, main kept one, and a real fix from the other vanished with no gate noticing — found weeks later by hand.

## What ships

A **sello** binds a verdict to a byte-exact candidate (every changed path hashed against the trunk merge-base). With the sello ON — **opt-in per project** — `ship-guard` denies commit, push and PR when the bytes diverge, the base moved, a risk>0 change has no review, or the verdict was `blocked`. Risk-0 changes (docs/copy) pass in total silence.

| Piece | Where |
|---|---|
| Deterministic core (candidate, risk, messages, check) | `targets/sello.mjs` |
| The gate | `targets/ship-guard.mjs` |
| State transitions | `rsc sello on/off/freeze/approve/block/budget/budget-check/check/report/status` |
| Health surface | `rsc doctor` |
| Lens orchestration | `skills/review/SKILL.md` |

Risk is classified by **what a path touches** (secrets/auth/CI/migrations/billing/harness → full panel; docs → silence; rest → one lens), never by size. Overrides raise freely, lower explicitly, and can never lower secrets or the harness's own config. A finding blocks only if it is **causal + severe + evidenced**; everything else accumulates in `.rsc/sello-findings.md`. Fixes declare a line budget *before* they happen.

## The adversarial panel earned its keep

Three fresh-context lenses reviewed the first commit. **All three returned NOT-READY**, with verified repros; two blockers were found by two lenses independently:

| Blocker | Consequence |
|---|---|
| `core.quotePath` escaped non-ASCII paths | `facturación.js` hashed as *deleted* → post-review mutations passed as `sealed`. **The core guarantee was void.** |
| Sello state entered its own candidate when `.rsc/` was tracked | `freeze`→`approve` never converged → permanent delivery lockout whose documented recovery **looped forever** |
| Risk table used first-match-wins | `.claude/CLAUDE.md`, `credentials.txt`, `docs/prod.pem` → tier 0. The floor was decorative. |
| Stale sello checked before risk-0 | A docs-only edit inherited an old `blocked` verdict |
| Delivery regex matched substrings | `grep -rn "git push" docs/` denied; `git -C . commit` allowed |

Plus: `.no-ship-guard` silently disabled the sello while `status` claimed it was armed; a malformed config discarded the whole risk table; `sello off` — the recovery every denial advertises — was unreachable with a broken config; non-`main` trunks made the gate inert while reporting `no-repo`; a tier-2 change could seal with zero lenses; budget counted 0 for fixes hidden in new files; symlinks were followed out of the repo.

**And the docs overclaimed.** `sello.mjs` said it made a *human* approval binding, when `approve` is an unauthenticated local call made by the reviewing agent itself. That is the same overselling I criticized in the source material, in my own text. The trust model is now stated plainly in the header and both skills: **it binds bytes, not intent** — drift protection, not tamper-evidence.

## Tests: 18 → 36 (230 total)

One regression test per blocker, using the reviewers' own repros. Also closed the coverage holes they proved by mutation: the CLI's 100+ lines had **zero** tests; `MESSAGES` was checked by count instead of by key; `runGuard` mapped a crash to "allow"; and deleting the materialization line changed **nothing** in the whole suite — a decorative gate, the exact defect class this repo has already paid for four times.

## Gates

`npm test` 230 pass / 0 fail · `validate` OK · `manifest:check` OK (258) · `eval-lint` PASS

## Not in scope, on purpose

No "authority" state machine, no re-review loop, no unconditional panel, no UI/UX lens, no telemetry. Off by default; with it off, delivery behaves exactly as before — asserted by test.