### PR TITLE
feat(gates): pay the gate-honesty debt — GAP state, gradeable rules, four-input refuters

### DIFF
--- a/skills/fastapi/scripts/verify.sh
+++ b/skills/fastapi/scripts/verify.sh
@@ -9,9 +9,20 @@
 # Auto-detects each tool. If a tool is missing it prints a yellow SKIP and continues
 # (it never FAILs on a missing tool). Prefers `uv run <tool>` when `uv` is present,
 # else the bare tool on PATH. Exits non-zero only if a tool actually ran and reported
-# a failure. The coverage threshold is read from the project's pyproject.toml
-# (--cov-fail-under); this script does not hardcode a second threshold. Idempotent:
-# re-running yields the same result (read-only beyond whatever the project's pytest does).
+# a failure. Idempotent: re-running yields the same result (read-only beyond whatever
+# the project's pytest does).
+#
+# COVERAGE IS ONLY A GATE IF YOUR PROJECT MAKES IT ONE. The threshold is deliberately
+# delegated to the project (--cov-fail-under in pyproject.toml / setup.cfg / .coveragerc)
+# rather than hardcoded here. But when the project sets none, `pytest --cov` prints a
+# percentage and exits 0 however far coverage falls — and a layer that prints a number and
+# exits 0 is a report, not a gate. That case is reported as [gap] instead of PASS, because
+# the two are indistinguishable on screen and the broken one can only ever produce green:
+# no failing run will ever surface it.
+#
+# A [gap] does NOT change the exit code — breaking every repo that passes today is not this
+# script's call. This script reports; the `verify` skill judges, and there a gap counts as
+# an unverified criterion, which fails the verdict.
 #
 # Compatible with stock macOS bash 3.2: no `mapfile`, no associative arrays, and every
 # array access is guarded so `set -u` never trips on an "unbound" empty array.
@@ -30,7 +41,28 @@ warn() { printf '%s%s%s\n' "$YELLOW" "$*" "$RESET"; }
 ok()   { printf '%s%s%s\n' "$GREEN" "$*" "$RESET"; }
 fail() { printf '%s%s%s\n' "$RED" "$*" "$RESET"; }
 
-PASSED=0; SKIPPED=0; FAILED=0
+PASSED=0; SKIPPED=0; FAILED=0; GAPS=0
+
+# gap <reason> — the layer ran and had nothing to fail with. Counted and printed, but it
+# deliberately does NOT touch FAILED: see the header note on why the exit code is unchanged.
+gap() { printf '%sGAP: %s%s\n' "$YELLOW" "$*" "$RESET"; GAPS=$((GAPS + 1)); }
+
+# coverage_threshold_configured — does the project actually gate on coverage?
+# Looks for pytest's --cov-fail-under (addopts or a bare flag) and coverage.py's fail_under.
+# Grep rc: 0 = found, 1 = not found, >=2 = the scan itself broke. Treat "broke" as NOT
+# configured so the answer errs toward reporting a gap; a broken scan must never buy a pass.
+coverage_threshold_configured() {
+  local f rc
+  for f in "$TARGET/pyproject.toml" "$TARGET/setup.cfg" "$TARGET/tox.ini" "$TARGET/.coveragerc" "$TARGET/pytest.ini"; do
+    [ -f "$f" ] || continue
+    grep -qE 'cov-fail-under|fail_under' "$f" && return 0
+    rc=$?
+    if [ "$rc" -ge 2 ]; then
+      warn "NOTE: could not read '${f}' while checking for a coverage threshold; treating it as absent"
+    fi
+  done
+  return 1
+}
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -105,12 +137,21 @@ run_step "ruff check"        ruff check "$TARGET"
 run_step "ruff format check" ruff format --check "$TARGET"
 run_step "mypy"              mypy "$TARGET"
 run_step "pytest + coverage" pytest --cov --cov-report=term-missing
+# Only meaningful if pytest actually ran; a SKIP already says nothing was measured.
+if tool_available pytest && ! coverage_threshold_configured; then
+  gap "coverage ran without a threshold (no --cov-fail-under / fail_under found) — this layer cannot fail. Add --cov-fail-under=<n> to pyproject.toml addopts to make it a gate."
+fi
 run_step "pip-audit"         pip-audit
 
-printf '\n%d passed, %d skipped, %d failed\n' "$PASSED" "$SKIPPED" "$FAILED"
+printf '\n%d passed, %d skipped, %d failed, %d gap(s)\n' "$PASSED" "$SKIPPED" "$FAILED" "$GAPS"
+if [ "$GAPS" -gt 0 ]; then
+  warn "A GAP is neither a pass nor a failure: the layer ran and could not have failed. Report it as unverified."
+fi
 if [ "$FAILED" -gt 0 ]; then
   fail "verify.sh: failures detected"
   exit 1
 fi
-ok "verify.sh: ok"
+# "every check that could fail, passed" rather than a bare ok: with a GAP present, the
+# stronger claim would be false in exactly the way this script now exists to prevent.
+ok "verify.sh: ok (every check that could fail, passed)"
 exit 0

