### PR TITLE
feat(sello): global switch — turn it on once for every project

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -6,7 +6,7 @@ import { readState } from './lib/state.js';
 import { loadManifest } from './lib/manifest.js';
 import { listBackups } from './lib/backups.js';
 import { SDD_GATE_TEXT } from '../targets/hook-once.mjs';
-import { isEnabled, checkSello, readSello, countFindings, readConfig, validateRiskConfig } from '../targets/sello.mjs';
+import { isEnabled, checkSello, readSello, countFindings, readEffectiveConfig, validateRiskConfig } from '../targets/sello.mjs';
 
 // The sello's health, surfaced where the user already looks (spec: non-blocking
 // findings live in the project and are SUMMARIZED here, never nagged about).
@@ -19,6 +19,7 @@ function selloStatus(root) {
     const verdict = checkSello(root);
     const out = {
       enabled: true,
+      decidedBy: readEffectiveConfig(root)?.scope,
       check: verdict.code,
       status: sello.missing ? 'none' : sello.corrupt ? 'corrupt' : sello.status,
       nonBlockingFindings: countFindings(root),
@@ -29,7 +30,7 @@ function selloStatus(root) {
       out.note = 'ship-guard branch-hygiene rules are opted out (.rsc/.no-ship-guard); the sello itself still enforces.';
     }
     try {
-      const { lowered } = validateRiskConfig(readConfig(root) || {});
+      const { lowered } = validateRiskConfig(readEffectiveConfig(root) || {});
       if (lowered.length) out.loweredClasses = lowered;
     } catch (e) { out.configError = e.message; }
     return out;

--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -340,7 +340,12 @@ async function main() {
       switch (sub) {
         case 'on':
         case 'off': {
-          const cfg = S.readConfig(root) || {};
+          // --global writes the user-scope switch (every project inherits it);
+          // without it, the project switch, which always wins over the global one.
+          const isGlobal = argv.includes('--global');
+          const target = isGlobal ? S.globalConfigPath() : paths.config;
+          const cfg = (isGlobal ? S.readGlobalConfig() : S.readConfig(root)) || {};
+          delete cfg.scope; // derived, never persisted
           // `off` never validates: it is the recovery advertised by every deny
           // message, so a broken config must not be able to lock it away.
           if (sub === 'on') {
@@ -348,15 +353,22 @@ async function main() {
           }
           const { writeFileSync, mkdirSync } = await import('node:fs');
           const { dirname } = await import('node:path');
-          mkdirSync(dirname(paths.config), { recursive: true });
-          writeFileSync(paths.config, JSON.stringify({ ...cfg, enabled: sub === 'on' }, null, 2) + '\n');
+          mkdirSync(dirname(target), { recursive: true });
+          writeFileSync(target, JSON.stringify({ ...cfg, enabled: sub === 'on' }, null, 2) + '\n');
+          const where = isGlobal ? 'for every project (global)' : 'for this project';
           say(sub === 'on'
-            ? '✅ sello ON for this project. Risk-0 changes (docs/copy) still pass silently; everything else needs a review before commit/push/PR.'
-            : '✅ sello OFF for this project. Delivery behaves exactly as before.');
+            ? `✅ sello ON ${where}. Risk-0 changes (docs/copy) still pass silently; everything else needs a review before commit/push/PR.`
+            : `✅ sello OFF ${where}. Delivery behaves exactly as before.`);
+          if (isGlobal) {
+            const p = S.readConfig(root);
+            if (p && p.enabled !== undefined && p.enabled !== (sub === 'on')) {
+              say(`   ⚠️  this project overrides it (project = ${p.enabled ? 'on' : 'off'}); the project switch always wins. Change it with \`sello ${p.enabled ? 'off' : 'on'}\` here.`);
+            }
+          }
           return;
         }
         case 'freeze': {
-          const cfg = S.readConfig(root);
+          const cfg = S.readEffectiveConfig(root);
           const candidate = S.computeCandidate(root, cfg);
           if (!candidate) { say(S.MESSAGES.noTrunk()); process.exitCode = 1; return; }
           const paths2 = Object.keys(candidate.files);
@@ -374,7 +386,7 @@ async function main() {
         case 'block': {
           const sello = S.readSello(root);
           if (sello.missing || sello.corrupt || !sello.status) { say(S.MESSAGES.notFrozen()); process.exitCode = 1; return; }
-          const cfg = S.readConfig(root);
+          const cfg = S.readEffectiveConfig(root);
           const current = S.computeCandidate(root, cfg);
           const changed = current && Object.keys({ ...sello.files, ...current.files })
             .some((p) => sello.files[p] !== current.files[p]);
@@ -415,7 +427,7 @@ async function main() {
         case 'budget-check': {
           const sello = S.readSello(root);
           if (sello.missing || sello.corrupt || !sello.budget) { say('sello: no declared budget. Recover: run `rsc sello budget --lines <N>` BEFORE fixing.'); process.exitCode = 1; return; }
-          const current = S.computeCandidate(root, S.readConfig(root));
+          const current = S.computeCandidate(root, S.readEffectiveConfig(root));
           const spent = S.budgetSpent(sello, current || { numstat: {} });
           if (spent <= sello.budget.lines) { say(`✅ within budget: ~${spent}/${sello.budget.lines} line(s).`); return; }
           const justify = str('justify');
@@ -448,12 +460,21 @@ async function main() {
           const enabled = S.isEnabled(root);
           const verdict = S.checkSello(root);
           const sello = S.readSello(root);
-          const cfg = S.readConfig(root);
+          const cfg = S.readEffectiveConfig(root);
           let lowered = [];
           let configError;
           try { ({ lowered } = S.validateRiskConfig(cfg || {})); } catch (e) { configError = e.message; }
+          const globalCfg = S.readGlobalConfig();
+          const projectCfg = S.readConfig(root);
           say(JSON.stringify({
             enabled,
+            // Which scope decided, and what each one says — two scopes quietly
+            // disagreeing is a failure this harness has already lived through.
+            decidedBy: cfg?.scope,
+            scopes: {
+              global: globalCfg?.enabled === undefined ? 'unset' : globalCfg.enabled ? 'on' : 'off',
+              project: projectCfg?.enabled === undefined ? 'unset' : projectCfg.enabled ? 'on' : 'off',
+            },
             check: verdict.code,
             // An inert gate must never look armed: name every reason it is standing down.
             inert: enabled && ['no-trunk', 'disabled'].includes(verdict.code) ? verdict.code : undefined,
@@ -471,7 +492,7 @@ async function main() {
           return;
         }
         default:
-          say('Use: npx @ericrisco/rsc sello on|off|status|freeze|approve --lenses a,b [--accept-partial-lenses]|block --reason "…"|budget --lines N|budget-check [--justify "…"]|check|report');
+          say('Use: npx @ericrisco/rsc sello on|off [--global]|status|freeze|approve --lenses a,b [--accept-partial-lenses]|block --reason "…"|budget --lines N|budget-check [--justify "…"]|check|report');
           return;
       }
     }

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -104,8 +104,9 @@ End every review you give with one of three, and nothing mushy in between:
 
 ### The sello — when this project opted in
 
-If `.rsc/sello-config.json` has `enabled: true`, the review's verdict is **sealed to the exact
-bytes reviewed**, and the ship gate refuses commit/push/PR on anything else.
+If the sello is on — `.rsc/sello-config.json` in the project, or `~/.rsc/sello-config.json` for
+every project (`sello on --global`; the project switch always wins) — the review's verdict is
+**sealed to the exact bytes reviewed**, and the ship gate refuses commit/push/PR on anything else.
 
 **What the sello does and does not prove.** It binds bytes, not intent: it guarantees *what ships
 is what was reviewed*, never *the review was good*. You are the one calling `sello approve`, so it

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -72,8 +72,10 @@ the command), and can be disabled per project with `.rsc/.no-ship-guard`. It gua
 commit → push step; opening the PR is still this skill's job (and its hard rule). If the guard
 blocks you, do not work around it — run ship.
 
-The same guard also enforces the **sello** where the project opted in (`.rsc/sello-config.json`
-with `enabled: true`): commit, push and PR are denied unless the change's exact bytes match the
+The same guard also enforces the **sello** where it was opted into — per project
+(`.rsc/sello-config.json`) or for all of them (`~/.rsc/sello-config.json` via
+`sello on --global`, with the project switch always winning; `rsc sello status` prints which
+scope decided): commit, push and PR are denied unless the change's exact bytes match the
 sealed, approved review — one byte of drift, a moved base, or a missing review on a risk>0 change
 all block, and every denial names its way out (re-run `review`, or `npx @ericrisco/rsc sello off`).
 Risk-0 changes (docs/copy) always pass silently. Off by default; the flow lives in the `review`

--- a/targets/sello.mjs
+++ b/targets/sello.mjs
@@ -25,6 +25,7 @@
 
 import { existsSync, lstatSync, readFileSync, readlinkSync, writeFileSync, appendFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 
@@ -47,15 +48,49 @@ export function selloPaths(root) {
   };
 }
 
-export function readConfig(root) {
+// The user-scope switch: turn the sello on once for every project instead of
+// per repo. RSC_SELLO_HOME exists so tests can point it somewhere disposable
+// (same escape hatch as hook-once's marker dir).
+export function selloHome() {
+  return process.env.RSC_SELLO_HOME || homedir();
+}
+export function globalConfigPath(home = selloHome()) {
+  return join(home, '.rsc', 'sello-config.json');
+}
+
+function readJson(path) {
   try {
-    const cfg = JSON.parse(readFileSync(selloPaths(root).config, 'utf8'));
+    const cfg = JSON.parse(readFileSync(path, 'utf8'));
     return cfg && typeof cfg === 'object' ? cfg : null;
   } catch { return null; }
 }
 
+// Project-scope config only — this is what `sello on/off` writes.
+export function readConfig(root) {
+  return readJson(selloPaths(root).config);
+}
+export function readGlobalConfig() {
+  return readJson(globalConfigPath());
+}
+
+// What actually governs a project: global as the base, project keys on top.
+// PRECEDENCE IS EXPLICIT AND SURFACED — this harness has already been bitten by
+// two scopes silently disagreeing (a project opt-out that never reached the
+// user-scope guard), so `scope` says which one decided and `status`/`doctor`
+// print it.
+export function readEffectiveConfig(root) {
+  const g = readGlobalConfig();
+  const p = readConfig(root);
+  if (!g && !p) return null;
+  const merged = { ...(g || {}), ...(p || {}) };
+  merged.scope = p && p.enabled !== undefined ? 'project'
+    : g && g.enabled !== undefined ? 'global'
+      : 'none';
+  return merged;
+}
+
 export function isEnabled(root) {
-  const cfg = readConfig(root);
+  const cfg = readEffectiveConfig(root);
   return !!(cfg && cfg.enabled === true);
 }
 
@@ -351,7 +386,7 @@ export const MESSAGES = {
 
 export function checkSello(rawRoot) {
   const root = resolveRoot(rawRoot);
-  const cfg = readConfig(root);
+  const cfg = readEffectiveConfig(root);
   if (!cfg || cfg.enabled !== true) return { ok: true, code: 'disabled' };
 
   const candidate = computeCandidate(root, cfg);

--- a/tests/sello.test.js
+++ b/tests/sello.test.js
@@ -493,6 +493,98 @@ test('materialization: the guard and its sello core are installed together', asy
   assert.match(guard, /new URL\('\.\/sello\.mjs', import\.meta\.url\)/, 'the guard must import its sibling, not a package path');
 });
 
+// --- the global switch and scope precedence ----------------------------------------
+// Two scopes silently disagreeing is a failure this harness has already lived
+// through (a project opt-out that never reached the user-scope guard), so
+// precedence is asserted in both directions and the decision is surfaced.
+
+function withHome(root) {
+  const home = mkdtempSync(join(tmpdir(), 'rsc-sello-home-'));
+  mkdirSync(join(home, '.rsc'), { recursive: true });
+  return { home, env: { ...process.env, RSC_SELLO_HOME: home } };
+}
+const setGlobal = (home, cfg) => writeFileSync(join(home, '.rsc', 'sello-config.json'), JSON.stringify(cfg));
+const cliIn = (root, env, ...args) => spawnSync('node', [RSC, 'sello', ...args], { cwd: root, encoding: 'utf8', env });
+
+test('sello global: a project with no config inherits the global switch', () => {
+  const root = makeRepo();
+  const { home, env } = withHome(root);
+  writeFileSync(join(root, 'app.js'), 'unreviewed\n');
+  setGlobal(home, { enabled: true });
+  const r = cliIn(root, env, 'status');
+  const st = JSON.parse(r.stdout);
+  assert.equal(st.enabled, true, 'global on must reach a project with no config of its own');
+  assert.equal(st.decidedBy, 'global');
+  assert.equal(st.scopes.global, 'on');
+  assert.equal(st.scopes.project, 'unset');
+  assert.equal(cliIn(root, env, 'check').status, 1, 'and it actually enforces');
+});
+
+test('sello global: the project switch always wins, in both directions', () => {
+  const root = makeRepo();
+  const { home, env } = withHome(root);
+  writeFileSync(join(root, 'app.js'), 'unreviewed\n');
+
+  setGlobal(home, { enabled: true });
+  writeFileSync(selloPaths(root).config, JSON.stringify({ enabled: false }));
+  let st = JSON.parse(cliIn(root, env, 'status').stdout);
+  assert.equal(st.enabled, false, 'project off must override global on');
+  assert.equal(st.decidedBy, 'project');
+
+  setGlobal(home, { enabled: false });
+  writeFileSync(selloPaths(root).config, JSON.stringify({ enabled: true }));
+  st = JSON.parse(cliIn(root, env, 'status').stdout);
+  assert.equal(st.enabled, true, 'project on must override global off');
+  assert.equal(st.decidedBy, 'project');
+});
+
+test('sello global: `on --global` writes the user scope and warns when a project overrides it', () => {
+  const root = makeRepo();
+  const { home, env } = withHome(root);
+  writeFileSync(selloPaths(root).config, JSON.stringify({ enabled: false }));
+  const r = cliIn(root, env, 'on', '--global');
+  assert.equal(r.status, 0, r.stdout + r.stderr);
+  assert.match(r.stdout, /global/);
+  assert.match(r.stdout, /project switch always wins/, 'a silently-overridden global switch is the bug this warns about');
+  assert.equal(JSON.parse(readFileSync(join(home, '.rsc', 'sello-config.json'), 'utf8')).enabled, true);
+  assert.equal(JSON.parse(readFileSync(selloPaths(root).config, 'utf8')).enabled, false, 'the project file must not be touched');
+});
+
+test('sello global: risk overrides come from the global config when the project has none', () => {
+  const root = makeRepo();
+  const { home, env } = withHome(root);
+  // A globally-declared raise rule must classify a project path it matches.
+  setGlobal(home, { enabled: true, risk: { raise: [{ class: 'infra', pattern: '(^|/)terraform/' }] } });
+  mkdirSync(join(root, 'terraform'), { recursive: true });
+  writeFileSync(join(root, 'terraform', 'main.tf'), 'resource {}\n');
+  const frozen = cliIn(root, env, 'freeze');
+  assert.equal(frozen.status, 0, frozen.stdout + frozen.stderr);
+  assert.match(frozen.stdout, /risk tier 2/, 'a global raise rule must apply to the project');
+  assert.match(frozen.stdout, /terraform\/main\.tf → infra/);
+});
+
+test('sello global: the derived scope marker is never persisted into a config file', () => {
+  const root = makeRepo();
+  const { home, env } = withHome(root);
+  setGlobal(home, { enabled: true });
+  cliIn(root, env, 'on');
+  assert.equal(JSON.parse(readFileSync(selloPaths(root).config, 'utf8')).scope, undefined, 'project config');
+  cliIn(root, env, 'on', '--global');
+  assert.equal(JSON.parse(readFileSync(join(home, '.rsc', 'sello-config.json'), 'utf8')).scope, undefined, 'global config');
+});
+
+test('sello global: the guard honors the global switch too', () => {
+  const root = makeRepo();
+  const { home, env } = withHome(root);
+  setGlobal(home, { enabled: true });
+  writeFileSync(join(root, 'app.js'), 'unreviewed\n');
+  const input = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'git commit -m x' } });
+  const r = spawnSync('node', [SHIP_GUARD, root], { encoding: 'utf8', input, env });
+  assert.equal(r.status, 0);
+  const denial = JSON.parse(r.stdout || '{}');
+  assert.equal(denial.hookSpecificOutput?.permissionDecision, 'deny', 'the gate must enforce a globally-enabled sello');
+});
+
 test('sello: non-blocking findings accumulate in a readable artifact', () => {
   const root = makeRepo();
   assert.equal(countFindings(root), 0);


### PR DESCRIPTION
## The gap

The approved spec says the sello is enabled *"por proyecto o globalmente"*. Only the project half shipped in #218 — the global clause was specified and missed. This is an **amendment to that spec**, not a new one.

## What ships

`rsc sello on --global` writes `~/.rsc/sello-config.json`; every project inherits it without touching its own `.rsc/`.

**Precedence is explicit and, more importantly, visible.** Two scopes silently disagreeing is a failure this harness has already lived through: the `danger-guard` opt-out a project could create while the user-scope copy of the same guard kept denying, because each resolves its own `root`. That bug cost real time in this very session. So:

| | |
|---|---|
| The project switch always wins | Both directions — project `off` beats global `on`, project `on` beats global `off` |
| `rsc sello status` | Prints `decidedBy` plus what each scope says (`on` / `off` / `unset`) |
| `rsc doctor` | Prints `decidedBy` |
| `on --global` | Warns **on the spot** when the current project overrides what you just set, and names the command that would change it |

```
$ rsc sello on --global
✅ sello ON for every project (global). …
   ⚠️  this project overrides it (project = off); the project switch always wins.
      Change it with `sello on` here.
```

Risk overrides merge the same way (global as base, project keys on top), so a raise rule declared once applies everywhere. The derived `scope` marker is never persisted back into a config file.

## Tests: 36 → 42 (236 total)

Inheritance with no project config · precedence in both directions · the override warning · a global raise rule classifying a project path · the marker never persisted · and the **materialized guard** honoring a globally-enabled sello (not just the library — the binary, via stdin hook JSON).

`RSC_SELLO_HOME` lets tests point the user scope somewhere disposable, the same escape hatch `hook-once` uses for its marker dir.

## Gates

`npm test` 236 pass / 0 fail · `validate` OK · `manifest:check` OK (258) · `eval-lint` PASS

Verified end to end in a clean project: global on → inherited, project off → overrides, warning fires.