### PR TITLE
fix(sdd): make "every phase ends with an envelope" true, and test it

### DIFF
--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -101,6 +101,28 @@ Render it at the dial's verbosity. Do not log a decision to `decisions.md` — a
 | Siding with the plan when it contradicts the constitution | The constitution wins by definition — flag CRITICAL. If the principle itself is wrong, that is a `constitution` change the user makes, not a quiet override here. |
 | Guessing what a vague requirement meant | Guessing defeats the gate. Mark AMBIGUOUS and route to `clarify`; do not encode your guess. |
 
+## Result envelope
+
+End with the parseable block every SDD phase shares, so the dispatcher can chain without
+interpreting prose (contract: `../sdd/SKILL.md`):
+
+```json result-envelope
+{
+  "status": "complete|blocked|failed",
+  "executive_summary": "Cross-read of spec/plan/tasks against the constitution; findings ranked.",
+  "artifact": "02-DOCS/wiki/sdd/analysis/<slug>.md",
+  "next_recommended": "implement",
+  "risk": "low|medium|high",
+  "skill_resolution": {
+    "used": ["analyze"],
+    "missing": [],
+    "fallback": [],
+    "compact_rules": ["Read adversarially across artifacts, not inside one.", "A finding without a location is an opinion."]
+  },
+  "evidence": ["report path exists", "blockers listed with artifact + location", "constitution conflicts named"]
+}
+```
+
 ## Next in the chain
 
 On `GATE: PASS` (or once the user consciously accepts the remaining MEDIUM/LOW findings), proceed to **`implement`** — execute the tasks with TDD discipline, delegating concrete test tooling to the relevant stack skill (`fastapi`, `nextjs`, `go`, `flutter`, `postgresdb`). On `GATE: BLOCKED`, route each CRITICAL/HIGH finding to its owning phase (`clarify`, `plan`, `tasks`, or `constitution`), let the user resolve, then re-run `analyze`. The gate only opens once.

--- a/skills/clarify/SKILL.md
+++ b/skills/clarify/SKILL.md
@@ -113,6 +113,28 @@ After baking back, the spec line becomes a bounded, testable behavior with accep
 
 The gate is passed when the spec, constitution and profile were all read (settled questions cited, not re-asked); all ten taxonomy categories were considered; only the build-changing gaps were put to the user, as dial-sized decisions with recommendations; every answer is baked into the spec body with observable acceptance criteria, logged under `## Clarifications` and bounded under `## Out of scope`; and the final re-read opened no new gap.
 
+## Result envelope
+
+End with the parseable block every SDD phase shares, so the dispatcher can chain without
+interpreting prose (contract: `../sdd/SKILL.md`):
+
+```json result-envelope
+{
+  "status": "complete|blocked|failed",
+  "executive_summary": "Open points resolved; the spec is de-risked and ready to plan against.",
+  "artifact": "02-DOCS/wiki/sdd/specs/<slug>.md",
+  "next_recommended": "plan",
+  "risk": "low|medium|high",
+  "skill_resolution": {
+    "used": ["clarify"],
+    "missing": [],
+    "fallback": [],
+    "compact_rules": ["Ask only what changes the spec.", "An unanswered question is recorded, never invented."]
+  },
+  "evidence": ["answers folded back into the spec", "remaining open points listed with their owner"]
+}
+```
+
 ## Next in the chain
 
 Hand off to **`plan`** — turn the now-sharp spec into a technical implementation plan (architecture, interfaces, data flow, testing strategy, risks), deferring stack specifics to the relevant stack skill. The chain continues: clarify → **plan** → tasks → analyze → implement → verify → review → ship. `debug` is callable any time if what you are "clarifying" turns out to be a runtime fault, not a spec gap.

--- a/skills/constitution/SKILL.md
+++ b/skills/constitution/SKILL.md
@@ -132,6 +132,28 @@ This skill's `02-DOCS` record is the constitution at `02-DOCS/wiki/sdd/constitut
 
 Every later rsc-sdd phase reads this file before it works. The harness maintains and improves the article over the life of the project; this skill is the place that ratifies and amends it.
 
