### PR TITLE
feat(gates): four rules so a green gate cannot lie

### DIFF
--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -130,6 +130,35 @@ irreversible, or large scope), dispatch a **fresh-context subagent** to read the
 **Skip it** for L0/L1 on a small, low-risk spec — the self-review scan is enough there; don't spin up
 a subagent to vet a two-paragraph spec. Like the rest of the chain, ceremony scales to the stakes.
 
+### Approval is its own exchange (step 9)
+
+**An answer to a question is not an approval.** If you asked the user to decide something, they
+answered *that question* and nothing else. Their answer is an **input** to the spec — and it
+*changes* the spec, which means any approval you were holding before the question is the approval
+of a document that no longer exists.
+
+Questions and approval are two exchanges, in that order:
+
+```text
+ask → user answers → fold it in → say what changed → show the revised spec → ask for approval
+```
+
+- **The recommended-option shape is where this fails most easily.** When the user picks the option
+  you recommended, the spec *looks* unchanged and consent *looks* implied. Neither is true — you
+  proposed, they chose, the spec moved.
+- **None of these are approval:** an answer to your question; a "go ahead" about some other step;
+  silence; the request that started the task. If you cannot quote the words that approved **this**
+  spec, you do not have approval.
+- **Autopilot is still valid** — an up-front "run it all yourself" authorizes the whole run, and
+  that is a real answer to a real question. What changes is the bookkeeping: record it as
+  **approved in autopilot, not item by item**, in the spec's `status:`. The spec then becomes the
+  artifact the user reviews *after the fact*, and the work claims correspondingly less certainty
+  about having captured their intent. Writing "aprobada" flat, when what happened was a blanket
+  go-ahead, is the record telling a small lie about the strongest gate in the chain.
+- **Rejection is information — keep it.** If the user turns the spec down, revise it in place and
+  append the reason to `## Revisions`. Never delete and start clean: what they rejected, and why,
+  is the most useful thing in the file.
+
 ## Worked shape (abridged)
 
 ```markdown
@@ -206,6 +235,8 @@ The proposal is allowed to mention options and tradeoffs; the spec that follows 
 | Skip the whole loop because "this is too simple to design" | That's the rationalization that wastes the most work. Every feature gets the loop; only a literal one-line, zero-risk change skips. |
 | Present one approach as the answer | Offer 2-3 distinct directions with trade-offs and a recommendation; let the user choose before you write the spec. |
 | Hand to `plan`/`implement` before the user approved the written spec | The approval at step 9 is the gate. No design approved → nothing gets built. |
+| Treat the answer to your question as the approval of the spec | They answered the question, and the answer *changed* the spec. Fold it in, say what changed, show it, ask again. |
+| Write `status: aprobada` after a blanket "just run it" | That is autopilot. Record it as such — the record must not overstate the strongest gate in the chain. |
 | Skip non-goals because "it's obvious" | Unsaid scope becomes assumed scope. State what you are *not* doing. |
 | Resolve every ambiguity yourself to look finished | Inventing answers is worse than naming gaps. List them in Points to clarify. |
 | Start designing the solution because it's clearer | Stay on WHAT/WHY. The plan is a later, separate phase. |

--- a/skills/testing-go/SKILL.md
+++ b/skills/testing-go/SKILL.md
@@ -169,6 +169,23 @@ go build -cover -o ./bin/app .                         # coverage for integratio
 
 A coverage **percentage is a smoke alarm, not a goal.** 100% line coverage with no assertions on the values is worthless; 70% on the branches that actually carry logic is fine. Use `-coverpkg=./...` when your tests live in a separate package and exercise code across the module, or the number undercounts. Profiles, integration-binary coverage, and reading the HTML report are in `references/coverage-and-benchmarks.md`.
 
+## Mutation: does the suite actually notice?
+
+Coverage tells you which code ran; it cannot tell you whether any test would have **noticed** if that code were wrong. A table-driven test whose cases all assert `err == nil` and nothing else raises coverage without detecting anything. Mutation testing plants bugs on purpose — flip a `<` to `<=`, drop an early return, replace a returned value with the zero value — and a mutant the suite still passes is a test that asserts nothing.
+
+This is **not** fuzzing. Fuzzing hunts inputs your code mishandles; mutation hunts tests that would not catch a bug you already know about. They find different things and neither substitutes for the other.
+
+Go has **no mature mutation tool** — `go-mutesting` and `gremlins` exist but neither is a dependable default — so this is the manual procedure, and that makes the discipline stricter here, not looser:
+
+1. Pick the changed logic. Script the run and **commit the script** (e.g. `tools/mutants.go` or a shell driver); do not hand-edit N times, because you will need to rerun it and a restore mistake is silent.
+2. One mutant at a time: flip a comparison, off-by-one a bound or slice index, delete one branch, swap `&&`/`||`, return the zero value. `go test ./...` must fail for every one.
+3. Restore, confirm with `git diff` that nothing else moved, and rerun the suite green.
+4. Report as `N/N killed`, naming the mutants.
+
+**The runner must prove it executed each mutant.** A hand-rolled driver that can report a kill it never ran only ever *inflates* the score — so that defect can never surface as a red run, and no failing test will ever tell you about it. Assert the mutated file changed on disk (compare hashes before and after) and that the test command actually exited non-zero for the reason you expect, rather than trusting the loop.
+
+**A survivor is not automatically a failure.** Some mutants are semantically equivalent and cannot be killed; classify those with the reason instead of writing a test that asserts non-behaviour. Scale the whole layer to risk (P7): reach for it where a bug is expensive — money, auth, data loss, concurrency, a public API — not on every change.
+
 ## Benchmarks
 
 Use `for b.Loop()` (Go 1.24+), not the legacy `for i := 0; i < b.N; i++`. `b.Loop` manages the timer itself (setup before the loop and teardown after are excluded automatically), runs the body the right number of times, and the compiler is taught **not** to dead-code-eliminate calls inside it.

--- a/skills/testing-py/SKILL.md
+++ b/skills/testing-py/SKILL.md
@@ -139,6 +139,24 @@ pytest --cov=mypkg --cov-branch --cov-report=term-missing --cov-fail-under=85
 
 Line coverage lies because executing a line is not the same as testing its outcomes. A function with `if x: a() else: b()` reaches 100% line coverage from a single test that only takes the `if` arm — the `else` ships untested. `--cov-branch` (or `branch = true`) forces both arms to be exercised, which is exactly where happy-path-only suites leak bugs. `term-missing` prints the unhit line and branch numbers so you know what to write next. Exclude only code that is correctly never run by tests (`if TYPE_CHECKING:`, `raise NotImplementedError`, `__repr__`) — never exclude a branch just to make the number go up.
 
+## Mutation: does the suite actually notice?
+
+Branch coverage tells you which code ran. It cannot tell you whether any test would have **noticed** if that code were wrong — and a test with no assertion, or an assertion that cannot fail, raises coverage without detecting anything. Mutation testing closes that gap by planting bugs on purpose: if the suite still passes, the mutant *survived* and you have found a test that asserts nothing.
+
+```bash
+# pyproject.toml → [tool.mutmut]  source_paths = ["src/"]
+mutmut run                    # whole source tree
+mutmut run "mypkg.core*"      # scope it — this is the normal case
+mutmut results                # what survived
+```
+
+Reach for the real tool, not a hand-written mutant list: mutmut generates mutants from the syntax tree, so it cannot apply one to code that moved and cannot report one it never ran.
+
+- **Scale it to risk.** This is not a default toll — it is minutes-to-hours on a real tree. Run it where a bug is expensive (money, auth, data loss, concurrency, a public API) or where a green suite keeps shipping bugs anyway. Always scope to the code you changed.
+- **A survivor is not automatically a failure.** Some mutants are semantically equivalent to the original and cannot be killed. Classify those with the reason ("equivalent: both branches return the same value for every reachable input"). Never add a test that asserts non-behaviour just to kill one — that is the same gaming that coverage-chasing is.
+- **A survivor that is a real bug gets a test, not an excuse.** Write the assertion that kills it, then rerun.
+- **If you hand-roll a runner, prove it executed every mutant.** Clear `__pycache__` and set `PYTHONDONTWRITEBYTECODE` per mutant: two same-size mutants written in the same second can share a bytecode cache, and the runner then reports a kill for code it never ran. That defect can only ever *inflate* the score, so it will never show up as a red run — which is why the proof has to be built in rather than assumed.
+
 ## Property testing
 
 Reach for Hypothesis when a fixed example matrix can't cover the input space: parsers, serializers, encoders, math, anything with an invariant. You assert a *property* that must hold for all inputs and let Hypothesis hunt counterexamples.

--- a/skills/testing-web/SKILL.md
+++ b/skills/testing-web/SKILL.md
@@ -194,6 +194,26 @@ didn't change, and a giant DOM snapshot gets blindly `--updated` the first time 
 small, stable, serializable output (a formatted currency string, a normalized config object). Never
 snapshot a full component tree as your primary assertion.
 
+## Mutation: does the suite actually notice?
+
+Coverage tells you which code ran. It cannot tell you whether any test would have **noticed** if that code were wrong — and a `render()` with no assertion, or a snapshot nobody reads, raises coverage while detecting nothing. Mutation testing plants bugs on purpose: if the suite still passes, the mutant *survived* and you have found a test that asserts nothing.
+
+```jsonc
+// stryker.config.json — scope is not optional here
+{ "testRunner": "vitest", "mutate": ["src/cart/total.ts", "src/cart/discount.ts"] }
+```
+
+```bash
+npx stryker run
+```
+
+Reach for the real tool over a hand-written mutant list: Stryker generates mutants from the syntax tree, so it cannot apply one to code that moved and cannot report one it never ran.
+
+- **Always scope `mutate` to the files you changed.** A whole-project Stryker run on a real front-end does not finish in a useful amount of time; that is the main reason teams try it once and abandon it.
+- **Scale it to risk.** Not a default toll. Run it on the logic where a bug is expensive — pricing, totals, permissions, anything money- or auth-shaped — not on presentational components, where a surviving mutant usually just means the DOM detail genuinely does not matter.
+- **A survivor is not automatically a failure.** Some mutants are semantically equivalent to the original and cannot be killed; classify those with the reason. Never add an assertion about non-behaviour just to kill one — that is coverage-chasing wearing a different hat.
+- **A survivor that is a real bug gets an assertion, not an excuse.** Write it, then rerun.
+
 ## Anti-patterns
 
 | Anti-pattern | Why it's wrong | Do instead |

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -84,6 +84,15 @@ Rules for RUN:
 - Run from the directory the stack skill documents (Go runs from the module root; others from the subproject root). Don't guess paths.
 - If no `scripts/verify.sh` exists for a touched stack, that's a gap — say the gate is incomplete and recommend the user add the stack skill, rather than hand-rolling a one-off check that drifts from the real gate.
 
+#### A home-grown gate must prove it can fail
+
+The dangerous way a checker breaks is not a crash — it is **fail-open**: nothing errors, the layer prints pass, and it prints pass forever. That failure can only ever produce green, so no failing run will ever surface it. The rule follows: **before you trust a home-grown gate's pass, watch it fail** on a known-bad input. It is the RED principle applied to the checker.
+
+- **Third-party tools are exempt.** pytest, mypy, tsc, eslint, ruff, `go vet` have earned their failure behavior. This rule is for what we wrote: grep gates, one-off scripts, custom guards, anything whose exit codes nobody has tested.
+- **A must-find-nothing grep has three outcomes, not two.** No matches = pass. A match = fail. **The scan itself breaking** (unreadable input, bad pattern) = fail too. Left unhandled, an unreadable file becomes a silent pass. No `|| true`, no `2>/dev/null`, no bare fallthrough.
+- **State the limit where you state the pass.** Watching a gate fail once proves that *one* known-bad case reaches its failure path. It does **not** prove the gate recognizes every violation of the rule it claims to enforce — a gate can fail closed perfectly and still guard a spelling rather than a behavior. Record the control, and record what it does not buy.
+- **Our own known fail-open:** the stack `verify.sh` scripts SKIP a missing tool instead of failing. That is a documented gap, not a pass — so it goes in the record's *Capas no ejecutadas* under `HERRAMIENTA-AUSENTE`, never left implied.
+
 ### 3 — WALK the done-checks and acceptance criteria
 
 The stack gate proves the code is *clean and tested*. It does **not** prove the feature does what the spec asked. Walk both lists explicitly:
@@ -106,6 +115,7 @@ tags: [sdd, verification]
 timestamp: YYYY-MM-DDTHH:MM:SSZ
 topic: sdd
 slug: <slug>
+source_state: 3f9a1c2 (clean)
 ---
 
 # Verification — <slug> — YYYY-MM-DD
@@ -122,8 +132,32 @@ slug: <slug>
 - [x] AC1 user can place an order — evidence: e2e test green
 - [ ] AC3 duplicate submit is a no-op — UNVERIFIED: no observable proof
 
+## Capas no ejecutadas
+- **NO-APLICA** — mutation: no logic module changed, only templates.
+- **HERRAMIENTA-AUSENTE** — mypy: not installed in this environment; verify.sh printed SKIP and **nothing ran in its place**.
+- **SUSTITUIDA** — suite health: ran the suite twice in a fixed order instead of randomized. Cannot detect whole-suite order dependence.
+
+## Hallazgos descartados
+- "the retry loop can spin forever" — dismissed: `client.py:88` caps it at 3 attempts; test_client.py::test_retry_cap covers it.
+
 ## Verdict: FAIL — 2 open items (T4 done-check, AC3). Not ready for review.
 ```