--- a/skills/go/scripts/verify.sh
+++ b/skills/go/scripts/verify.sh
@@ -11,6 +11,17 @@
 # Real problems (unformatted code, vet/test/vuln failures) exit non-zero.
 # Read-only: never mutates your source.
 #
+# ONE LAYER HERE IS A REPORT, NOT A GATE. `go test -cover` takes no threshold flag, so
+# coverage can print any number — 4%, 0% — and still exit 0. It is therefore reported as
+# [gap]: the layer ran and had nothing to fail with. Said out loud because a layer that
+# prints a number and exits 0 looks exactly like a layer that passed, and that shape can
+# only ever produce green — no failing run will ever tell you about it. Want a real
+# coverage gate in Go? Parse `go tool cover -func` and compare, or use a CI action; this
+# script does not pretend to be one.
+#
+# A [gap] does NOT change the exit code: this script reports, the `verify` skill judges,
+# and there it counts as an unverified criterion, which fails the verdict.
+#
 # Portability: runs on stock macOS bash 3.2 (no mapfile, no associative arrays,
 # no unguarded array expansions under `set -u`).
 
@@ -24,12 +35,16 @@ else
 fi
 
 failed=0
+gaps=0
 
 have()  { command -v "$1" >/dev/null 2>&1; }
 warn()  { printf '%s[skip]%s %s\n' "$YELLOW" "$RESET" "$*"; }
 fail()  { printf '%s[fail]%s %s\n' "$RED" "$RESET" "$*"; failed=1; }
 ok()    { printf '%s[ ok ]%s %s\n' "$GREEN" "$RESET" "$*"; }
 info()  { printf -- '----- %s\n' "$*"; }
+# A layer that ran but had nothing to fail with. Deliberately does NOT set `failed`:
+# breaking every repo that passes today is not this script's call to make.
+gap()   { printf '%s[gap ]%s %s\n' "$YELLOW" "$RESET" "$*"; gaps=$((gaps + 1)); }
 
 # Must run from a module root.
 if [ ! -f go.mod ]; then
@@ -89,6 +104,10 @@ if have go; then
     warn "cgo disabled or C compiler '$cgo_cc' not found; running plain go test -cover"
     if go test -cover ./...; then ok "tests pass (no race)"; else fail "tests failed"; fi
   fi
+  # The tests above are a gate; the coverage number printed alongside them is not.
+  # `go test -cover` has no threshold flag, so coverage cannot fail this script no matter
+  # how far it falls. Reported so nobody reads the percentage as a checked constraint.
+  gap "coverage: reported, not gated — 'go test -cover' takes no threshold, so this layer cannot fail"
 else
   warn "go not found - skipping tests"
 fi
@@ -102,8 +121,14 @@ else
 fi
 
 echo
+if [ "$gaps" -ne 0 ]; then
+  printf '%s%d layer(s) ran without being able to fail (see [gap] above).%s\n' "$YELLOW" "$gaps" "$RESET"
+  printf 'Not a pass and not a failure: report them as unverified rather than green.\n'
+fi
 if [ "$failed" -ne 0 ]; then
   printf '%sFAIL:%s one or more checks failed.\n' "$RED" "$RESET"
   exit 1
 fi
-printf '%sPASS:%s all checks passed.\n' "$GREEN" "$RESET"
+# Deliberately "checks that could fail, passed" and not "all checks passed": with a [gap]
+# present the second sentence would be false in the way this whole change exists to stop.
+printf '%sPASS:%s every check that could fail, passed.\n' "$GREEN" "$RESET"

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -76,6 +76,24 @@ code tells you nothing about whether it can fail. **Refactor only on green** kee
 reversible against a passing bar. **Checkpoint after each task** is what makes this resumable and
 reviewable instead of a 2000-line surprise diff.
 