+## Result envelope
+
+End with the parseable block every SDD phase shares, so the dispatcher can chain without
+interpreting prose (contract: `../sdd/SKILL.md`):
+
+```json result-envelope
+{
+  "status": "complete|blocked|failed",
+  "executive_summary": "Constitution written with N numbered, testable rules the later phases inherit.",
+  "artifact": "02-DOCS/wiki/sdd/constitution.md",
+  "next_recommended": "specify",
+  "risk": "low|medium|high",
+  "skill_resolution": {
+    "used": ["constitution"],
+    "missing": [],
+    "fallback": [],
+    "compact_rules": ["Principles are inherited constraints, not choices to re-make.", "Every rule is testable or it is a preference."]
+  },
+  "evidence": ["constitution path exists", "rules numbered and testable", "decisions log appended"]
+}
+```
+
 ## Next in the chain
 
 The constitution is the guardrail; now describe what to build. Hand off to **`../specify/SKILL.md`** — turn a fuzzy intent into a spec (what & why, no implementation), grounded in these principles. The full chain: **constitution → specify → clarify → plan → tasks → analyze → implement → verify → review → ship** (with `debug`, `worktrees`, `parallel` callable on demand). The dispatcher is `../sdd/SKILL.md`.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -141,6 +141,28 @@ regardless. (`implement` re-checks this as a hard gate before its first commit.)
 - Concrete framework/ORM/test-runner mechanics → the stack skill (`../fastapi/SKILL.md`,
   `../nextjs/SKILL.md`, `../go/SKILL.md`, `../flutter/SKILL.md`, `../postgresdb/SKILL.md`).
 
+## Result envelope
+
+End with the parseable block every SDD phase shares, so the dispatcher can chain without
+interpreting prose (contract: `../sdd/SKILL.md`):
+
+```json result-envelope
+{
+  "status": "complete|blocked|failed",
+  "executive_summary": "Technical plan derived from the clarified spec, with the isolation decision made.",
+  "artifact": "02-DOCS/wiki/sdd/plans/<slug>.md",
+  "next_recommended": "tasks",
+  "risk": "low|medium|high",
+  "skill_resolution": {
+    "used": ["plan"],
+    "missing": [],
+    "fallback": [],
+    "compact_rules": ["The plan answers HOW; the spec owns WHAT.", "Name the isolation choice before the build starts."]
+  },
+  "evidence": ["plan path exists", "each spec acceptance criterion has an approach", "risks and rollback stated"]
+}
+```
+
 ## Next in the chain
 
 Plan written, indexed, decisions logged → propose isolation (above), then hand off to

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -237,6 +237,28 @@ Review is mostly a conversation, but two artifacts persist into the harness wiki
 
 Index both in `02-DOCS/wiki/index.md` (the Knowledge map; root `CLAUDE.md` keeps only a short pointer) under the `sdd/` topic — the harness owns that map; this skill just keeps its rows honest.
 
+## Result envelope
+
+End with the parseable block every SDD phase shares, so the dispatcher can chain without
+interpreting prose (contract: `../sdd/SKILL.md`):
+
+```json result-envelope
+{
+  "status": "complete|blocked|failed",
+  "executive_summary": "Adversarial review against spec/plan/constitution; verdict and blocking findings.",
+  "artifact": "02-DOCS/wiki/sdd/reviews/<slug>.md",
+  "next_recommended": "ship",
+  "risk": "low|medium|high",
+  "skill_resolution": {
+    "used": ["review"],
+    "missing": [],
+    "fallback": [],
+    "compact_rules": ["Rank or it is noise: blocker / should-fix / nit.", "A finding without a repro is a question, not a defect."]
+  },
+  "evidence": ["verdict stated (APPROVE | APPROVE WITH NITS | CHANGES REQUESTED)", "each blocker carries location + repro + fix"]
+}
+```
+
 ## Next in the chain
 
 When the diff carries an **APPROVE** / **APPROVE WITH NITS** verdict and every blocker is resolved, hand off to **ship** — close the branch via PR / merge / cleanup, with **git authorship as Eric, never Claude**. If the review came back **CHANGES REQUESTED**, the loop goes back to **implement** (fix), then **verify** (re-prove green), then back here for re-review. Don't ship a diff that hasn't earned its verdict.

--- a/tests/result-envelope.test.js
+++ b/tests/result-envelope.test.js
@@ -31,3 +31,49 @@ test('parseResultEnvelope extracts fenced json result-envelope blocks', () => {
   assert.equal(parsed.status, 'complete');
   assert.deepEqual(parsed.skill_resolution.used, ['sdd-init', 'specify']);
 });