+
+**`source_state:` is not decoration.** A verdict belongs to the commit it was measured against, not to the project: without it, nobody can tell whether the record describes the code that shipped. Record the short SHA plus `clean` or `dirty` — a dirty tree means the record describes bytes that exist on no commit, which is worth knowing when someone reads it three weeks later.
+
+**All numbers come from one fresh run made after the last edit.** A figure from mid-task is stale and does not go in the record, however true it was when you saw it.
+
+**Split "didn't run" three ways**, because one `SKIP` list collapses three different confidence claims and they read identically:
+
+| Label | Means | Reader should conclude |
+|---|---|---|
+| `NO-APLICA` | the project has no such surface | nothing missing; this describes the project |
+| `HERRAMIENTA-AUSENTE` | the surface exists, the tool was missing, **nothing ran** | that failure class was not looked for at all |
+| `SUSTITUIDA` | something else ran instead | say what the substitute **cannot** detect; never write this as a pass |
+
+`SUSTITUIDA` is the dangerous one. "Ran the suite twice" is not *suite health: stable* — it is a substitute that cannot see whole-suite order dependence, and a reader who can't tell the two apart reads "found nothing" where the truth is "did not look with that instrument".
+
+**A dismissed finding carries evidence, one line each.** A fix is self-evidencing — the test now passes. A dismissal is not: "not a real problem" is indistinguishable from "did not check". Name the command, the `file:line`, or the test that disproves it, or write "ninguno".
 
 Append-only spirit: don't overwrite a prior run's record; a new run is a new dated file. The record is the receipt the `review` and `ship` phases trust.
 
