### PR TITLE
fix(evals): the write check flagged paths it merely saw, not paths it wrote

### DIFF
--- a/scripts/lib/eval-integrity.js
+++ b/scripts/lib/eval-integrity.js
@@ -29,12 +29,66 @@ export const ROLE_MARKERS = {
   loader: 'return its full text as',
 };
 
-// Write verbs that indicate a transcript actually WROTE a path rather than merely naming it. A
-// mention is not a mutation: the grader quotes repo paths constantly and is not violating anything.
-const WRITE_SIGNALS = [
-  'Write', 'Edit', 'MultiEdit', 'NotebookEdit',
-  'cat >', 'tee ', '>>', 'mv ', 'cp ', 'rm ',
+// Tools that write. Checked against a tool call's actual target path, never against nearby text.
+const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
+
+// Shell constructs that write TO a path. `cat 02-DOCS/x` is a read and must not match; `cat > 02-DOCS/x`
+// must. Each pattern is anchored on the redirect/verb so the protected path has to be its TARGET.
+const SHELL_WRITE_TO = (p) => [
+  new RegExp(`>>?\\s*\\S*${p}`),          // > path, >> path
+  new RegExp(`\\btee\\s+(-\\S+\\s+)*\\S*${p}`),
+  new RegExp(`\\b(mv|cp|rsync)\\s+[^|;&]*\\s\\S*${p}`),
+  new RegExp(`\\brm\\s+(-\\S+\\s+)*\\S*${p}`),
+  new RegExp(`\\b(mkdir|touch)\\s+(-\\S+\\s+)*\\S*${p}`),
 ];
+
+/**
+ * Structurally extract the tool calls from a transcript. This is the fix for the defect the first
+ * real run exposed: the previous version looked for a write VERB within ~400 chars of a protected
+ * path in the raw text. In a treatment transcript the injected SKILL.md itself names
+ * 02-DOCS/wiki/... paths, and tool names appear in every JSON envelope, so the proximity window
+ * matched almost always. It blocked a run in which nothing had been written — verified against the
+ * filesystem, which held no new files at all. An over-blocking gate is still a broken gate: it would
+ * have made every treatment run BLOCKED and wedged skill-harden permanently.
+ */
+export function extractToolCalls(transcriptText) {
+  const calls = [];
+  for (const line of String(transcriptText || '').split('\n')) {
+    if (!line.trim()) continue;
+    let o;
+    try { o = JSON.parse(line); } catch { continue; }
+    const msg = o && typeof o.message === 'object' && o.message ? o.message : o;
+    const content = msg && msg.content;
+    if (!Array.isArray(content)) continue;
+    for (const b of content) {
+      if (b && b.type === 'tool_use') calls.push({ name: b.name, input: b.input || {} });
+    }
+  }
+  return calls;
+}
+
+/** Did this tool call write to a path under `protected`? */
+export function callWritesTo(call, protectedPath) {
+  if (!call) return false;
+  if (WRITE_TOOLS.has(call.name)) {
+    const target = String(call.input.file_path || call.input.path || call.input.notebook_path || '');
+    return target.includes(protectedPath);
+  }
+  if (call.name === 'Bash') {
+    const cmd = String(call.input.command || '');
+    if (!cmd.includes(protectedPath)) return false;
+    const esc = protectedPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return SHELL_WRITE_TO(esc).some((re) => re.test(cmd));
+  }
+  return false;
+}
+
+/** Did this tool call READ the given path? A path inside a tool input, not prose mentioning it. */
+export function callReads(call, path) {
+  if (!call) return false;
+  const input = JSON.stringify(call.input || {});
+  return input.includes(path);
+}
 
 // Paths an eval arm may never write. 02-DOCS is the project's brain and is untracked (P9), so a
 // stray write there has no undo.
@@ -73,35 +127,29 @@ export function findViolations({ skillId, agents }) {
   const rubricPath = `skills/${skillId}/evals/cases.yaml`;
 
   for (const a of agents || []) {
-    const text = String(a.text || '');
+    // Judged on TOOL CALLS, not on text. A transcript naming a path proves nothing: the treatment's
+    // own injected skill body names 02-DOCS paths, and the grader quotes repo paths constantly.
+    const calls = a.calls || extractToolCalls(a.text);
+
     if (a.role === 'baseline') {
-      // Graded separately: reading the skill removes the control; reading the rubric is reading the
-      // answer key, which also inflates the baseline's own score.
-      const skillHits = countOf(text, skillPath);
+      // Only the control arm is judged on reads — the treatment is supposed to have the skill and
+      // the loader reads both files by design.
+      const skillHits = calls.filter((c) => callReads(c, skillPath)).length;
       if (skillHits > 0) {
         violations.push({ kind: 'baseline-read-skill', agent: a.name, pattern: skillPath, count: skillHits });
       }
-      const rubricHits = countOf(text, rubricPath);
+      // Reading the rubric is reading the answer key: it also inflates the baseline's own score.
+      const rubricHits = calls.filter((c) => callReads(c, rubricPath)).length;
       if (rubricHits > 0) {
         violations.push({ kind: 'baseline-read-rubric', agent: a.name, pattern: rubricPath, count: rubricHits });
       }
     }
+
     if (a.role === 'baseline' || a.role === 'treatment') {
       for (const p of PROTECTED_PATHS) {
-        if (!text.includes(p)) continue;
-        // Require a write verb near the path, or a mention becomes a violation and the grader's
-        // quotations would block every run.
-        const wrote = WRITE_SIGNALS.some((verb) => {
-          let i = text.indexOf(p);
-          while (i !== -1) {
-            const window = text.slice(Math.max(0, i - 400), i + 400);
-            if (window.includes(verb)) return true;
-            i = text.indexOf(p, i + p.length);
-          }
-          return false;
-        });
-        if (wrote) {
-          violations.push({ kind: 'wrote-protected-path', agent: a.name, pattern: p, count: countOf(text, p) });
+        const hits = calls.filter((c) => callWritesTo(c, p)).length;
+        if (hits > 0) {
+          violations.push({ kind: 'wrote-protected-path', agent: a.name, pattern: p, count: hits });
         }
       }
     }
@@ -118,7 +166,7 @@ export function readAgents(dir) {
     .filter((f) => /^agent-.*\.jsonl$/.test(f))
     .map((f) => {
       const text = readFileSync(join(dir, f), 'utf8');
-      return { name: f, role: classifyAgent(text), text };
+      return { name: f, role: classifyAgent(text), text, calls: extractToolCalls(text) };
     });
 }
 

--- a/scripts/lib/eval-integrity.js
+++ b/scripts/lib/eval-integrity.js
@@ -67,18 +67,40 @@ export function extractToolCalls(transcriptText) {
   return calls;
 }
 
-/** Did this tool call write to a path under `protected`? */
+// The per-arm sandbox. A write under here is the CORRECT behaviour, however its path reads.
+export const SANDBOX_MARKER = '.rsc/eval-sandbox/';
+
+/**
+ * Did this tool call write to a path under `protected`?
+ *
+ * Two false positives were fixed here, both the same mistake — "the path appears in the string" is
+ * not "the write targets that location":
+ *  1. proximity matching in raw transcript text (the injected SKILL.md names 02-DOCS paths);
+ *  2. substring matching against a sandbox path that MIRRORS the wiki layout inside itself, e.g.
+ *     .rsc/eval-sandbox/specify/treatment-1/02-DOCS/wiki/sdd/specs/x.md — a correct write that
+ *     contains "02-DOCS/wiki/" as a substring.
+ * Both were caught only by checking the filesystem, which held no new files either time. The lesson
+ * is in the shape of the check, not in the patterns: anchor on the sandbox first, always.
+ */
 export function callWritesTo(call, protectedPath) {
   if (!call) return false;
   if (WRITE_TOOLS.has(call.name)) {
     const target = String(call.input.file_path || call.input.path || call.input.notebook_path || '');
+    if (target.includes(SANDBOX_MARKER)) return false;
     return target.includes(protectedPath);
   }
   if (call.name === 'Bash') {
     const cmd = String(call.input.command || '');
     if (!cmd.includes(protectedPath)) return false;
     const esc = protectedPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return SHELL_WRITE_TO(esc).some((re) => re.test(cmd));
+    const sandboxEsc = SANDBOX_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return SHELL_WRITE_TO(esc).some((re) => {
+      const m = re.exec(cmd);
+      if (!m) return false;
+      // The matched write target itself must not sit inside the sandbox. Checking the whole command
+      // would let one sandboxed write excuse a real one in the same line.
+      return !new RegExp(`${sandboxEsc}[^\\s'"]*${esc}`).test(m[0]);
+    });
   }
   return false;
 }

--- a/tests/eval-integrity.test.js
+++ b/tests/eval-integrity.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import {
   classifyAgent, findViolations, checkIntegrity, readAgents, ROLE_MARKERS, PROTECTED_PATHS,
-  extractToolCalls, callWritesTo, callReads,
+  extractToolCalls, callWritesTo, callReads, SANDBOX_MARKER,
 } from '../scripts/lib/eval-integrity.js';
 import { behavioralGate, scoreFromRaw, formatScorecard } from '../scripts/lib/behavior-score.js';
 
@@ -142,6 +142,32 @@ test('a real write TO a protected path is still caught, by tool and by shell', (
       `should catch: ${cmd}`,
     );
   }
+});
+
+test('REGRESSION 2: a sandbox path that MIRRORS the wiki layout is not a protected write', () => {
+  // Second false positive in this same check. The treatment arms wrote correctly inside their zone
+  // but recreated the wiki tree inside it:
+  //   .rsc/eval-sandbox/specify/treatment-1/02-DOCS/wiki/sdd/specs/x.md
+  // Substring matching flagged it; the filesystem held no new files in the real 02-DOCS. "The path
+  // appears in the string" is not "the write targets that location" — anchor on the sandbox first.
+  const mirrored = withCalls('t', 'treatment',
+    call('Bash', { command: "mkdir -p /repo/.rsc/eval-sandbox/specify/treatment-1/02-DOCS/wiki/sdd/specs" }),
+    call('Bash', { command: "cat > /repo/.rsc/eval-sandbox/specify/treatment-1/02-DOCS/wiki/sdd/specs/x.md <<'EOF'" }),
+    call('Write', { file_path: '/repo/.rsc/eval-sandbox/specify/treatment-0/02-DOCS/wiki/index.md' }),
+  );
+  assert.equal(findViolations({ skillId: 'demo', agents: [mirrored] }).ok, true);
+  assert.equal(SANDBOX_MARKER, '.rsc/eval-sandbox/');
+});
+
+test('a sandboxed write in the same command does not excuse a real one', () => {
+  // Checking the whole command for the sandbox marker would let one legitimate write launder another.
+  const both = withCalls('t', 'treatment', call('Bash', {
+    command: "cat > .rsc/eval-sandbox/x/treatment-0/a.md <<'EOF' ; cat > 02-DOCS/wiki/real.md <<'EOF'",
+  }));
+  assert.ok(
+    findViolations({ skillId: 'demo', agents: [both] }).violations.some((v) => v.kind === 'wrote-protected-path'),
+    'the unsandboxed write must still be caught',
+  );
 });
 
 test('reads are counted from tool inputs, not from prose', () => {

--- a/tests/eval-integrity.test.js
+++ b/tests/eval-integrity.test.js
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import {
   classifyAgent, findViolations, checkIntegrity, readAgents, ROLE_MARKERS, PROTECTED_PATHS,
+  extractToolCalls, callWritesTo, callReads,
 } from '../scripts/lib/eval-integrity.js';
 import { behavioralGate, scoreFromRaw, formatScorecard } from '../scripts/lib/behavior-score.js';
 
@@ -20,6 +21,9 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const WORKFLOW = readFileSync(join(ROOT, 'scripts/skill-behavior-eval.workflow.js'), 'utf8');
 
 const agent = (name, role, text) => ({ name, role, text });
+// A transcript line carrying one tool_use, the shape the real .jsonl files use.
+const call = (name, input) => JSON.stringify({ message: { content: [{ type: 'tool_use', name, input }] } });
+const withCalls = (name, role, ...lines) => ({ name, role, text: lines.join('\n'), calls: extractToolCalls(lines.join('\n')) });
 
 // ------------------------------------------------------------------ role classification
 
@@ -61,7 +65,7 @@ test('a clean run has no violations', () => {
 test('a baseline that read the skill is a violation, with a count', () => {
   const r = findViolations({
     skillId: 'demo',
-    agents: [agent('base', 'baseline', 'cat skills/demo/SKILL.md ... skills/demo/SKILL.md again')],
+    agents: [withCalls('base', 'baseline', call('Read', { file_path: 'skills/demo/SKILL.md' }), call('Bash', { command: 'cat skills/demo/SKILL.md' }))],
   });
   assert.equal(r.ok, false);
   const v = r.violations.find((x) => x.kind === 'baseline-read-skill');
@@ -72,7 +76,7 @@ test('a baseline that read the skill is a violation, with a count', () => {
 test('a baseline that read the RUBRIC is reported separately — it is the answer key', () => {
   const r = findViolations({
     skillId: 'demo',
-    agents: [agent('base', 'baseline', 'opened skills/demo/evals/cases.yaml')],
+    agents: [withCalls('base', 'baseline', call('Read', { file_path: 'skills/demo/evals/cases.yaml' }))],
   });
   assert.ok(r.violations.some((x) => x.kind === 'baseline-read-rubric'));
 });
@@ -80,7 +84,7 @@ test('a baseline that read the RUBRIC is reported separately — it is the answe
 test('the TREATMENT reading the skill is not a violation — it is supposed to have it', () => {
   const r = findViolations({
     skillId: 'demo',
-    agents: [agent('t', 'treatment', 'skills/demo/SKILL.md skills/demo/evals/cases.yaml')],
+    agents: [withCalls('t', 'treatment', call('Read', { file_path: 'skills/demo/SKILL.md' }), call('Read', { file_path: 'skills/demo/evals/cases.yaml' }))],
   });
   assert.equal(r.ok, true, 'only the control arm is judged on reads');
 });
@@ -88,7 +92,7 @@ test('the TREATMENT reading the skill is not a violation — it is supposed to h
 test('the LOADER reading both files is not a violation — that is its job', () => {
   const r = findViolations({
     skillId: 'demo',
-    agents: [agent('l', 'loader', 'skills/demo/SKILL.md and skills/demo/evals/cases.yaml')],
+    agents: [withCalls('l', 'loader', call('Read', { file_path: 'skills/demo/SKILL.md' }))],
   });
   assert.equal(r.ok, true);
 });
@@ -97,7 +101,7 @@ test('writing into 02-DOCS/wiki is a violation for either arm', () => {
   for (const role of ['baseline', 'treatment']) {
     const r = findViolations({
       skillId: 'demo',
-      agents: [agent('x', role, 'Write to 02-DOCS/wiki/sdd/specs/thing.md')],
+      agents: [withCalls('x', role, call('Write', { file_path: '02-DOCS/wiki/sdd/specs/thing.md' }))],
     });
     assert.ok(
       r.violations.some((x) => x.kind === 'wrote-protected-path'),
@@ -106,14 +110,60 @@ test('writing into 02-DOCS/wiki is a violation for either arm', () => {
   }
 });
 
-test('MENTIONING a protected path without a write verb is not a violation', () => {
-  // The grader quotes repo paths constantly; if a mention counted, every run would block and the
-  // gate would be useless noise within a week.
-  const r = findViolations({
-    skillId: 'demo',
-    agents: [agent('x', 'baseline', 'the record would normally live in 02-DOCS/wiki/sdd/ somewhere')],
-  });
-  assert.equal(r.ok, true);
+test('REGRESSION: naming a protected path is not writing to it', () => {
+  // The defect the first real run exposed. The old check looked for a write VERB within ~400 chars
+  // of a protected path in the raw text. A treatment transcript embeds the whole SKILL.md, and
+  // verify/SKILL.md itself names 02-DOCS/wiki/sdd/config.yaml — so the window matched and the run was
+  // BLOCKED while the filesystem held no new files at all. Over-blocking is still a broken gate: it
+  // would have blocked every treatment run and wedged skill-harden.
+  const skillBodyMentions = withCalls('t', 'treatment',
+    call('Bash', { command: 'cat 02-DOCS/wiki/sdd/config.yaml' }),           // a READ
+    call('Bash', { command: "cat > .rsc/eval-sandbox/x/treatment-0/out.md <<'EOF'" }), // write, in zone
+  );
+  const r = findViolations({ skillId: 'demo', agents: [skillBodyMentions] });
+  assert.equal(r.ok, true, 'reading a protected path, or writing inside the sandbox, is not a violation');
+});
+
+test('a real write TO a protected path is still caught, by tool and by shell', () => {
+  const byTool = withCalls('a', 'treatment', call('Write', { file_path: '/repo/02-DOCS/wiki/x.md' }));
+  assert.ok(findViolations({ skillId: 'demo', agents: [byTool] }).violations.length, 'Write tool');
+
+  for (const cmd of [
+    'cat > 02-DOCS/wiki/x.md',
+    'echo hi >> 02-DOCS/wiki/x.md',
+    'tee 02-DOCS/wiki/x.md',
+    'mv /tmp/a.md 02-DOCS/wiki/a.md',
+    'cp a 02-DOCS/wiki/a',
+    'mkdir -p 02-DOCS/wiki/new',
+  ]) {
+    const a = withCalls('a', 'baseline', call('Bash', { command: cmd }));
+    assert.ok(
+      findViolations({ skillId: 'demo', agents: [a] }).violations.some((v) => v.kind === 'wrote-protected-path'),
+      `should catch: ${cmd}`,
+    );
+  }
+});
+
+test('reads are counted from tool inputs, not from prose', () => {
+  // Prose in an answer that happens to name the skill path is not the baseline having read it.
+  const prose = withCalls('b', 'baseline', JSON.stringify({ message: { content: [{ type: 'text', text: 'as skills/demo/SKILL.md would say' }] } }));
+  assert.equal(findViolations({ skillId: 'demo', agents: [prose] }).ok, true);
+
+  const real = withCalls('b', 'baseline', call('Read', { file_path: 'skills/demo/SKILL.md' }));
+  assert.ok(findViolations({ skillId: 'demo', agents: [real] }).violations.some((v) => v.kind === 'baseline-read-skill'));
+});
+
+test('extractToolCalls survives junk lines and non-tool content', () => {
+  const calls = extractToolCalls(['not json', '', '{"message":{"content":"plain string"}}', call('Bash', { command: 'ls' })].join('\n'));
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].name, 'Bash');
+});
+
+test('callWritesTo and callReads are exported and pure', () => {
+  assert.equal(callWritesTo({ name: 'Bash', input: { command: 'cat 02-DOCS/wiki/a' } }, '02-DOCS/wiki/'), false);
+  assert.equal(callWritesTo({ name: 'Bash', input: { command: 'cat > 02-DOCS/wiki/a' } }, '02-DOCS/wiki/'), true);
+  assert.equal(callWritesTo(null, '02-DOCS/wiki/'), false);
+  assert.equal(callReads({ name: 'Read', input: { file_path: 'skills/x/SKILL.md' } }, 'skills/x/SKILL.md'), true);
 });
 
 test('findViolations refuses to run without a skillId', () => {


### PR DESCRIPTION
The integrity gate from #227 over-blocked on its **first real use** — twice, both times the same mistake: *"the path appears in the string"* is not *"the write targets that location"*. Ground truth both times was a filesystem holding **no new files at all**.

An over-blocking gate is still a broken gate. Left as shipped, every treatment run would return `BLOCKED` and `skill-harden` would be wedged permanently.

## The two false positives

**1. Proximity matching.** The check looked for a write verb within ~400 chars of a protected path in raw transcript text. A treatment transcript embeds the whole `SKILL.md`, and `verify/SKILL.md` itself names `02-DOCS/wiki/sdd/config.yaml`; tool names appear in every JSON envelope. So the window matched almost always.

Now structural: parse `tool_use` entries, then check either a write tool's actual `file_path`, or a shell redirect / `mv` / `cp` / `tee` / `mkdir` whose **target** is the protected path. `cat 02-DOCS/x` is a read and no longer matches.

**2. Sandbox paths that mirror the wiki.** The arms wrote correctly inside their zone — and recreated the wiki tree within it:

```
.rsc/eval-sandbox/specify/treatment-1/02-DOCS/wiki/sdd/specs/x.md
```

Substring matching flagged that as a protected write. The sandbox now anchors first, and the check is **per match**, so a legitimate sandboxed write in the same command cannot launder a real one alongside it.

Reads got the same treatment: counted from tool inputs, not from prose that happens to name the skill path.

## Validation

Against **both** runs, not a fixture:

| run | verdict | correct? |
|---|---|---|
| `verify` run 1 | BLOCKED — baseline read the skill, arms wrote to 02-DOCS | ✅ those writes happened; the files exist |
| `specify` run 1 | BLOCKED — 4 violations | ✅ same |
| `verify` run 2 | clean | ✅ filesystem confirms no writes |
| `specify` run 2 | clean | ✅ same |
| `testing-web` run 2 | clean | ✅ |

398 tests green, **6/6 mutants killed** on the new logic, plus two regression tests named after the two false positives.

## What the fix unlocked

The first clean measurement of these skills — and the contaminated numbers were not merely noisy, they were **inverted**:

| skill | run 1 (contaminated) | run 2 (integrity verified) |
|---|---|---|
| `verify` | BLOCKED | **PASS 8.6 · lift +3.3** |
| `specify` | BLOCKED, lift **−1.4** | FAIL 8.2 · lift **+2.4** |
| `testing-py` | FAIL 7.5 · +1.7 | **PASS 9.7 · +1.5** |
| `testing-web` | FAIL 8.1 · +0.1 | FAIL 9.5 · **+0.2** |

`specify` had measured as *worse than no skill at all*. It adds +2.4. That number was going to be read as "the skill hurts".

And the per-arm sandboxes from #227, which had never executed live, **worked**: the baseline read the skill 0 times (7 before), both arms wrote only into their own zone, and one treatment even staged its wiki edits as `pending-writes/` files rather than touching the repo.

`testing-web`'s flat lift is now confirmed twice with integrity verified — a real finding about that skill, not an artifact.