+
+// --- the contract, not just the validator ------------------------------------------
+//
+// `sdd` states "Every SDD phase ends with the same parseable block". For the catalog's
+// whole life that was false — 5 of the 10 canonical phases had no envelope — and this
+// file passed anyway, because it only exercised the validator on a synthetic object.
+// A validator with nothing to validate is the same decorative-gate pattern the rubric
+// kept producing, so the claim now has a test over the real skills.
+import { readFileSync } from 'node:fs';
+import { join, dirname as dn } from 'node:path';
+import { fileURLToPath as furl } from 'node:url';
+
+const SKILLS = join(dn(furl(import.meta.url)), '..', 'skills');
+// The chain `specify` prints, in order. These are the phases the dispatcher chains,
+// so these are the ones that owe an envelope.
+const CANONICAL_PHASES = [
+  'constitution', 'specify', 'clarify', 'plan', 'tasks',
+  'analyze', 'implement', 'verify', 'review', 'ship',
+];
+
+test('every canonical SDD phase carries a result envelope', () => {
+  const missing = CANONICAL_PHASES.filter(
+    (id) => !readFileSync(join(SKILLS, id, 'SKILL.md'), 'utf8').includes('```json result-envelope'),
+  );
+  assert.deepEqual(missing, [], `sdd claims every phase emits one; these do not: ${missing.join(', ')}`);
+});
+
+test("each phase's envelope validates and routes to a real phase", () => {
+  for (const id of CANONICAL_PHASES) {
+    const body = readFileSync(join(SKILLS, id, 'SKILL.md'), 'utf8');
+    const parsed = parseResultEnvelope(body);
+    assert.ok(parsed, `${id}: the envelope block must be parseable, not illustrative prose`);
+    // The documented shape uses pipe-separated placeholders for the open fields, so
+    // check the structure and the routing rather than the literal values.
+    for (const key of ['status', 'executive_summary', 'artifact', 'next_recommended', 'risk', 'skill_resolution', 'evidence']) {
+      assert.ok(key in parsed, `${id}: envelope is missing '${key}'`);
+    }
+    assert.ok(parsed.skill_resolution.used.includes(id), `${id}: skill_resolution.used must name the phase itself`);
+    assert.ok(Array.isArray(parsed.evidence) && parsed.evidence.length, `${id}: evidence must be a non-empty list`);
+    const next = String(parsed.next_recommended).split('|').map((s) => s.trim());
+    const known = new Set([...CANONICAL_PHASES, 'sdd-init', 'debug', 'none']);
+    for (const n of next) {
+      assert.ok(known.has(n), `${id}: next_recommended '${n}' is not a phase in the chain`);
+    }
+  }
+});


### PR DESCRIPTION
## The claim

`skills/sdd/SKILL.md`:

> Every SDD phase ends with the same parseable block so the dispatcher can chain phases without interpreting a novel.

**Five of the ten canonical phases had no envelope**: `constitution`, `clarify`, `plan`, `analyze`, `review`. False for the catalog's whole life — which means the autopilot chaining the sentence describes was half-built, with the dispatcher falling back to reading prose for half the chain.

Per the instruction to either make a claim true or delete it: this one is worth making true. The envelope is what lets phases chain deterministically, so the fix is the feature working, not the sentence going away.

## What changed

Each of the five now ends with an envelope carrying **its real artifact path, its real next phase, and evidence lines specific to what that phase produces** — not a copy of a sibling's:

| Phase | artifact | next |
|---|---|---|
| `constitution` | `sdd/constitution.md` | `specify` |
| `clarify` | `sdd/specs/<slug>.md` | `plan` |
| `plan` | `sdd/plans/<slug>.md` | `tasks` |
| `analyze` | `sdd/analysis/<slug>.md` | `implement` |
| `review` | `sdd/reviews/<slug>.md` | `ship` |

## Why it rotted — and the part that matters

`tests/result-envelope.test.js` only exercised the **validator** against a synthetic object. A validator with nothing to validate passes forever while the contract it is named after decays. That is the same decorative-gate pattern this repo has now found seven times, sitting in the file named after the contract.

Two tests now run over the **real skills**:

1. every canonical phase carries an envelope;
2. each envelope parses, has all seven fields, names its own phase in `skill_resolution`, carries non-empty `evidence`, and routes to a phase that exists.

**Verified to bite**, not assumed: run against the pre-fix skills they fail, naming `clarify, plan, analyze, review`.

## Gates

`npm test` **271** pass / 0 fail · `validate` OK · `manifest:check` OK (258) · `eval-lint` PASS