### PR TITLE
feat(evals): the baseline was not a control — BLOCKED instead of a fake number

### DIFF
--- a/scripts/lib/behavior-score.js
+++ b/scripts/lib/behavior-score.js
@@ -41,7 +41,25 @@ export function aggregate(scenarios) {
   return { absoluteScore, lift, n: valid.length, dropped };
 }
 
-export function behavioralGate(agg) {
+// integrity is OPTIONAL and absent means "not checked", never "clean" — callers that predate the
+// integrity layer (holdoutGate, raw stdin scoring) keep their exact behaviour.
+//
+// A violated integrity is BLOCKED, not FAIL, and the distinction is the whole point: FAIL says "the
+// skill does not clear the bar" and sends someone to edit the skill. When the control read the
+// answer key, the only true statement is "this run measures nothing" — a different action entirely.
+export function behavioralGate(agg, integrity) {
+  if (integrity && integrity.ok === false) {
+    const vs = Array.isArray(integrity.violations) ? integrity.violations : [];
+    return {
+      pass: false,
+      blocked: true,
+      reasons: [integrity.reason || 'integrity check failed'],
+      mustFix: vs.length
+        ? vs.map((v) => `${v.kind}: ${v.agent} touched ${v.pattern} (x${v.count}) — re-run with the arm isolated.`)
+        : ['Re-run the eval with integrity verifiable; the scores from this run are not a measurement.'],
+      violations: vs,
+    };
+  }
   const reasons = [];
   const mustFix = [];
   if (!agg || agg.n === 0) {
@@ -118,7 +136,7 @@ export function formatHoldoutVerdict(scored, gate) {
 }
 
 // raw: { skillId, scenarios: [{index, xIsTreatment, gradeX, gradeY, error?}] }
-export function scoreFromRaw(raw) {
+export function scoreFromRaw(raw, integrity) {
   const scenarios = (raw && Array.isArray(raw.scenarios) ? raw.scenarios : []).map((s) => {
     if (!s || s.error || !s.gradeX || !s.gradeY) {
       return { index: s ? s.index : null, error: (s && s.error) || 'missing-grade', absolute: null, delta: null };
@@ -131,8 +149,9 @@ export function scoreFromRaw(raw) {
     return { index: s.index, treatment: t, baseline: b, absolute: d.absolute, delta: d.delta };
   });
   const agg = aggregate(scenarios);
-  const gate = behavioralGate(agg);
+  const gate = behavioralGate(agg, integrity);
   const out = { skillId: (raw && raw.skillId) || null, scenarios, aggregate: agg, gate };
+  if (integrity) out.integrity = integrity;
   // Carried through untouched so the hold-out verdict can echo the fresh scenario for hand-audit.
   if (raw && raw.holdoutScenario) out.holdoutScenario = raw.holdoutScenario;
   return out;
@@ -143,7 +162,18 @@ export function formatScorecard(scored) {
   const lines = [];
   lines.push(`# Behavioral scorecard — ${skillId || '(unknown skill)'}`);
   lines.push('');
-  lines.push(`**Verdict:** ${gate.pass ? 'PASS ✅' : 'FAIL ❌'}  ·  absolute ${agg.absoluteScore == null ? 'n/a' : agg.absoluteScore}/10 (gate >= ${ABS_MIN})  ·  lift ${agg.lift == null ? 'n/a' : agg.lift} (gate >= ${LIFT_MIN})  ·  n=${agg.n}${agg.dropped ? ` (${agg.dropped} dropped)` : ''}`);
+  if (gate.blocked) {
+    // Deliberately NO absolute and NO lift here. Printing them beside a block invites reading them
+    // anyway, and they are not measurements — that is exactly what the block is saying.
+    lines.push(`**Verdict:** BLOCKED ⛔  ·  ${gate.reasons[0]}`);
+    lines.push('');
+    lines.push('The scores from this run are withheld: they are not a measurement of this skill.');
+    lines.push('');
+    lines.push('**Integrity violations:**');
+    for (const f of gate.mustFix) lines.push(`- ${f}`);
+    return lines.join('\n');
+  }
+  lines.push(`**Verdict:** ${gate.pass ? 'PASS ✅' : 'FAIL ❌'}  ·  absolute ${agg.absoluteScore == null ? 'n/a' : agg.absoluteScore}/10 (gate >= ${ABS_MIN})  ·  lift ${agg.lift == null ? 'n/a' : agg.lift} (gate >= ${LIFT_MIN})  ·  n=${agg.n}${agg.dropped ? ` (${agg.dropped} dropped)` : ''}${scored.integrity ? '  ·  integrity verified' : '  ·  integrity NOT CHECKED (pass --transcripts)'}`);
   lines.push('');
   lines.push('| Scenario | Treatment | Baseline | Delta |');
   lines.push('|---|---|---|---|');

--- a/scripts/lib/eval-integrity.js
+++ b/scripts/lib/eval-integrity.js
@@ -1,0 +1,154 @@
+// eval-integrity.js — is a behavioral eval run measuring anything at all?
+//
+// skill-behavior-eval promises to run each capability scenario "with and without the skill". The
+// "without" arm runs with full filesystem access inside this repo, where the skill under test IS a
+// file, and nothing stopped it reading that file. Measured in the 2026-08-18 run: the `verify`
+// baseline read skills/verify/SKILL.md 7 times AND skills/verify/evals/cases.yaml 4 times — the
+// very must_include list it was being graded against. It then produced "SUSTITUIDA", a word that
+// exists nowhere but the skill written the day before.
+//
+// A lift measured against a control that read the answer key is a lower bound of unknown size.
+// Publishing it as a number is the claim-without-evidence this repo keeps paying for (P2), and it
+// feeds skill-harden's --holdout, which decides what enters a 264-skill catalog.
+//
+// This module answers the question deterministically, from the transcripts themselves — never from
+// what an agent says about its own behaviour, which is the way this fails open.
+//
+// Design note: the pure functions take text, the reader touches disk. That split is what makes the
+// interesting logic testable without fixtures on disk.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Prompt markers the workflow actually emits. tests/eval-integrity.test.js asserts each of these
+// still appears verbatim in scripts/skill-behavior-eval.workflow.js — without that tie, rewording a
+// prompt silently retires the classifier and every run starts reporting "clean".
+export const ROLE_MARKERS = {
+  grader: 'adversarial, independent grader',
+  treatment: '=== END SKILL ===',
+  loader: 'return its full text as',
+};
+
+// Write verbs that indicate a transcript actually WROTE a path rather than merely naming it. A
+// mention is not a mutation: the grader quotes repo paths constantly and is not violating anything.
+const WRITE_SIGNALS = [
+  'Write', 'Edit', 'MultiEdit', 'NotebookEdit',
+  'cat >', 'tee ', '>>', 'mv ', 'cp ', 'rm ',
+];
+
+// Paths an eval arm may never write. 02-DOCS is the project's brain and is untracked (P9), so a
+// stray write there has no undo.
+export const PROTECTED_PATHS = ['02-DOCS/wiki/'];
+
+/**
+ * Which arm produced this transcript. Order matters: a grader transcript quotes the skill body, so
+ * it would otherwise look like a treatment.
+ */
+export function classifyAgent(transcriptText) {
+  const t = String(transcriptText || '');
+  if (t.includes(ROLE_MARKERS.grader)) return 'grader';
+  if (t.includes(ROLE_MARKERS.treatment)) return 'treatment';
+  if (t.includes(ROLE_MARKERS.loader)) return 'loader';
+  return 'baseline';
+}
+
+const countOf = (text, needle) => {
+  let n = 0;
+  let i = text.indexOf(needle);
+  while (i !== -1) { n++; i = text.indexOf(needle, i + needle.length); }
+  return n;
+};
+
+/**
+ * findViolations({skillId, agents}) — agents: [{name, role, text}]
+ * Returns {ok, violations:[{kind, agent, pattern, count}]}.
+ *
+ * Only the baseline is judged on reads: the treatment is SUPPOSED to have the skill, and the loader
+ * reads both files by design. Every arm is judged on writes.
+ */
+export function findViolations({ skillId, agents }) {
+  if (!skillId) throw new Error('findViolations: skillId is required');
+  const violations = [];
+  const skillPath = `skills/${skillId}/SKILL.md`;
+  const rubricPath = `skills/${skillId}/evals/cases.yaml`;
+
+  for (const a of agents || []) {
+    const text = String(a.text || '');
+    if (a.role === 'baseline') {
+      // Graded separately: reading the skill removes the control; reading the rubric is reading the
+      // answer key, which also inflates the baseline's own score.
+      const skillHits = countOf(text, skillPath);
+      if (skillHits > 0) {
+        violations.push({ kind: 'baseline-read-skill', agent: a.name, pattern: skillPath, count: skillHits });
+      }
+      const rubricHits = countOf(text, rubricPath);
+      if (rubricHits > 0) {
+        violations.push({ kind: 'baseline-read-rubric', agent: a.name, pattern: rubricPath, count: rubricHits });
+      }
+    }
+    if (a.role === 'baseline' || a.role === 'treatment') {
+      for (const p of PROTECTED_PATHS) {
+        if (!text.includes(p)) continue;
+        // Require a write verb near the path, or a mention becomes a violation and the grader's
+        // quotations would block every run.
+        const wrote = WRITE_SIGNALS.some((verb) => {
+          let i = text.indexOf(p);
+          while (i !== -1) {
+            const window = text.slice(Math.max(0, i - 400), i + 400);
+            if (window.includes(verb)) return true;
+            i = text.indexOf(p, i + p.length);
+          }
+          return false;
+        });
+        if (wrote) {
+          violations.push({ kind: 'wrote-protected-path', agent: a.name, pattern: p, count: countOf(text, p) });
+        }
+      }
+    }
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+/** Read a workflow transcript directory into [{name, role, text}]. Throws if unreadable. */
+export function readAgents(dir) {
+  if (!dir) throw new Error('readAgents: transcripts dir is required');
+  const st = statSync(dir); // throws ENOENT — deliberately not caught here
+  if (!st.isDirectory()) throw new Error(`readAgents: not a directory: ${dir}`);
+  return readdirSync(dir)
+    .filter((f) => /^agent-.*\.jsonl$/.test(f))
+    .map((f) => {
+      const text = readFileSync(join(dir, f), 'utf8');
+      return { name: f, role: classifyAgent(text), text };
+    });
+}
+
+/**
+ * checkIntegrity({skillId, transcriptsDir}) → {ok, blocked, reason, violations, counts}
+ *
+ * FAILS CLOSED. A missing dir, an unreadable dir, or zero baseline transcripts all return
+ * blocked — never a silent pass. "We could not look" must never render as "we looked and it was
+ * fine", which is the single failure mode this whole file exists for.
+ */
+export function checkIntegrity({ skillId, transcriptsDir }) {
+  let agents;
+  try {
+    agents = readAgents(transcriptsDir);
+  } catch (e) {
+    return { ok: false, blocked: true, reason: `integrity not verifiable: ${e.message}`, violations: [], counts: {} };
+  }
+  const counts = agents.reduce((acc, a) => { acc[a.role] = (acc[a.role] || 0) + 1; return acc; }, {});
+  if (!counts.baseline) {
+    return {
+      ok: false, blocked: true,
+      reason: `integrity not verifiable: no baseline transcript found in ${transcriptsDir}`,
+      violations: [], counts,
+    };
+  }
+  const { ok, violations } = findViolations({ skillId, agents });
+  if (ok) return { ok: true, blocked: false, reason: 'integrity verified', violations: [], counts };
+  return {
+    ok: false, blocked: true,
+    reason: `${violations.length} integrity violation(s) — this run measures nothing`,
+    violations, counts,
+  };
+}

--- a/scripts/skill-behavior-eval.js
+++ b/scripts/skill-behavior-eval.js
@@ -1,15 +1,25 @@
 #!/usr/bin/env node
 // skill-behavior-eval.js — turn the behavior workflow's raw JSON into a scorecard.
 // Usage:
-//   node scripts/skill-behavior-eval.js --score   <raw.json>   (or pipe raw JSON on stdin with -)
+//   node scripts/skill-behavior-eval.js --score   <raw.json> [--transcripts <dir>]
 //   node scripts/skill-behavior-eval.js --holdout <raw.json>   (fresh-scenario transfer gate)
 // Exits 0 if the gate passes, 1 if it fails/blocks, 2 on usage/parse error.
+//
+// --transcripts runs the integrity check (scripts/lib/eval-integrity.js) over the workflow's agent
+// transcripts: did the "without the skill" arm read the skill, or its grading rubric, or write into
+// 02-DOCS? Any of those and the verdict is BLOCKED and the numbers are withheld, because a lift
+// measured against a contaminated control is not a measurement.
+//
+// Without --transcripts the scorecard says "integrity NOT CHECKED" on the verdict line. That is
+// deliberate: the flag is optional so existing callers keep working, so silence must not read as
+// clean.
 //
 // --holdout exists so the fix loop's blocking decision is a comparison of numbers an agent reports,
 // never a judgement an agent makes (constitution P1).
 
 import { readFileSync } from 'node:fs';
 import { scoreFromRaw, formatScorecard, holdoutGate, formatHoldoutVerdict } from './lib/behavior-score.js';
+import { checkIntegrity } from './lib/eval-integrity.js';
 
 function readInput(argPath) {
   if (argPath && argPath !== '-') return readFileSync(argPath, 'utf8');
@@ -25,12 +35,21 @@ function main() {
   }
   let raw;
   try {
-    raw = JSON.parse(readInput(args[1]));
+    raw = JSON.parse(readInput(args[1] && args[1] !== '--transcripts' ? args[1] : '-'));
   } catch (e) {
     process.stderr.write(`parse error: ${e.message}\n`);
     process.exit(2);
   }
-  const scored = scoreFromRaw(raw);
+  const ti = args.indexOf('--transcripts');
+  const transcriptsDir = ti !== -1 ? args[ti + 1] : null;
+  if (ti !== -1 && !transcriptsDir) {
+    process.stderr.write('--transcripts needs a directory\n');
+    process.exit(2);
+  }
+  const integrity = transcriptsDir
+    ? checkIntegrity({ skillId: (raw && raw.skillId) || '', transcriptsDir })
+    : undefined;
+  const scored = scoreFromRaw(raw, integrity);
   if (mode === '--holdout') {
     const gate = holdoutGate(scored);
     process.stdout.write(formatHoldoutVerdict(scored, gate) + '\n');

--- a/scripts/skill-behavior-eval.workflow.js
+++ b/scripts/skill-behavior-eval.workflow.js
@@ -90,6 +90,10 @@ if (!loaded || !Array.isArray(loaded.scenarios) || loaded.scenarios.length === 0
   return { skillId, scenarios: [], error: 'no-capability-scenarios' }
 }
 
+// A distinct write zone per (scenario, arm). Under .rsc/, which is already gitignored, so an eval
+// write can neither dirty the tracked tree nor show up later as an abandoned diff.
+const sandbox = (index, arm) => `.rsc/eval-sandbox/${skillId}/${arm}-${index}/`
+
 phase('Execute & Grade')
 const results = await pipeline(
   loaded.scenarios,
@@ -97,7 +101,18 @@ const results = await pipeline(
   (sc, _orig, index) => parallel([
     () => agent(
       `Complete this task fully and concretely. Produce the ACTUAL deliverable the task asks for, ` +
-      `not a description of how you would do it.\n\nTASK:\n${sc.scenario}`,
+      `not a description of how you would do it.\n\n` +
+      // The baseline IS the control. Reading the skill destroys the only thing this arm is for, so
+      // the prohibition carries its reason — a rule without one gets rationalised away first. This
+      // is guidance, not a barrier: the barrier is the post-hoc check in scripts/lib/eval-integrity.js,
+      // which BLOCKS the run if this arm touched the skill or its rubric.
+      `CONSTRAINTS — you are the control arm of a measurement:\n` +
+      `- Do NOT read anything under skills/ . You are the "without the skill" arm; if you read the ` +
+      `skill under test there is no control and the measurement is void.\n` +
+      `- Do NOT read any evals/cases.yaml — that is the rubric you are being graded against.\n` +
+      `- The repository is READ-ONLY. Never write to 02-DOCS/ or to any tracked file.\n` +
+      `- Write every file you produce under ${sandbox(index, 'baseline')} .\n\n` +
+      `TASK:\n${sc.scenario}`,
       { label: `baseline:${index}`, phase: 'Execute & Grade' },
     ),
     () => agent(
@@ -105,6 +120,13 @@ const results = await pipeline(
       `skills/${loaded.skillId}/references/; read them if the skill points you there.\n\n` +
       `=== SKILL: ${loaded.skillId} ===\n${loaded.skillBody}\n=== END SKILL ===\n\n` +
       `Complete this task fully and concretely. Produce the ACTUAL deliverable, not a description.\n\n` +
+      // Both arms once wrote the same path (02-DOCS/wiki/sdd/specs/magic-link-login.md) and one
+      // clobbered the other mid-run, so the grader scored a file that no longer existed. A distinct
+      // sandbox per arm makes that collision impossible by construction rather than by luck.
+      `CONSTRAINTS:\n` +
+      `- The repository is READ-ONLY. Never write to 02-DOCS/ or to any tracked file: this is a ` +
+      `measurement, and it must not mutate the project it runs inside.\n` +
+      `- Write every file you produce under ${sandbox(index, 'treatment')} .\n\n` +
       `TASK:\n${sc.scenario}`,
       { label: `treatment:${index}`, phase: 'Execute & Grade' },
     ),

--- a/skills/author-skill/SKILL.md
+++ b/skills/author-skill/SKILL.md
@@ -148,6 +148,7 @@ A skill ships only when every box is checked or a miss is consciously justified.
 - [ ] **Concrete tooling delegated** to the stack skills rather than reinvented.
 - [ ] **evals present** — `cases.yaml` (≥5 `should_trigger` incl. non-obvious, ≥4 `should_not_trigger` each with a real-sibling `route_to`, ≥1 `capability` with a `must_include` rubric) + an honest `README.md`. `scripts/eval-lint.sh` passes — but it only checks presence and the counts (≥5/≥4/≥1) and that those keys are lists; the `route_to`-points-at-a-real-sibling, non-obvious phrasings, and `must_include` quality are yours to verify here, not the linter's.
 - [ ] **verify.sh** present iff the skill has a checkable artifact; process skills rely on evals.
+- [ ] **Every `must_include` item discriminates** — answerable by the scenario's task, plausibly caused by the skill and plausibly missed without it. An item *both* arms fail measures nothing and lowers the absolute; it has turned a real PASS into a FAIL here. → `references/eval-authoring.md`.
 - [ ] **Sibling links resolve** — every `../x/SKILL.md` points to a skill that exists.
 - [ ] **Wired** — `tags` + `recommends` set, `npm run manifest` re-run, and `npm run validate` / `npm run manifest:check` pass (manifest current, no dangling recommends).
 

--- a/skills/author-skill/references/eval-authoring.md
+++ b/skills/author-skill/references/eval-authoring.md
@@ -63,6 +63,40 @@ The `must_include` points are the differentiators — the specific things a *goo
 
 For a process skill (no `verify.sh`), the capability scenario is the *primary* rigor — it is how you prove the safety rails actually change behavior. Make it count.
 
+## A `must_include` item must discriminate, or it subtracts
+
+Measured on 2026-08-18, running the behavioral eval on five skills for the first time. Two items
+added to `testing-py` and `testing-web` came back **unsatisfied in both arms** — treatment and
+baseline alike. They demanded the answer *name* a tool (`mutmut`, Stryker); both arms did the
+behaviour (planted a bug, checked the suite caught it) without naming one. Contributing nothing to
+lift and still counting against the coverage term, they dragged `testing-py` from **PASS (9.0,
+lift +2.2) to FAIL (7.5, lift +1.7)**. The rule they encoded was fine; the item was not.
+
+Two tests before an item earns its place:
+
+1. **Answerable by the scenario's task.** If the scenario says "write this test file", then "names
+   the mutation tool" is not part of that deliverable and no competent answer will contain it.
+2. **Discriminating.** The skill must plausibly cause it and a bare agent must plausibly miss it.
+   An item both arms satisfy measures the model; one both arms fail measures nothing and lowers the
+   absolute.
+
+**The symptom, so you can catch it from a scorecard:** an item unsatisfied in *both* arms is
+suspect. Nine times out of ten it is written as a spelling ("mentions X") rather than a behaviour
+("does not treat coverage as proof the suite detects bugs"). Rewrite it as the behaviour, or delete
+it — do not leave it in as an aspiration, because the aggregate cannot tell an aspiration from a
+failure.
+
+The same run showed the other side: the equivalent item in `testing-go`, where the skill gives a
+concrete *procedure* rather than a tool name, discriminated hard and nearly doubled the lift
+(1.5 → 2.7). Prescriptive guidance produces gradeable behaviour; a tool name produces a keyword
+check.
+
+**And the scenario itself must be executable where it runs.** `verify`'s scenario asked to verify a
+FastAPI orders feature that exists in no checkout, so both arms correctly answered "there is nothing
+to verify" and several items were unsatisfiable by construction — the absolute measured the scenario,
+not the skill. Make a `capability` scenario self-contained: carry the spec, the diff and the reported
+facts inline rather than assuming repo state.
+
 ## README.md — run it honestly
 
 `evals/README.md` documents the two-axis run procedure and is candid about limits:

--- a/skills/testing-py/evals/cases.yaml
+++ b/skills/testing-py/evals/cases.yaml
@@ -42,5 +42,3 @@ capability:
       - "asserts on the return value / observable behavior, not on mock private internals like _mock_calls"
       - "mentions a strict posture: --strict-markers and/or --strict-config (or the pytest 9 strict_* aliases)"
       - "at least one negative/error-path test (e.g. raises on non-200), not only the happy path"
-      - "Does not present branch coverage as proof the suite detects bugs: names mutation testing (mutmut) as the layer that catches assertion-free tests, and scopes it to the changed module rather than the whole tree."
-      - "Calibrates mutation by risk rather than prescribing it as a default toll, and says a surviving mutant may be semantically equivalent — to be classified with a reason, never killed with an assertion about non-behaviour."

--- a/skills/testing-web/evals/cases.yaml
+++ b/skills/testing-web/evals/cases.yaml
@@ -50,5 +50,3 @@ capability:
       - Tests an error path (500 -> visible error / role=alert) in a separate case
       - No bare act() misuse in the component test; no assertions on state/props/className
       - At least one real expect(...) assertion per test
-      - "Does not present coverage as proof the suite detects bugs: names Stryker as the layer that catches assertion-free tests, and scopes `mutate` to the changed files because a whole-project run does not finish."
-      - "Calibrates mutation by risk rather than prescribing it always, and treats a surviving mutant as possibly equivalent (classified with a reason) instead of adding an assertion about non-behaviour."

--- a/skills/verify/evals/cases.yaml
+++ b/skills/verify/evals/cases.yaml
@@ -61,13 +61,38 @@ should_not_trigger:
 # and refuses to call it done without evidence; an ungrounded answer tends to
 # eyeball the code, trust stale results, or declare success prematurely.
 capability:
-  - scenario: "Implementation of the 'duplicate-submit is a no-op' order feature just finished in a FastAPI service. The user says 'it's done, let's merge'. Verify it."
+  - scenario: >
+      A change is finished and the user says "it's done, let's merge". Verify it, and produce the
+      verification record.
+
+      Everything you need is here — do NOT assume any of it exists on disk; this scenario is
+      self-contained on purpose.
+
+      APPROVED SPEC (acceptance criteria):
+        AC1. Submitting an order returns 201 with the created order id.
+        AC2. Submitting the SAME order twice creates exactly one order; the second call returns
+             200 with the first order's id.
+        AC3. An order with a negative quantity is rejected with 422 and nothing is stored.
+
+      TASK DONE-CHECKS from the plan:
+        T1. POST /orders creates an order.            done-check: a test asserts 201 + id.
+        T2. Duplicate POST is a no-op.                done-check: a test asserts one row after two POSTs.
+        T3. Negative quantity is rejected.            done-check: a test asserts 422 + no write.
+
+      WHAT THE IMPLEMENTER REPORTS:
+        - Files changed: app/orders.py, tests/test_orders.py
+        - "I ran the suite: 2 passed. Tests written: test_create_order_returns_201,
+           test_negative_quantity_rejected."
+        - "mypy wasn't installed so the type step printed SKIP, and coverage ran without a
+           threshold configured. Everything else was green."
+        - "The retry loop can spin forever" was raised in review; the implementer replied
+          "not a real problem".
     must_include:
       - "Reads the accompaniment level from 02-DOCS/wiki/harness/user-profile.md and adapts verbosity (verdict legibility unchanged by the dial)."
-      - "LOCATES the spec acceptance criteria and the task done-checks, and identifies the FastAPI subproject as the touched stack from git diff/manifests."
-      - "RUNS the fastapi stack scripts/verify.sh (ruff/black, mypy, pytest+coverage, pip-audit) from the documented root and captures the output verbatim rather than reusing a previous run."
-      - "Treats any tool SKIP (missing tool) as UNVERIFIED, not as a pass, and notes the constitution's coverage floor as part of the gate."
-      - "WALKS every task done-check and every acceptance criterion, marking each with concrete evidence (a passing test / observable result) or as an open FAIL item — specifically flags the duplicate-submit criterion as UNVERIFIED if no test exercises the duplicate-POST path."
+      - "LOCATES the three acceptance criteria and the three task done-checks from the material given, and maps each to what the implementer actually reports."
+      - "Refuses to accept the implementer's summary as the gate: says the checks must be re-run and the output read, rather than trusting a reported '2 passed'."
+      - "Treats the mypy SKIP as UNVERIFIED rather than a pass, and does not let 'everything else was green' stand in for the skipped layer."
+      - "WALKS all three done-checks and all three acceptance criteria, and catches that AC2/T2 (duplicate POST is a no-op) has NO test at all — the two named tests cover AC1 and AC3 only — marking it UNVERIFIED rather than passing it."
       - "Does NOT fix a failing test inline; if a check fails it records it and hands off to debug, and refuses to fix-then-claim."
       - "RECORDS a dated verification file under 02-DOCS/wiki/sdd/verifications/ and indexes it in the root CLAUDE.md Knowledge map."
       - "Returns a VERDICT that is PASS only if EVERY item has passing evidence; a single unverified acceptance criterion makes the whole verdict FAIL — and refuses to call it 'done' otherwise."

--- a/tests/eval-integrity.test.js
+++ b/tests/eval-integrity.test.js
@@ -1,0 +1,218 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, mkdtempSync, writeFileSync, chmodSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import {
+  classifyAgent, findViolations, checkIntegrity, readAgents, ROLE_MARKERS, PROTECTED_PATHS,
+} from '../scripts/lib/eval-integrity.js';
+import { behavioralGate, scoreFromRaw, formatScorecard } from '../scripts/lib/behavior-score.js';
+
+// skill-behavior-eval promised to run each scenario "with and without the skill" and nothing enforced
+// the "without". First real run (2026-08-18): the `verify` baseline read skills/verify/SKILL.md 7×
+// AND skills/verify/evals/cases.yaml 4× — the rubric it was graded against — then produced the word
+// "SUSTITUIDA", which exists nowhere but that skill. Four of six baselines were clean, which is worse
+// than all of them being dirty: the contamination is opportunistic, so identical runs yield different
+// lifts and nothing says so. This is the mechanism P2 demands, plus the test of the mechanism.
+// Spec: 02-DOCS/wiki/sdd/specs/eval-integrity.md
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW = readFileSync(join(ROOT, 'scripts/skill-behavior-eval.workflow.js'), 'utf8');
+
+const agent = (name, role, text) => ({ name, role, text });
+
+// ------------------------------------------------------------------ role classification
+
+test('classifyAgent separates the four arms, grader before treatment', () => {
+  // Order matters: a grader transcript quotes the skill body, so a naive check calls it a treatment.
+  assert.equal(classifyAgent(`... ${ROLE_MARKERS.grader} ... ${ROLE_MARKERS.treatment} ...`), 'grader');
+  assert.equal(classifyAgent(`x ${ROLE_MARKERS.treatment} y`), 'treatment');
+  assert.equal(classifyAgent(`x ${ROLE_MARKERS.loader} y`), 'loader');
+  assert.equal(classifyAgent('Complete this task fully and concretely.'), 'baseline');
+  assert.equal(classifyAgent(''), 'baseline');
+  assert.equal(classifyAgent(null), 'baseline');
+});
+
+test('the classifier stays tied to the prompts the workflow actually emits', () => {
+  // Without this, rewording a prompt silently retires the classifier: every baseline would be
+  // misread as something else and every run would start reporting "clean". A fail-open by drift.
+  for (const [role, marker] of Object.entries(ROLE_MARKERS)) {
+    assert.ok(
+      WORKFLOW.includes(marker),
+      `marker for ${role} ("${marker}") no longer appears in skill-behavior-eval.workflow.js`,
+    );
+  }
+});
+
+// ------------------------------------------------------------------ violation detection
+
+test('a clean run has no violations', () => {
+  const r = findViolations({
+    skillId: 'demo',
+    agents: [
+      agent('a', 'baseline', 'wrote a test file under .rsc/eval-sandbox/demo/baseline-0/'),
+      agent('b', 'treatment', 'followed the injected skill'),
+    ],
+  });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.violations, []);
+});
+
+test('a baseline that read the skill is a violation, with a count', () => {
+  const r = findViolations({
+    skillId: 'demo',
+    agents: [agent('base', 'baseline', 'cat skills/demo/SKILL.md ... skills/demo/SKILL.md again')],
+  });
+  assert.equal(r.ok, false);
+  const v = r.violations.find((x) => x.kind === 'baseline-read-skill');
+  assert.ok(v, 'expected baseline-read-skill');
+  assert.equal(v.count, 2, 'the count is what makes it auditable by hand');
+});
+
+test('a baseline that read the RUBRIC is reported separately — it is the answer key', () => {
+  const r = findViolations({
+    skillId: 'demo',
+    agents: [agent('base', 'baseline', 'opened skills/demo/evals/cases.yaml')],
+  });
+  assert.ok(r.violations.some((x) => x.kind === 'baseline-read-rubric'));
+});
+
+test('the TREATMENT reading the skill is not a violation — it is supposed to have it', () => {
+  const r = findViolations({
+    skillId: 'demo',
+    agents: [agent('t', 'treatment', 'skills/demo/SKILL.md skills/demo/evals/cases.yaml')],
+  });
+  assert.equal(r.ok, true, 'only the control arm is judged on reads');
+});
+
+test('the LOADER reading both files is not a violation — that is its job', () => {
+  const r = findViolations({
+    skillId: 'demo',
+    agents: [agent('l', 'loader', 'skills/demo/SKILL.md and skills/demo/evals/cases.yaml')],
+  });
+  assert.equal(r.ok, true);
+});
+
+test('writing into 02-DOCS/wiki is a violation for either arm', () => {
+  for (const role of ['baseline', 'treatment']) {
+    const r = findViolations({
+      skillId: 'demo',
+      agents: [agent('x', role, 'Write to 02-DOCS/wiki/sdd/specs/thing.md')],
+    });
+    assert.ok(
+      r.violations.some((x) => x.kind === 'wrote-protected-path'),
+      `${role}: expected wrote-protected-path`,
+    );
+  }
+});
+
+test('MENTIONING a protected path without a write verb is not a violation', () => {
+  // The grader quotes repo paths constantly; if a mention counted, every run would block and the
+  // gate would be useless noise within a week.
+  const r = findViolations({
+    skillId: 'demo',
+    agents: [agent('x', 'baseline', 'the record would normally live in 02-DOCS/wiki/sdd/ somewhere')],
+  });
+  assert.equal(r.ok, true);
+});
+
+test('findViolations refuses to run without a skillId', () => {
+  assert.throws(() => findViolations({ agents: [] }), /skillId is required/);
+});
+
+// ------------------------------------------------------------------ fail-closed reading
+
+test('checkIntegrity BLOCKS when the transcripts dir is missing', () => {
+  const r = checkIntegrity({ skillId: 'demo', transcriptsDir: join(tmpdir(), 'definitely-not-here-xyz') });
+  assert.equal(r.blocked, true);
+  assert.match(r.reason, /not verifiable/);
+});
+
+test('checkIntegrity BLOCKS when no dir is given at all', () => {
+  const r = checkIntegrity({ skillId: 'demo' });
+  assert.equal(r.blocked, true, '"we could not look" must never render as "we looked and it was fine"');
+});
+
+test('checkIntegrity BLOCKS when there is no baseline transcript', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ei-nobase-'));
+  writeFileSync(join(dir, 'agent-1.jsonl'), `has ${ROLE_MARKERS.treatment} only`);
+  const r = checkIntegrity({ skillId: 'demo', transcriptsDir: dir });
+  assert.equal(r.blocked, true);
+  assert.match(r.reason, /no baseline transcript/);
+});
+
+test('checkIntegrity passes a genuinely clean directory', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ei-clean-'));
+  writeFileSync(join(dir, 'agent-1.jsonl'), 'plain baseline work in .rsc/eval-sandbox/demo/baseline-0/');
+  writeFileSync(join(dir, 'agent-2.jsonl'), `treatment ${ROLE_MARKERS.treatment}`);
+  const r = checkIntegrity({ skillId: 'demo', transcriptsDir: dir });
+  assert.equal(r.ok, true);
+  assert.equal(r.blocked, false);
+  assert.equal(r.counts.baseline, 1);
+});
+
+test('readAgents throws rather than returning empty on a bad path', () => {
+  assert.throws(() => readAgents(join(tmpdir(), 'nope-not-real-dir')));
+  assert.throws(() => readAgents(''), /required/);
+});
+
+// ------------------------------------------------------------------ the third verdict
+
+test('behavioralGate without integrity behaves exactly as before (back-compat)', () => {
+  const g = behavioralGate({ absoluteScore: 9, lift: 2, n: 1, dropped: 0 });
+  assert.equal(g.pass, true);
+  assert.equal(g.blocked, undefined, 'absent integrity must not invent a blocked field');
+});
+
+test('violated integrity BLOCKS, and blocked is not the same as failed', () => {
+  const g = behavioralGate(
+    { absoluteScore: 9.9, lift: 5, n: 1, dropped: 0 },
+    { ok: false, reason: 'contaminated', violations: [{ kind: 'baseline-read-skill', agent: 'a', pattern: 'p', count: 3 }] },
+  );
+  assert.equal(g.pass, false);
+  assert.equal(g.blocked, true, 'a passing-looking score must still block');
+  assert.match(g.mustFix[0], /baseline-read-skill/);
+});
+
+test('a BLOCKED scorecard withholds the absolute and the lift', () => {
+  // Printing them next to a block invites reading them anyway, and they are not measurements.
+  const scored = scoreFromRaw(
+    { skillId: 'demo', scenarios: [] },
+    { ok: false, reason: 'contaminated', violations: [{ kind: 'baseline-read-skill', agent: 'a', pattern: 'skills/demo/SKILL.md', count: 3 }] },
+  );
+  const card = formatScorecard(scored);
+  assert.match(card, /BLOCKED/);
+  assert.doesNotMatch(card, /absolute/, 'the absolute must not appear on a blocked card');
+  assert.doesNotMatch(card, /lift/, 'the lift must not appear on a blocked card');
+  assert.match(card, /not a measurement/);
+});
+
+test('an unchecked run says so on the verdict line', () => {
+  const card = formatScorecard(scoreFromRaw({
+    skillId: 'demo',
+    scenarios: [{ index: 0, xIsTreatment: true, gradeX: { mustInclude: [{ satisfied: true }], quality: { completeness: 9, actionability: 9, correctness: 9, grounding: 9 } }, gradeY: { mustInclude: [{ satisfied: false }], quality: { completeness: 5, actionability: 5, correctness: 5, grounding: 5 } } }],
+  }));
+  assert.match(card, /integrity NOT CHECKED/, 'silence must not read as clean');
+});
+
+// ------------------------------------------------------------------ the workflow's own guards
+
+test('the workflow gives each arm a distinct write zone', () => {
+  assert.match(WORKFLOW, /eval-sandbox/, 'no sandbox path in the prompts');
+  assert.match(WORKFLOW, /sandbox\(index, 'baseline'\)/);
+  assert.match(WORKFLOW, /sandbox\(index, 'treatment'\)/);
+  // Under .rsc/ so an eval write cannot dirty the tracked tree.
+  assert.match(WORKFLOW, /\.rsc\/eval-sandbox/);
+});
+
+test('the workflow tells the baseline not to read the skill, and why', () => {
+  assert.match(WORKFLOW, /Do NOT read anything under skills\//);
+  assert.match(WORKFLOW, /there is no control/, 'a prohibition without its reason gets rationalised away');
+  assert.match(WORKFLOW, /Do NOT read any evals\/cases\.yaml/);
+});
+
+test('the workflow declares the repository read-only for both arms', () => {
+  const hits = WORKFLOW.match(/READ-ONLY/g) || [];
+  assert.ok(hits.length >= 2, `expected both arms to be told the repo is read-only, found ${hits.length}`);
+  assert.equal(PROTECTED_PATHS[0], '02-DOCS/wiki/');
+});

--- a/tests/gate-honesty-debt.test.js
+++ b/tests/gate-honesty-debt.test.js
@@ -239,26 +239,30 @@ test('D — each prohibition carries its reason, not just the ban', () => {
 
 // -------------------------------------- E: the rules are gradeable behaviour in the eval scenarios
 
-test('E — the mutation rule is a gradeable behaviour in all three testing skills', () => {
-  for (const id of TESTING) {
+test('E — the mutation rule is gradeable where it DISCRIMINATES (testing-go only)', () => {
+  // Changed on 2026-08-18 by measurement, not by preference. The first real behavioral eval run
+  // showed these items came back unsatisfied in BOTH arms for testing-py and testing-web — they
+  // demanded the answer *name* a tool, and both arms did the behaviour without naming one. They
+  // contributed zero lift and still counted against the coverage term, dragging testing-py from
+  // PASS (9.0, +2.2) to FAIL (7.5, +1.7). So they were removed from those two rubrics.
+  //
+  // testing-go's equivalent item discriminated hard (lift 1.5 -> 2.7) because that skill gives a
+  // concrete procedure rather than a tool name. It stays, and is pinned here.
+  //
+  // The mutation RULE itself is still required in all three skill bodies — that is the test above.
+  // What changed is only the claim that the eval measures it. See 02-DOCS/wiki/sdd/specs/eval-integrity.md.
+  const go = capabilityBlock('testing-go');
+  assert.match(go, /proof the suite detects bugs/i, 'testing-go must grade coverage-is-not-detection');
+  assert.match(go, /no mature mutation tool/, "testing-go must grade Go's honest no-tool answer");
+  assert.match(go, /inflate/i, 'testing-go must grade the prove-it-ran requirement');
+
+  for (const id of ['testing-py', 'testing-web']) {
     const block = capabilityBlock(id);
-    assert.match(
+    assert.doesNotMatch(
       block,
       /proof the suite detects bugs/i,
-      `${id}: must grade the coverage-is-not-detection behaviour specifically`,
+      `${id}: the non-discriminating item is back — an item both arms fail lowers the absolute and measures nothing`,
     );
-    assert.match(
-      block,
-      /mutmut|Stryker|no mature mutation tool/,
-      `${id}: must grade the ecosystem's actual mutation answer`,
-    );
-    // Graded as behaviour ("does not present coverage as proof"), not as a keyword mention.
-    assert.match(
-      block,
-      /[Dd]oes not present/,
-      `${id}: the item must grade a behaviour, not a mention`,
-    );
-    assert.match(block, /equivalent|inflate/i, `${id}: must grade the survivor/runner nuance`);
   }
 });
 


### PR DESCRIPTION
The first real run of the behavioural eval (5 skills, 6 scenarios, 23 agents) did not validate the rules it was meant to measure. **It found the instrument was broken.** This closes that.

## The finding

`skill-behavior-eval` promises to run each capability scenario *"with and without the skill"*. The "without" arm runs with full filesystem access **inside this repo, where the skill under test is a file**, and nothing stopped it reading that file:

| arm | read its `SKILL.md` | read its `evals/cases.yaml` |
|---|---|---|
| `verify` baseline | **7×** | **4×** |
| `specify` baseline | **6×** | 0 |
| the other 4 baselines | 0 | 0 |

The `verify` case is the bad one: `cases.yaml` **is the `must_include` list it was being graded against.** It read the answer key. The proof it mattered is in its own output — it produced the word `SUSTITUIDA`, which exists nowhere but the skill written the day before.

That only 2 of 6 were contaminated is **worse** than all of them being: it depends on whether the agent wanders into `skills/`, so identical runs yield different lifts and nothing says so. A lift measured this way is a lower bound of unknown size, and it was being published as a number — into `skill-harden --holdout`, the gate that decides what enters a 264-skill catalog. P2, in the most expensive place available.

Two more defects from the same run: both arms of `specify` wrote **the same file** and one clobbered the other mid-run (so its `-1.4` lift is uninterpretable), and the run mutated the real `02-DOCS/` wiki — 4 artifacts, 3 index rows, 4 decisions entries about features nobody is building.

## What lands

**A. `BLOCKED` is a third verdict, and it is not `FAIL`.** New `scripts/lib/eval-integrity.js` classifies each arm from its prompt and detects three violations deterministically from the transcripts — never from what an agent says about itself, which is how this fails open. On violation the verdict is `BLOCKED` and **the absolute and lift are withheld from the scorecard**. A FAIL says "the skill does not clear the bar" and sends someone to edit the skill; when the control read the answer key the only true statement is "this run measures nothing". Different actions, so different verdicts — and printing the numbers beside a block invites reading them anyway.

It **fails closed**: no transcripts, unreadable dir, or zero baseline transcripts all return `BLOCKED`. "We could not look" must never render as "we looked and it was fine". Without `--transcripts`, the verdict line says `integrity NOT CHECKED` so silence cannot read as clean.

**Where the check lives, and why not where you'd expect:** `grep -c "node:fs"` returns **0** for both workflow scripts — they have no filesystem. So detection cannot live in the eval; it lives in the CLI reading transcripts. That single fact decided the architecture.

**B. Each arm gets its own write zone.** `.rsc/eval-sandbox/<skill>/<arm>-<index>/` — distinct by construction, under an already-gitignored path so an eval write cannot dirty the tracked tree. Both arms are told the repo is READ-ONLY; the baseline additionally gets "do not read `skills/**` — *you are the control; if you read the skill there is no control*". The reason is in the prompt because a prohibition without one gets rationalised away first. This is **guidance, declared as such** — the barrier is (A).

**C. A scenario must be executable where it runs.** `verify`'s asked to verify a FastAPI orders feature that exists in no checkout; both arms correctly said "there is nothing to verify" and several items were unsatisfiable by construction, so the absolute measured the scenario. Rewritten to be self-contained: it now carries the spec, the done-checks and the implementer's reported facts inline.

**D. A `must_include` item must discriminate, or it subtracts.** The items this delivery chain added to `testing-py` and `testing-web` came back unsatisfied in **both** arms — they demanded the answer *name* a tool (`mutmut`, Stryker) and both arms did the behaviour (planted a bug, checked the suite caught it) without naming one. Zero lift, still counting against the coverage term: they dragged `testing-py` from **PASS (9.0, +2.2) to FAIL (7.5, +1.7)**. Removed. The rule stays in the skill bodies; what is retired is the false claim that the eval measures it.

**My initial call here was wrong and the data corrected it.** I was going to strip the mutation items from all three `testing-*`. `testing-go` finished last with **PASS 9.5 / +2.7**, those two items nearly doubling its lift (1.5 → 2.7) — stripping them would have destroyed the only one of the three rubrics that measures anything. The cause is transferable and is now written in `references/eval-authoring.md`: where a skill gives a **procedure**, behaviour is gradeable; where it gives a **tool name**, you get a keyword check.

## Verification

| Gate | Result |
|---|---|
| `npm run validate` / `manifest:check` | OK, 264 skills |
| `npm test` | **392 passed, 0 failed** (+22) |
| `eval-lint.sh` | 264 skills, 0 failures |
| `drift:check` | all claims resolve |
| manual mutation | **12/12 killed** |

**Validated against the five real transcripts that caused the spec**, not a synthetic fixture:

| skill | verdict |
|---|---|
| `verify` | **BLOCKED** — 4 violations |
| `specify` | **BLOCKED** — 5 violations |
| `testing-py` | FAIL 7.5 / +1.7 · integrity verified |
| `testing-web` | FAIL 8.1 / +0.1 · integrity verified |
| `testing-go` | **PASS 9.5 / +2.7** · integrity verified |

It discriminates exactly where it should, and it found **more than my manual analysis did**: I had only spotted the reads; the detector added that all six arms of `verify` and `specify` wrote into `02-DOCS/wiki/`.

**And the mechanism from the previous release caught this change** — the only real proof it was worth shipping. Removing those rubric items broke `gate-honesty-debt.test.js` (391/392), which required all three `testing-*` to grade mutation. Rewritten to the measured truth.

**Declared limit:** this does **not** re-run the eval with the fixed instrument. The per-arm zones and prohibitions **have never executed live** — the detector was validated against the old transcripts, which is stronger than a fixture and is not the same as a run. That is another 23 agents, and it is the user's call.