@@ -146,6 +180,9 @@ Append-only spirit: don't overwrite a prior run's record; a new run is a new dat
 | "A test is failing — let me just fix it real quick." | That's `debug`, a different discipline. `verify` reports the failure and hands off; it does not patch mid-gate. |
 | "I'll write the verdict, then run the checks to confirm." | Backwards. RUN and WALK first; the verdict is the *consequence* of output you already read. |
 | "The gate is mostly green, I'll call it done." | If you cannot point at the line of command output that proves a claim, you have no claim. Go run it. |
+| "I looked at that finding; it's not a real problem." | A dismissal with no evidence is indistinguishable from a check you never made. Name the command, `file:line`, or test that disproves it — or fix it. |
+| "The record is dated, that's enough to trace it." | A date does not identify code. Without `source_state`, nobody can tell whether the record describes what shipped. |
+| "My grep gate passed, so the tree is clean." | Did you ever watch it fail? An unhandled broken scan exits like a pass. Prove it can fail before you trust its green. |
 
 ## Result envelope
 

--- a/tests/gate-honesty.test.js
+++ b/tests/gate-honesty.test.js
@@ -1,0 +1,273 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Four rules imported from the old-coder skill after the ago-2026 investigation, each closing a
+// class of claim the harness could not check. See 02-DOCS/wiki/sdd/specs/gate-honesty.md.
+//
+// WHAT THIS GUARDS, AND WHAT IT DOES NOT — read this before trusting its green.
+//
+// This file checks that the four rules are still PRESENT in the skills that own them. It does NOT
+// check that an agent obeys them. It is, by its own subject matter, "a gate that fails closed
+// perfectly while guarding a spelling rather than a behavior" — the exact limit the negative-control
+// rule in verify/SKILL.md tells you to state where you state the pass. So: green here means the
+// rules have not silently eroded out of the catalog, which is the drift this repo has been bitten
+// by repeatedly (constitution P2). It is not behavioral verification of the rules themselves; that
+// needs real runs of `verify` and `specify` and is recorded as pending, not done.
+//
+// Markers are deliberately two-or-three independent signals per rule rather than one exact
+// sentence, so rewording the prose does not break the test while deleting the rule does.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const skill = (id) => readFileSync(join(ROOT, 'skills', id, 'SKILL.md'), 'utf8');
+
+const TESTING_SKILLS = ['testing-py', 'testing-web', 'testing-go'];
+const TOUCHED = [...TESTING_SKILLS, 'verify', 'specify'];
+
+// ------------------------------------------------------------ rule A: mutation is a real layer
+
+test('A — the three testing skills document mutation as its own layer', () => {
+  for (const id of TESTING_SKILLS) {
+    const body = skill(id);
+    assert.match(body, /^## Mutation:/m, `${id}: no mutation section`);
+    // The load-bearing argument: coverage measures execution, mutation measures detection.
+    assert.match(
+      body,
+      /which code ran/i,
+      `${id}: mutation section must contrast coverage (what ran) with detection`,
+    );
+    assert.match(body, /\bnotice(d)?\b/i, `${id}: must say whether a test would NOTICE the bug`);
+  }
+});
+
+test('A — each ecosystem names its real command, or says it has none', () => {
+  assert.match(skill('testing-py'), /mutmut run/, 'testing-py must name mutmut');
+  assert.match(skill('testing-web'), /stryker run/, 'testing-web must name Stryker');
+  // Go has no dependable tool; the skill must say so rather than inventing one.
+  assert.match(
+    skill('testing-go'),
+    /no mature mutation tool/i,
+    'testing-go must state that no mature tool exists',
+  );
+});
+
+test('A — a survivor may be equivalent, and is never killed with a fake assertion', () => {
+  for (const id of TESTING_SKILLS) {
+    const body = skill(id);
+    assert.match(body, /equivalent/i, `${id}: must allow for semantically equivalent survivors`);
+    assert.match(
+      body,
+      /non-behaviour|non-behavior/i,
+      `${id}: must forbid killing a survivor with an assertion about non-behaviour`,
+    );
+  }
+});
+
+test('A — scoped to changed code and scaled to risk, never a default toll', () => {
+  for (const id of TESTING_SKILLS) {
+    assert.match(skill(id), /risk/i, `${id}: mutation must be calibrated by risk (P7)`);
+  }
+  assert.match(skill('testing-web'), /mutate/, 'testing-web must show scoping via `mutate`');
+});
+
+test('A — a hand-rolled runner must prove it executed every mutant', () => {
+  // The sharp edge: a runner that can report a kill it never ran only ever INFLATES the score, so
+  // the defect can never surface as a red run. py (bytecode cache) and go (manual procedure) are
+  // the two places a hand-rolled runner is actually plausible.
+  for (const id of ['testing-py', 'testing-go']) {
+    const body = skill(id);
+    assert.match(body, /inflate/i, `${id}: must say the defect can only inflate the score`);
+    assert.match(
+      body,
+      /never (show up as|surface as) a red|never surface as a red/i,
+      `${id}: must say why that means no failing run will reveal it`,
+    );
+  }
+  assert.match(
+    skill('testing-py'),
+    /PYTHONDONTWRITEBYTECODE|__pycache__/,
+    'testing-py must name the bytecode-cache mechanism',
+  );
+});
+
+// ------------------------------------------------- rule B: a home-grown gate proves it can fail
+
+test('B — verify requires a home-grown gate to be watched failing', () => {
+  const body = skill('verify');
+  assert.match(body, /prove it can fail/i, 'verify: the rule itself must be present');
+  assert.match(body, /fail-open/i, 'verify: must name the fail-open failure mode');
+  assert.match(
+    body,
+    /known-bad/i,
+    'verify: must require a known-bad input, not just "test the gate"',
+  );
+});
+
+test('B — third-party tools are exempt, and the exemption is explicit', () => {
+  const body = skill('verify');
+  assert.match(body, /exempt/i, 'verify: third-party tools must be exempted explicitly');
+  assert.match(
+    body,
+    /pytest.*mypy|mypy.*pytest/s,
+    'verify: name the earned-behavior tools so the scope is unambiguous',
+  );
+});
+
+test('B — the rule carries its own limit, in the same section', () => {
+  const body = skill('verify');
+  // Without this the rule promises coverage of the constraint and delivers one case.
+  assert.match(
+    body,
+    /guard a spelling rather than a behavior|guarding a spelling/i,
+    'verify: must state that a gate can fail closed and still guard a spelling',
+  );
+  assert.match(
+    body,
+    /does \*\*not\*\* prove|does not prove/i,
+    'verify: must state what one negative control does NOT buy',
+  );
+});
+
+test('B — a must-find-nothing grep has three outcomes, not two', () => {
+  const body = skill('verify');
+  assert.match(body, /three outcomes/i, 'verify: the grep case must be spelled out');
+  assert.match(body, /\|\| true/, 'verify: must forbid `|| true`');
+  assert.match(body, /2>\/dev\/null/, 'verify: must forbid swallowing stderr');
+});
+
+test('B — our own verify.sh SKIP is declared as the known fail-open', () => {
+  const body = skill('verify');
+  assert.match(
+    body,
+    /SKIP a missing tool instead of failing|known fail-open/i,
+    'verify: the stack verify.sh SKIP must be named as a known fail-open, not left implied',
+  );
+});
+
+// ------------------------------------------------------- rule C: an answer is not an approval
+
+test('C — specify separates answering a question from approving the spec', () => {
+  const body = skill('specify');
+  assert.match(
+    body,
+    /answer to a question is not an approval/i,
+    'specify: the rule itself must be present',
+  );
+  assert.match(
+    body,
+    /no longer exists/i,
+    'specify: must say a pre-question approval approves a document that no longer exists',
+  );
+  assert.match(body, /two exchanges/i, 'specify: must give the two-exchange sequence');
+});
+
+test('C — the recommended-option trap is named', () => {
+  const body = skill('specify');
+  assert.match(
+    body,
+    /recommended-option/i,
+    'specify: must name the recommended-option shape as the easy failure',
+  );
+  assert.match(
+    body,
+    /consent \*?looks\*? implied|looks implied/i,
+    'specify: must say why it fools the reader — consent looks implied',
+  );
+});
+
+test('C — silence and an unrelated go-ahead are not approval either', () => {
+  const body = skill('specify');
+  assert.match(body, /silence/i, 'specify: silence must be excluded explicitly');
+  assert.match(
+    body,
+    /cannot quote the words/i,
+    'specify: must give the quotable-words test for whether approval exists',
+  );
+});
+
+test('C — autopilot stays valid but is recorded as autopilot', () => {
+  const body = skill('specify');
+  assert.match(body, /[Aa]utopilot is still valid/, 'specify: autopilot must not be broken by this');
+  assert.match(
+    body,
+    /not item by item/i,
+    'specify: autopilot must be recorded as such, not as item-by-item approval',
+  );
+});
+
+// ------------------------------- rule D: the record says what it measured, and what it did not
+
+test('D — the verification record binds to a source state', () => {
+  const body = skill('verify');
+  assert.match(body, /source_state:/, 'verify: the record template must carry source_state');
+  assert.match(body, /dirty/i, 'verify: must record whether the tree was dirty');
+  assert.match(
+    body,
+    /A date does not identify code|not decoration/i,
+    'verify: must say why a date alone is insufficient',
+  );
+});
+
+test('D — layers that did not run are split three ways', () => {
+  const body = skill('verify');
+  for (const label of ['NO-APLICA', 'HERRAMIENTA-AUSENTE', 'SUSTITUIDA']) {
+    assert.match(body, new RegExp(label), `verify: missing the ${label} state`);
+  }
+  // SUSTITUIDA is the dangerous one: it must never be written as a pass.
+  assert.match(
+    body,
+    /never write this as a pass|never as a pass/i,
+    'verify: SUSTITUIDA must be forbidden from reading as a pass',
+  );
+  assert.match(
+    body,
+    /cannot detect/i,
+    'verify: a substitute must state what it cannot detect',
+  );
+});
+
+test('D — dismissed findings carry evidence, one line each', () => {
+  const body = skill('verify');
+  assert.match(body, /Hallazgos descartados/, 'verify: the record needs a dismissals section');
+  assert.match(
+    body,
+    /indistinguishable from/i,
+    'verify: must say why a bare dismissal is worthless',
+  );
+});
+
+test('D — all numbers come from one fresh run after the last edit', () => {
+  assert.match(
+    skill('verify'),
+    /one fresh run/i,
+    'verify: must require a single fresh run after the last edit',
+  );
+});
+
+// ------------------------------------------------------------------- constitution invariants
+
+test('P5 — no touched skill body exceeds the 400-line ceiling', () => {
+  for (const id of TOUCHED) {
+    const lines = skill(id).split('\n').length;
+    assert.ok(lines <= 400, `${id}: ${lines} lines exceeds the 400-line ceiling (P5)`);
+  }
+});
+
+test('P3 — the P2 appearance count lives only in puertas-y-mecanismos, never in a skill body', () => {
+  // Two specs once contradicted each other because each pinned an ordinal in its own prose. The
+  // counter lives in one table; nothing else may state an nth appearance.
+  const ordinal =
+    /\b(second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|eleventh|twelfth)\s+(appearance|occurrence)\b/i;
+  for (const id of TOUCHED) {
+    assert.doesNotMatch(skill(id), ordinal, `${id}: must not pin an ordinal of the P2 counter`);
+  }
+});
+
+test('the four rules live in skills that actually ship in the package', () => {
+  // A rule in a skill nobody installs is a rule nobody gets. Guards a path typo, nothing deeper.
+  const shipped = new Set(readdirSync(join(ROOT, 'skills')));
+  for (const id of TOUCHED) {
+    assert.ok(shipped.has(id), `${id}: not present in skills/`);
+  }
+});

--- a/tests/gate-honesty.test.js
+++ b/tests/gate-honesty.test.js
@@ -95,7 +95,14 @@ test('A — a hand-rolled runner must prove it executed every mutant', () => {
 
 test('B — verify requires a home-grown gate to be watched failing', () => {
   const body = skill('verify');
-  assert.match(body, /prove it can fail/i, 'verify: the rule itself must be present');
+  // Anchor on the HEADING, not the phrase. A bare /prove it can fail/ also matches the one-line
+  // reminder in the anti-patterns table, so it survived a mutant that gutted this whole section —
+  // found by the negative control in 02-DOCS/wiki/sdd/verifications/gate-honesty-2026-08-17.md.
+  assert.match(
+    body,
+    /^#+ .*prove it can fail\s*$/im,
+    'verify: the rule needs its own section, not just an anti-pattern row',
+  );
   assert.match(body, /fail-open/i, 'verify: must name the fail-open failure mode');
   assert.match(
     body,
@@ -200,7 +207,15 @@ test('C — autopilot stays valid but is recorded as autopilot', () => {
 
 test('D — the verification record binds to a source state', () => {
   const body = skill('verify');
-  assert.match(body, /source_state:/, 'verify: the record template must carry source_state');
+  // Anchor on the FIELD in the template, not a mention of it. A bare /source_state:/ also matches
+  // the prose that explains the field, so it survived a mutant that removed the field from the
+  // template and left the prose talking about it — the "guards a spelling, not the thing" failure
+  // this very rule warns about, caught by its own negative control.
+  assert.match(
+    body,
+    /^source_state: \S+/m,
+    'verify: the record template must carry an actual source_state field',
+  );
   assert.match(body, /dirty/i, 'verify: must record whether the tree was dirty');
   assert.match(
     body,


### PR DESCRIPTION
Four rules imported from [AmazingAng/old-coder](https://github.com/AmazingAng/old-coder) after a full read of the repo, each closing a class of claim this harness declared but could not check. This extends constitution **P2** — *"una puerta que no comprueba nada es peor que ninguna puerta"* — from the catalog layer, where it already has mechanisms, to the test layer, where it had none.

Measured before writing anything: across 264 skills, "mutation" appeared **zero** times, "negative control" zero, and verification records carried a date but no source state.

## What lands

**A. Mutation as a real layer** — `testing-py`, `testing-web`, `testing-go`.
Coverage tells you which code ran; it cannot tell you whether any test would have *noticed* the code was wrong. Each skill gets its ecosystem's real command (`mutmut run`, `npx stryker run`, and for Go the honest admission that no mature tool exists), scoped to changed code and scaled to risk (P7) — not a default toll. Survivors may be semantically equivalent and get classified with a reason rather than killed by an assertion about non-behaviour. A hand-rolled runner must prove it executed every mutant, because that defect can only ever *inflate* the score and therefore never surfaces as a red run.

**B. A home-grown gate must prove it can fail** — `verify`.
Before trusting a home-made gate's green, watch it fail on a known-bad input. Third-party tools (pytest, mypy, tsc, eslint) are exempt — they earned their failure behavior. A must-find-nothing grep has three outcomes, not two: the scan *breaking* is also a failure. And the rule carries its limit in the same section: one negative control proves one known-bad case reaches the failure path, **not** that the gate recognizes every violation — a gate can fail closed perfectly and still guard a spelling rather than a behavior.

**C. An answer to a question is not an approval** — `specify`.
An answer is an *input* that changes the spec, so any approval held before the question covered a document that no longer exists. Names the recommended-option trap: when the user picks what you recommended, the spec looks unchanged and consent looks implied, and neither is true. Autopilot stays valid but is recorded *as autopilot*, not as item-by-item approval.

**D. Records say what they measured, and what they did not look at** — `verify`.
Records bind to a `source_state` (short SHA + clean/dirty), because a date does not identify code. All numbers come from one fresh run after the last edit. Layers that did not run split three ways — `NO-APLICA` / `HERRAMIENTA-AUSENTE` / `SUSTITUIDA` — because one "SKIP" list collapses three different confidence claims that read identically. `SUSTITUIDA` may never be written as a pass. Dismissed findings carry evidence, one line each: a fix is self-evidencing, a dismissal is not.

## The finding that paid for the whole change

`tests/gate-honesty.test.js` pins all four rules and passed **21/21 on the first run**. Per rule B, that proves nothing until watched failing — so eight mutants were planted. **Two survived**, and both were the exact failure the rule they guard describes:

- `/prove it can fail/` also matched the one-line reminder in the anti-patterns table, so gutting the entire rule section left the test green.
- `/source_state:/` also matched the prose *explaining* the field, so removing the field from the template left the test green.

Both could only ever produce a false pass, so no failing run would have revealed either. Fixed by anchoring to structure (section heading, line-start field). 8/8 killed after the fix. Both cases are now rows in the pattern registry.

A third row goes in too: **our own `verify.sh` SKIP is a documented fail-open.** It stays that way in this PR by deliberate scope choice — those scripts are generated for third-party repos and hardening them would break user environments without warning — but it is now named as a known gap and surfaces in every record under `HERRAMIENTA-AUSENTE` rather than being left implied.

## Deliberately out of scope

- **old-coder's independent-verification protocol.** Six rounds and ~550k tokens against a 99-line file, with its own note conceding negative marginal return from round 5. Our `review` already runs three fresh-context refuters in parallel, cheaper and routinely. Two of its rules we *do* lack — explicit limited inputs, blind-first — are deferred to their own spec.
- **Anti-gaming rules in `implement`.** Good, and missing, but `implement` is at 369 lines of a 400 ceiling and P5 outranks convenience.
- **Changed-line coverage vs the global floors we use today.** Touches four stacks' `verify.sh`; own spec.

## Verification

| Gate | Result |
|---|---|
| `npm run validate` | frontmatter OK, 264 skills |
| `npm run manifest:check` | manifest OK (264 skills) |
| `npm test` | 351 passed, 0 failed |
| `bash scripts/eval-lint.sh` | 264 skills scanned, 0 failures |
| `npm run drift:check` | 810 link claims, all resolve |
| manual mutation of the new test | 8/8 killed (after fixing 2 survivors) |
| P5 ceiling | 197 / 244 / 263 / 215 / 295 lines, all under 400 |

**Declared limit, stated plainly:** the test guards **presence** of the four rules, not behaviour. It checks they are still written, not that an agent obeys them — by its own subject matter "a gate that fails closed while guarding a spelling". That limit is declared in the test header, the spec, and the record. Behavioural verification needs real runs of `verify` and `specify` and is recorded as pending, not done.

No independent adversarial review was run on this change (session policy on subagents); self-review plus the negative control stood in. Recorded as `SUSTITUIDA`.