+### Four things you may never do to reach green
+
+The loop only means anything if green cannot be manufactured. These are absolute, and each one is a
+way people reach green without fixing anything:
+
+1. **Never weaken a test to make it pass.** Not broadening an assertion, not adding a skip, not
+   raising a tolerance, not deleting it. A test that looks wrong is a **spec conversation** — surface
+   it, don't bury it.
+2. **Never edit a test and the implementation in the same step to reach green.** Change one, run,
+   then the other. Simultaneous edits let you redefine correctness to match your bug without
+   noticing you did it.
+3. **Never mock the unit under test**, or mock so much that the test only exercises the mocks. Mock
+   boundaries you don't own — network, clock, filesystem, third-party SDK — never the logic you are
+   being paid to verify.
+4. **Never chase the coverage number.** Coverage detects untested code; it is not a target. A test
+   added to touch lines, with no meaningful assertion, is gaming — and mutation testing exists
+   precisely to catch it (`../testing-py/SKILL.md`, `../testing-web/SKILL.md`, `../testing-go/SKILL.md`).
+
 ### The done-check is the contract
 
 Each task carries a done-check from the `tasks` phase ("returns 409 on duplicate email", "list

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -128,9 +128,41 @@ gap deliberately with `--accept-partial-lenses` (it is recorded). Every approval
 
 **Lenses by risk tier** — tier 0 never reaches you (the gate passes docs/copy silently);
 tier 1 → run the single most relevant pass from the table above yourself; tier 2 → dispatch
-**three parallel fresh-context subagents** (correctness · security · tests-as-evidence), each
-given only the diff and told to *refute* readiness, not confirm it. Fresh context is the point:
-a reviewer who inherits the implementer's context inherits its blind spots.
+**three parallel fresh-context subagents** (correctness · security · tests-as-evidence), each told
+to *refute* readiness, not confirm it. Fresh context is the point: a reviewer who inherits the
+implementer's context inherits its blind spots.
+
+**Give each refuter exactly four inputs — no more, no less.** The diff alone is not enough, and
+that is not a detail: with only the diff, the one failure class no test suite can structurally
+catch — *the change is correct and is not what the approved spec asked for* — is invisible to the
+whole panel.
+
+1. **The task contract** — the original request **plus every scope change a human explicitly
+   approved since.** Not just the first message: without the approved changes a legitimate scope
+   revision reads as a spec gap and you get a confident false positive.
+2. **The approved spec** (`02-DOCS/wiki/sdd/specs/<slug>.md`).
+3. **The exact source state** — commit SHA, or a tree hash when git is absent. A verdict belongs to
+   the state that was reviewed, not to the project.
+4. **The entry point** — the one command that reruns the checks.
+
+**And say what they do not get:** your conversation, your reasoning, your defences, and your draft
+verdict. If a claim needs your justification to stand, it is not proven.
+
+**Blind first, compare second.** Each refuter records what it attacked and what it found *before*
+being shown your conclusions. Only then may it compare and add findings — the blind record is
+append-only after that, never rewritten. Skip this and the fresh context is spent confirming your
+framing, which is the one thing it was bought to avoid.
+
+**The attack list is the deliverable, not just the findings.** "Nothing found" without saying where
+you looked is indistinguishable from not having looked — the same rule that governs a dismissal.
+
+Two extra finding classes the four inputs unlock, neither reachable from a diff:
+
+- **Contract vs spec** — what would a caller reasonably expect, given the stated deployment, that
+  no clause covers? An exclusion the spec deliberately approved is **not** a finding; an exclusion
+  the spec describes *inaccurately* is.
+- **Mapping, both directions** — an acceptance criterion with no test that can be made to fail, and
+  a test pinning behaviour no criterion asked for.
 
 **A finding blocks only if it survives all three filters** — no exceptions, and eagerness to
 find something is not evidence:

--- a/skills/specify/evals/cases.yaml
+++ b/skills/specify/evals/cases.yaml
@@ -78,3 +78,5 @@ capability:
       - "Captures observable behaviour (what the user sees/can do) and explicit non-goals / out-of-scope rather than implementation (no file format library, storage, or job-queue detail)."
       - "Turns answers into binary acceptance criteria and defers unresolved items (e.g. data scope, retention, format) to Points to clarify instead of fabricating decisions."
       - "Notes that the spec is complete-enough-to-plan with open points remaining, and hands off to clarify — not to plan or implementation."
+      - "After the user answers a question, folds the answer in, states what changed, shows the revised spec, and asks for approval AGAIN — it does not treat the answer as approval of the spec, including when the user picked the recommended option."
+      - "If told to run the whole chain up front, records the approval as autopilot rather than item-by-item, and says the spec is the artifact to review after the fact."

--- a/skills/testing-go/evals/cases.yaml
+++ b/skills/testing-go/evals/cases.yaml
@@ -42,3 +42,5 @@ capability:
       - A hand-written interface fake or net/http/httptest server for the HTTP dependency, not a mock framework by default
       - Runs with -race for the concurrent path and shows a go test -coverprofile / cross-package coverage command
       - A benchmark using for b.Loop() with b.ReportAllocs() rather than a b.N loop
+      - "Does not present the coverage percentage as proof the suite detects bugs: states Go has no mature mutation tool, gives the manual procedure, and distinguishes mutation (tests that would not notice a bug) from fuzzing (inputs the code mishandles)."
+      - "Requires a hand-rolled mutant runner to prove it executed each mutant, and says why — a kill reported without running can only inflate the score, so no failing run would ever reveal it."

--- a/skills/testing-py/evals/cases.yaml
+++ b/skills/testing-py/evals/cases.yaml
@@ -42,3 +42,5 @@ capability:
       - "asserts on the return value / observable behavior, not on mock private internals like _mock_calls"
       - "mentions a strict posture: --strict-markers and/or --strict-config (or the pytest 9 strict_* aliases)"
       - "at least one negative/error-path test (e.g. raises on non-200), not only the happy path"
+      - "Does not present branch coverage as proof the suite detects bugs: names mutation testing (mutmut) as the layer that catches assertion-free tests, and scopes it to the changed module rather than the whole tree."
+      - "Calibrates mutation by risk rather than prescribing it as a default toll, and says a surviving mutant may be semantically equivalent — to be classified with a reason, never killed with an assertion about non-behaviour."

--- a/skills/testing-web/evals/cases.yaml
+++ b/skills/testing-web/evals/cases.yaml
@@ -50,3 +50,5 @@ capability:
       - Tests an error path (500 -> visible error / role=alert) in a separate case
       - No bare act() misuse in the component test; no assertions on state/props/className
       - At least one real expect(...) assertion per test
+      - "Does not present coverage as proof the suite detects bugs: names Stryker as the layer that catches assertion-free tests, and scopes `mutate` to the changed files because a whole-project run does not finish."
+      - "Calibrates mutation by risk rather than prescribing it always, and treats a surviving mutant as possibly equivalent (classified with a reason) instead of adding an assertion about non-behaviour."

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -80,6 +80,7 @@ If `config.yaml` provides `testing.commands.verify`, run those commands first or
 Rules for RUN:
 
 - The stack `verify.sh` **skips missing tools** (yellow SKIP) rather than failing on them — so a SKIP is not a pass. Note every SKIP; a skipped test suite means that criterion is **unverified**, which is not the same as verified-passing.
+- A `GAP` is the third thing, and it is the one that looks most like a pass: **the layer ran and had nothing to fail with.** The fastapi gate reports it when coverage runs with no `--cov-fail-under` configured; the Go gate reports it always, because `go test -cover` takes no threshold. The script deliberately does not fail on a GAP — that judgement is yours. **Treat a GAP as an unverified criterion, which fails the verdict**, and record it (see the mapping below). A gate that reports and a gate that checks are indistinguishable on screen, and only the broken one is guaranteed to stay green.
 - A non-zero exit from a tool that actually ran is a hard FAIL. Record the failing tool and its output.
 - Run from the directory the stack skill documents (Go runs from the module root; others from the subproject root). Don't guess paths.
 - If no `scripts/verify.sh` exists for a touched stack, that's a gap — say the gate is incomplete and recommend the user add the stack skill, rather than hand-rolling a one-off check that drifts from the real gate.
@@ -156,6 +157,15 @@ source_state: 3f9a1c2 (clean)
 | `SUSTITUIDA` | something else ran instead | say what the substitute **cannot** detect; never write this as a pass |
 
 `SUSTITUIDA` is the dangerous one. "Ran the suite twice" is not *suite health: stable* — it is a substitute that cannot see whole-suite order dependence, and a reader who can't tell the two apart reads "found nothing" where the truth is "did not look with that instrument".
+
+**Where a `GAP` goes — and do not invent a fourth label.** A layer that ran without being able to fail is not `NO-APLICA` (the surface exists) and not `HERRAMIENTA-AUSENTE` (the tool ran). It is `SUSTITUIDA`: what ran was **a report in place of a gate**, and what it cannot detect is **coverage falling**. Write it that way:
+
+```text
+- **SUSTITUIDA** — coverage: ran without a threshold (GAP). A report, not a gate;
+  cannot detect coverage regressing. Fix: --cov-fail-under=<n> in pyproject addopts.
+```
+
+**And while you are there: the global percentage is the wrong number.** A project-wide floor barely moves when your change lands untested — 200 new uncovered lines in a 20k-line codebase is a rounding error against an 85% floor, so the gate passes and the change is untested. What matters is whether **the lines you touched** are exercised: `diff-cover coverage.xml --fail-under=100` gates exactly those. This is guidance, not something the generated `verify.sh` scripts do — recommend it, don't assume it ran.
 
 **A dismissed finding carries evidence, one line each.** A fix is self-evidencing — the test now passes. A dismissal is not: "not a real problem" is indistinguishable from "did not check". Name the command, the `file:line`, or the test that disproves it, or write "ninguno".
 

--- a/skills/verify/evals/cases.yaml
+++ b/skills/verify/evals/cases.yaml
@@ -72,3 +72,8 @@ capability:
       - "RECORDS a dated verification file under 02-DOCS/wiki/sdd/verifications/ and indexes it in the root CLAUDE.md Knowledge map."
       - "Returns a VERDICT that is PASS only if EVERY item has passing evidence; a single unverified acceptance criterion makes the whole verdict FAIL — and refuses to call it 'done' otherwise."
       - "On PASS, points to the review phase; on FAIL, routes failing checks to debug and missing coverage back to implement."
+      - "Treats a coverage GAP (the layer ran with no threshold configured, so it could not have failed) as an unverified criterion that fails the verdict — not as a pass — and records it as SUSTITUIDA: a report in place of a gate, unable to detect coverage regressing."
+      - "Before trusting any home-grown gate that reports green, asks for it to be watched failing on a known-bad input, and states the limit: one negative control proves one bad case reaches the failure path, not that the gate covers the rule it claims to enforce."
+      - "Splits layers that did not run into NO-APLICA / HERRAMIENTA-AUSENTE / SUSTITUIDA rather than one undifferentiated SKIP list, and never writes SUSTITUIDA as a pass."
+      - "Binds the record to a source state (short commit SHA plus clean/dirty) and takes every number from one fresh run made after the last edit, refusing to reuse mid-task figures."
+      - "Gives any dismissed finding its own evidence line (command, file:line, or the test that disproves it) rather than asserting it was not a real problem."

--- a/tests/gate-honesty-debt.test.js
+++ b/tests/gate-honesty-debt.test.js
@@ -1,0 +1,276 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The four debts gate-honesty (1.0.12) declared and did not pay. See
+// 02-DOCS/wiki/sdd/specs/gate-honesty-debt.md.
+//
+// WHAT THIS GUARDS, AND WHAT IT DOES NOT — same honesty as gate-honesty.test.js.
+//
+// Most of this file checks that rules are still PRESENT in the skills that own them, not that an
+// agent obeys them. It is a drift guard, not behavioural verification.
+//
+// TWO assertions here ARE structural facts rather than spellings, and they are the ones that
+// matter most, because they protect third-party repos rather than our prose:
+//   * `gap()` must not touch the failure variable in either verify.sh — a GAP reports, it never
+//     starts failing a repo that passes today.
+//   * neither GAP summary block may exit.
+// The live proof that those hold end-to-end (exit 0 with a GAP present, exit 1 when a real check
+// fails alongside a GAP) was run against toy projects and is recorded in
+// 02-DOCS/wiki/sdd/verifications/gate-honesty-debt-2026-08-17.md with the commands. It is not
+// re-run here: it needs pytest/ruff/go installed, and a test that silently skips when a tool is
+// missing is the exact fail-open this whole spec is about.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const skill = (id) => readFileSync(join(ROOT, 'skills', id, 'SKILL.md'), 'utf8');
+// Prose assertions run against whitespace-collapsed text. Skill bodies are hard-wrapped, so a
+// sentence matched with single spaces fails the moment the wrap lands mid-phrase — four assertions
+// here did exactly that on the first run, none of them because the rule was missing. Structural
+// assertions (headings, script bodies, YAML) deliberately keep the raw text.
+const prose = (id) => skill(id).replace(/\s+/g, ' ');
+const script = (id) => readFileSync(join(ROOT, 'skills', id, 'scripts/verify.sh'), 'utf8');
+const cases = (id) => readFileSync(join(ROOT, 'skills', id, 'evals/cases.yaml'), 'utf8');
+
+// The capability block only — an item asserted anywhere in the file would also match a
+// should_trigger prompt, which is not where behaviour is graded.
+const capabilityBlock = (id) => {
+  const text = cases(id);
+  const i = text.search(/^capability:\s*$/m);
+  assert.ok(i !== -1, `${id}: no capability block in cases.yaml`);
+  return text.slice(i);
+};
+
+const COVERAGE_SCRIPTS = ['fastapi', 'go'];
+const TESTING = ['testing-py', 'testing-web', 'testing-go'];
+const TOUCHED_SKILLS = [...TESTING, 'verify', 'specify', 'review', 'implement'];
+
+// ------------------------------------------------ A: a coverage layer declares if it can fail
+
+test('A — both coverage scripts report a GAP state distinct from PASS/SKIP/FAIL', () => {
+  for (const id of COVERAGE_SCRIPTS) {
+    const s = script(id);
+    assert.match(s, /^\s*gap\(\)/m, `${id}/verify.sh: no gap() helper`);
+    assert.match(s, /\bgaps?=0/i, `${id}/verify.sh: no gap counter initialised`);
+    assert.match(s, /cannot fail|not gated/i, `${id}/verify.sh: GAP must say why the layer cannot fail`);
+  }
+});
+
+test('A — INVARIANT: gap() never touches the failure variable', () => {
+  // The load-bearing assertion of this file. If a GAP ever set the failure flag, every repo with
+  // no coverage threshold would start failing a script that passed yesterday — a silent break of
+  // third-party environments, which is precisely what the spec forbade.
+  for (const id of COVERAGE_SCRIPTS) {
+    const body = script(id).match(/^\s*gap\(\)\s*\{[^}]*\}/m);
+    assert.ok(body, `${id}/verify.sh: could not isolate the gap() body`);
+    assert.doesNotMatch(
+      body[0],
+      /FAILED=|failed=|exit\b/,
+      `${id}/verify.sh: gap() must not set the failure counter or exit`,
+    );
+  }
+});
+
+test('A — INVARIANT: the GAP summary block does not exit', () => {
+  for (const id of COVERAGE_SCRIPTS) {
+    const s = script(id);
+    // The block guarded by the gap counter, up to the next `fi`.
+    const block = s.match(/if \[ "\$(GAPS|gaps)" -(ne|gt) 0 \];? then[\s\S]*?\nfi/);
+    assert.ok(block, `${id}/verify.sh: no summary block guarded by the gap counter`);
+    assert.doesNotMatch(block[0], /\bexit\b/, `${id}/verify.sh: the GAP summary must not exit`);
+  }
+});
+
+test('A — the fastapi gate detects an absent coverage threshold, and fails closed doing so', () => {
+  const s = script('fastapi');
+  assert.match(s, /coverage_threshold_configured/, 'fastapi: no threshold detection');
+  assert.match(s, /cov-fail-under\|fail_under|fail_under/, 'fastapi: must look for both flag spellings');
+  // A broken scan must not buy a pass — the grep-rc rule from the negative-control layer.
+  assert.match(
+    s,
+    /-ge 2|treating it as absent/,
+    'fastapi: a scan that breaks must err toward reporting a gap, not toward a pass',
+  );
+});
+
+test('A — the go gate states coverage is a report, not a gate', () => {
+  const s = script('go');
+  assert.match(s, /no threshold|takes no threshold/i, 'go: must say -cover takes no threshold');
+  assert.match(s, /REPORT, NOT A GATE|report, not a gate|reported, not gated/i, 'go: must say it plainly');
+});
+
+test('A — neither script still claims "all checks passed" while a GAP exists', () => {
+  for (const id of COVERAGE_SCRIPTS) {
+    assert.match(
+      script(id),
+      /could fail, passed/,
+      `${id}/verify.sh: the success line must be narrowed to checks that could fail`,
+    );
+  }
+});
+
+// ------------------------------------------------------- B: GAP maps to SUSTITUIDA in verify
+
+test('B — verify maps a GAP onto SUSTITUIDA rather than inventing a fourth label', () => {
+  const body = prose('verify');
+  assert.match(body, /GAP/, 'verify: must name the GAP state');
+  assert.match(
+    body,
+    /do not invent a fourth label/i,
+    'verify: must forbid a fourth label, or the taxonomy grows on contact',
+  );
+  assert.match(
+    body,
+    /report in place of a gate/i,
+    'verify: must explain the mapping — what ran was a report, not a gate',
+  );
+  assert.match(
+    body,
+    /unverified criterion.*fails the verdict|fails the verdict/i,
+    'verify: a GAP must block the verdict, or the script-side report is decorative (P2)',
+  );
+});
+
+test('B — verify prefers changed-line coverage over the global percentage', () => {
+  const body = prose('verify');
+  assert.match(body, /diff-cover/, 'verify: must name the tool that gates changed lines');
+  assert.match(
+    body,
+    /rounding error|barely moves/i,
+    'verify: must explain why a global floor passes an untested change',
+  );
+  assert.match(
+    body,
+    /guidance, not something the generated/i,
+    'verify: must be explicit this is guidance, not wired into the scripts',
+  );
+});
+
+// -------------------------------------------- C: review's refuters get four inputs, blind first
+
+test('C — review enumerates exactly four inputs for the refuters', () => {
+  const body = prose('review');
+  assert.match(body, /four inputs/i, 'review: the input set must be named as closed');
+  for (const marker of [/task contract/i, /approved spec/i, /exact source state/i, /entry point/i]) {
+    assert.match(body, marker, `review: missing input ${marker}`);
+  }
+  // Without the approved scope changes, a legitimate revision reads as a spec gap.
+  assert.match(
+    body,
+    /scope change a human explicitly approved/i,
+    'review: the contract must include approved scope changes, or false positives follow',
+  );
+});
+
+test('C — review says what the refuters are NOT given', () => {
+  const body = prose('review');
+  assert.match(body, /do not get|not given/i, 'review: the withheld set must be explicit');
+  assert.match(body, /draft verdict/i, 'review: the draft verdict must be withheld');
+  assert.match(
+    body,
+    /needs your justification to stand, it is not proven/i,
+    'review: must give the reason the withholding matters',
+  );
+});
+
+test('C — review requires blind-first recording, append-only afterwards', () => {
+  const body = prose('review');
+  assert.match(body, /[Bb]lind first|blind-first/, 'review: blind-first must be required');
+  assert.match(body, /append-only/i, 'review: the blind record must not be rewritable');
+  assert.match(
+    body,
+    /confirming your framing/i,
+    'review: must say what is lost without it — fresh context spent confirming us',
+  );
+});
+
+test('C — review makes the attack list a deliverable and names the spec-vs-contract class', () => {
+  const body = prose('review');
+  assert.match(body, /attack list is the deliverable/i, 'review: attack list must be a deliverable');
+  assert.match(
+    body,
+    /indistinguishable from not having looked/i,
+    'review: must say why "nothing found" alone is worthless',
+  );
+  assert.match(body, /Contract vs spec/i, 'review: must name the contract-vs-spec finding class');
+  assert.match(
+    body,
+    /describes \*?inaccurately\*?|describes it inaccurately|describes .* inaccurately/i,
+    'review: an approved exclusion is fine; an inaccurately described one is a finding',
+  );
+});
+
+// ------------------------------------------------------- D: implement forbids manufacturing green
+
+test('D — implement forbids the four ways of manufacturing green', () => {
+  const body = prose('implement');
+  assert.match(body, /[Nn]ever weaken a test/, 'implement: must forbid weakening a test');
+  assert.match(
+    body,
+    /same step to reach green|in the same step/i,
+    'implement: must forbid editing test and implementation in one step',
+  );
+  assert.match(body, /[Nn]ever mock the unit under test/, 'implement: must forbid mocking the unit under test');
+  assert.match(body, /[Nn]ever chase the coverage number/, 'implement: must forbid coverage-chasing');
+});
+
+test('D — each prohibition carries its reason, not just the ban', () => {
+  const body = prose('implement');
+  assert.match(body, /spec conversation/i, 'implement: a wrong-looking test is a spec conversation');
+  assert.match(
+    body,
+    /redefine correctness/i,
+    'implement: must say why simultaneous edits are dangerous',
+  );
+  assert.match(body, /boundaries you don't own|Mock\s+boundaries/i, 'implement: must say what MAY be mocked');
+  assert.match(body, /mutation testing exists/i, 'implement: must connect coverage-gaming to mutation');
+});
+
+// -------------------------------------- E: the rules are gradeable behaviour in the eval scenarios
+
+test('E — the mutation rule is a gradeable behaviour in all three testing skills', () => {
+  for (const id of TESTING) {
+    const block = capabilityBlock(id);
+    assert.match(block, /mutation/i, `${id}: capability scenario does not grade mutation`);
+    // Graded as behaviour ("does not present coverage as proof"), not as a keyword mention.
+    assert.match(
+      block,
+      /[Dd]oes not present/,
+      `${id}: the item must grade a behaviour, not a mention`,
+    );
+    assert.match(block, /equivalent|inflate/i, `${id}: must grade the survivor/runner nuance`);
+  }
+});
+
+test('E — verify grades all four of the 1.0.12 rules plus the GAP', () => {
+  const block = capabilityBlock('verify');
+  assert.match(block, /GAP/, 'verify eval: must grade the GAP state');
+  assert.match(block, /known-bad input/i, 'verify eval: must grade the negative-control demand');
+  assert.match(block, /NO-APLICA/, 'verify eval: must grade the three-way split');
+  assert.match(block, /source state/i, 'verify eval: must grade the source-state binding');
+  assert.match(block, /dismissed finding/i, 'verify eval: must grade dismissal evidence');
+});
+
+test('E — specify grades asking for approval again after an answer', () => {
+  const block = capabilityBlock('specify');
+  assert.match(block, /asks for approval AGAIN|approval AGAIN/i, 'specify eval: must grade re-asking');
+  assert.match(block, /recommended option/i, 'specify eval: must cover the recommended-option case');
+  assert.match(block, /autopilot/i, 'specify eval: must grade recording autopilot as autopilot');
+});
+
+// ----------------------------------------------------------------- constitution invariants
+
+test('P5 — no touched skill body exceeds the 400-line ceiling', () => {
+  for (const id of TOUCHED_SKILLS) {
+    const lines = skill(id).split('\n').length;
+    assert.ok(lines <= 400, `${id}: ${lines} lines exceeds the 400-line ceiling (P5)`);
+  }
+});
+
+test('P3 — no skill body pins an ordinal of the P2 appearance counter', () => {
+  const ordinal =
+    /\b(second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|eleventh|twelfth)\s+(appearance|occurrence)\b/i;
+  for (const id of TOUCHED_SKILLS) {
+    assert.doesNotMatch(skill(id), ordinal, `${id}: must not pin an ordinal of the P2 counter`);
+  }
+});

--- a/tests/gate-honesty-debt.test.js
+++ b/tests/gate-honesty-debt.test.js
@@ -101,8 +101,15 @@ test('A — the go gate states coverage is a report, not a gate', () => {
 
 test('A — neither script still claims "all checks passed" while a GAP exists', () => {
   for (const id of COVERAGE_SCRIPTS) {
+    // Must appear on an EXECUTABLE line, not a comment: /could fail, passed/ anywhere in the file
+    // also matched the comment explaining the wording, so mutating the real success line left this
+    // green. Found by the negative control (mutant A5).
+    const code = script(id)
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('#'))
+      .join('\n');
     assert.match(
-      script(id),
+      code,
       /could fail, passed/,
       `${id}/verify.sh: the success line must be narrowed to checks that could fail`,
     );
@@ -150,7 +157,11 @@ test('B — verify prefers changed-line coverage over the global percentage', ()
 
 test('C — review enumerates exactly four inputs for the refuters', () => {
   const body = prose('review');
-  assert.match(body, /four inputs/i, 'review: the input set must be named as closed');
+  assert.match(
+    body,
+    /exactly four inputs — no more, no less/i,
+    'review: the instruction itself must name the set as closed (a later back-reference is not it)',
+  );
   for (const marker of [/task contract/i, /approved spec/i, /exact source state/i, /entry point/i]) {
     assert.match(body, marker, `review: missing input ${marker}`);
   }
@@ -231,7 +242,16 @@ test('D — each prohibition carries its reason, not just the ban', () => {
 test('E — the mutation rule is a gradeable behaviour in all three testing skills', () => {
   for (const id of TESTING) {
     const block = capabilityBlock(id);
-    assert.match(block, /mutation/i, `${id}: capability scenario does not grade mutation`);
+    assert.match(
+      block,
+      /proof the suite detects bugs/i,
+      `${id}: must grade the coverage-is-not-detection behaviour specifically`,
+    );
+    assert.match(
+      block,
+      /mutmut|Stryker|no mature mutation tool/,
+      `${id}: must grade the ecosystem's actual mutation answer`,
+    );
     // Graded as behaviour ("does not present coverage as proof"), not as a keyword mention.
     assert.match(
       block,


### PR DESCRIPTION
Closes the four things [#225](https://github.com/ericrisco/rsc-harness/pull/225) (v1.0.12) declared as debt and did not pay. A declared debt that isn't paid in the next delivery stops being a debt and becomes a note nobody reads.

**One measurement corrects the previous spec.** #225 spoke of "the `verify.sh` of four stacks" and implied a widespread fail-open. Measured: there are **189** `verify.sh` in the catalog, all distinct, and only **2** actually run coverage (`fastapi`, `go`). The problem was real and considerably smaller and sharper than that prose suggested.

## A — a coverage layer now declares whether it could have failed

`fastapi/scripts/verify.sh` ran `pytest --cov` and delegated the threshold to the project. Reasonable — until the project sets none, at which point pytest prints a percentage, exits 0, and the step records `PASS`. `go/scripts/verify.sh` is blunter: `go test -cover` takes no threshold flag, so coverage could **never** fail it. Both are the canonical shape old-coder warned about, living inside our own generator, and both fail in the direction no failing run can reveal.

Each now reports a fourth state, `[gap]`: **the layer ran and had nothing to fail with**, with its reason and a fix. The success line narrows from "all checks passed" to "every check that could fail, passed", because with a gap present the stronger claim is false in exactly the way this change exists to stop.

**A GAP deliberately does not change the exit code.** These scripts are generated for third-party repos that pass today; making them fail would publish a breaking change without warning (P7). So that it does not end up decorative (P2), the blocking lives where the user contract is: `verify` must treat a GAP as an **unverified criterion**, which already fails the verdict. *The script reports; the skill blocks.*

## B — GAP maps onto `SUSTITUIDA`, and a fourth label is banned

A layer that ran without being able to fail is not `NO-APLICA` (the surface exists) nor `HERRAMIENTA-AUSENTE` (the tool ran). It is `SUSTITUIDA`: what ran was **a report in place of a gate**, and what it cannot detect is **coverage regressing**. Stated explicitly, with a ban on inventing a fourth state — a three-label taxonomy grows on contact otherwise.

Plus the argument for changed-line coverage where it belongs: a global floor barely moves when your change lands untested (200 uncovered lines in a 20k-line tree is a rounding error against 85%), so `diff-cover --fail-under=100` gates what actually matters. **Guidance, explicitly not wiring** — the generated scripts do not do this, and the test enforces that we say so.

## C — review's refuters get four inputs, and record blind first

They received *"only the diff"*. That is not a detail: with only the diff, the one failure class no test suite can structurally catch — *the change is correct and is not what the approved spec asked for* — is invisible to the entire panel.

Now four enumerated inputs: the **task contract** (original request **plus every scope change a human explicitly approved since** — without those, a legitimate revision reads as a spec gap and you get a confident false positive), the **approved spec**, the **exact source state**, the **entry point**. With an explicit withheld list (our conversation, reasoning, defences, draft verdict) and the reason: if a claim needs our justification to stand, it is not proven.

**Blind first, compare second** — record what you attacked and found *before* seeing our conclusions; append-only after. Skip it and the fresh context is spent confirming our framing, which is the one thing it was bought to avoid. And the attack list is a deliverable: "nothing found" without saying where you looked is indistinguishable from not looking.

## D — implement forbids manufacturing green

The four moves that turn red into green without fixing anything: weakening a test, editing test and implementation in the same step, mocking the unit under test, chasing the coverage number. Each with its reason inline. No anti-pattern rows added: `author-skill/SKILL.md:125` forbids the rationalization bank that restates rules already in the flow, and it is paid for on every load.

## E — the 1.0.12 rules become gradeable, not just present

13 behavioural `must_include` items across five `cases.yaml`, written as behaviour a grader can mark present or absent ("does not present coverage as proof the suite detects bugs…", "asks for approval AGAIN…") rather than as keyword mentions. The existing eval harness can now measure whether the rules change behaviour.

## Verification

| Gate | Result |
|---|---|
| `npm run validate` | frontmatter OK |
| `npm run manifest:check` | manifest OK (264 skills) |
| `npm test` | **370 passed, 0 failed** (+19) |
| `bash scripts/eval-lint.sh` | 264 skills, 0 failures |
| `npm run drift:check` | all claims resolve |
| `bash -n` both scripts | OK |
| manual mutation | **17/17 killed** (after fixing 4 vacuous assertions) |
| P5 ceiling | max 387 (`implement`), all under 400 |

**The user-facing invariant was proven live**, not reasoned about — the real script against toy projects: gap appears with no threshold, absent with `--cov-fail-under=90`, **exit 0** when everything that ran passed beside a gap, **exit 1** when a real test broke beside one. So a GAP neither breaks a passing repo nor masks a failure. Commands are in the verification record.

**The control found four vacuous assertions, three of them the same defect as last time**: the assertion matched a *different occurrence* of the phrase than the one carrying the rule — `four inputs` appeared twice in `review`, `mutation` twice in a capability block, and `could fail, passed` matched the *comment* explaining the wording instead of the success line. The fourth was my own fix for the third, anchored to the wrong `printf`. All re-anchored to structure. Twice now is a pattern, not an anecdote, and it is written into the pattern registry: **in a prose test, anchor to structure — never to a phrase that can appear twice.**

**Declared limits, stated plainly.** The behavioural eval is **written and not run** — 13 items make the rules measurable; running it costs model calls and is the user's cost decision. *Measurable is not measured.* And `go/scripts/verify.sh` **has never been executed**: Go is not installed on this machine, so only its syntax and text are verified. Nothing ran in its place. No independent adversarial review (session policy on subagents); self-review plus 17 mutants stood in.

Three files in the working tree — `README.md`, `site/og.png`, `site/og.svg` — are **not part of this delivery** and are deliberately left uncommitted rather than swept in.