### PR TITLE
feat(verify): a gate must prove it can pass, not only that it can fail

### DIFF
--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -85,7 +85,7 @@ Rules for RUN:
 - Run from the directory the stack skill documents (Go runs from the module root; others from the subproject root). Don't guess paths.
 - If no `scripts/verify.sh` exists for a touched stack, that's a gap — say the gate is incomplete and recommend the user add the stack skill, rather than hand-rolling a one-off check that drifts from the real gate.
 
-#### A home-grown gate must prove it can fail
+#### A home-grown gate must prove it can fail — and that it can pass
 
 The dangerous way a checker breaks is not a crash — it is **fail-open**: nothing errors, the layer prints pass, and it prints pass forever. That failure can only ever produce green, so no failing run will ever surface it. The rule follows: **before you trust a home-grown gate's pass, watch it fail** on a known-bad input. It is the RED principle applied to the checker.
 
@@ -93,6 +93,14 @@ The dangerous way a checker breaks is not a crash — it is **fail-open**: nothi
 - **A must-find-nothing grep has three outcomes, not two.** No matches = pass. A match = fail. **The scan itself breaking** (unreadable input, bad pattern) = fail too. Left unhandled, an unreadable file becomes a silent pass. No `|| true`, no `2>/dev/null`, no bare fallthrough.
 - **State the limit where you state the pass.** Watching a gate fail once proves that *one* known-bad case reaches its failure path. It does **not** prove the gate recognizes every violation of the rule it claims to enforce — a gate can fail closed perfectly and still guard a spelling rather than a behavior. Record the control, and record what it does not buy.
 - **Our own known fail-open:** the stack `verify.sh` scripts SKIP a missing tool instead of failing. That is a documented gap, not a pass — so it goes in the record's *Capas no ejecutadas* under `HERRAMIENTA-AUSENTE`, never left implied.
+
+**Then run the other control: a known-GOOD input, and watch it pass.** Both directions or neither — a gate proven only against bad input is half-tested, and the untested half is the one that fires on every run.
+
+**Over-blocking is not the safe side.** It feels like caution and it is not: a gate that fires on correct work gets muted, worked around, or wedges the pipeline that depends on it, which is the same damage as a gate that checks nothing with the sign reversed. And it is *harder* to notice, because the failure arrives dressed as diligence.
+
+Where this bites hardest is a check that matches text rather than structure — **"the path appears in the string" is not "the write targets that location"**. Our own integrity gate learned this twice in one day: it flagged a transcript that merely *named* a protected path (the skill body it had been handed named it), then flagged a sandbox directory whose path *contained* the protected one as a substring. Twelve mutants had proven it could fail; not one had asked whether it could pass, so the defect shipped and surfaced on first real use with the filesystem provably untouched. → `02-DOCS/wiki/harness/puertas-y-mecanismos.md`
+
+So when you write the negative control, write the positive one beside it, and prefer matching **structure** (a parsed tool call, a resolved path, an exit code) over matching text that happens to contain the thing you care about.
 
 ### 3 — WALK the done-checks and acceptance criteria
 

--- a/tests/gate-honesty.test.js
+++ b/tests/gate-honesty.test.js
@@ -21,6 +21,9 @@ import { fileURLToPath } from 'node:url';
 // sentence, so rewording the prose does not break the test while deleting the rule does.
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const skill = (id) => readFileSync(join(ROOT, 'skills', id, 'SKILL.md'), 'utf8');
+// Prose assertions run against whitespace-collapsed text: skill bodies are hard-wrapped, so a
+// sentence matched with single spaces breaks the moment the wrap lands mid-phrase.
+const prose = (id) => skill(id).replace(/\s+/g, ' ');
 
 const TESTING_SKILLS = ['testing-py', 'testing-web', 'testing-go'];
 const TOUCHED = [...TESTING_SKILLS, 'verify', 'specify'];
@@ -98,9 +101,11 @@ test('B — verify requires a home-grown gate to be watched failing', () => {
   // Anchor on the HEADING, not the phrase. A bare /prove it can fail/ also matches the one-line
   // reminder in the anti-patterns table, so it survived a mutant that gutted this whole section —
   // found by the negative control in 02-DOCS/wiki/sdd/verifications/gate-honesty-2026-08-17.md.
+  // The heading gained "— and that it can pass" on 2026-08-18; anchored on the phrase within a
+  // heading line rather than at end-of-line, so extending the title does not break the pin.
   assert.match(
     body,
-    /^#+ .*prove it can fail\s*$/im,
+    /^#+ .*prove it can fail.*$/im,
     'verify: the rule needs its own section, not just an anti-pattern row',
   );
   assert.match(body, /fail-open/i, 'verify: must name the fail-open failure mode');
@@ -109,6 +114,35 @@ test('B — verify requires a home-grown gate to be watched failing', () => {
     /known-bad/i,
     'verify: must require a known-bad input, not just "test the gate"',
   );
+});
+
+test('B — the rule now requires BOTH controls: can-fail and can-pass', () => {
+  // The missing symmetric half, added 2026-08-18 after the integrity gate over-blocked twice on its
+  // first real use. Twelve mutants had proven it could fail; none asked whether it could pass, so the
+  // defect shipped. Rule stated at 02-DOCS/wiki/sdd/verifications/eval-run2-2026-08-18.md.
+  const body = prose('verify');
+  assert.match(
+    body,
+    /known-GOOD input/i,
+    'verify: a gate must also be watched passing on a known-good input',
+  );
+  assert.match(
+    body,
+    /[Bb]oth directions or neither/,
+    'verify: half-testing a gate leaves the half that fires on every run untested',
+  );
+  assert.match(
+    body,
+    /[Oo]ver-blocking is not the safe side/,
+    'verify: must say why over-blocking is not caution',
+  );
+  // The concrete failure shape, so the rule is actionable rather than a slogan.
+  assert.match(
+    body,
+    /is not "the write targets that location"/,
+    'verify: must name the text-vs-structure trap that caused it',
+  );
+  assert.match(body, /prefer matching \*\*structure\*\*|matching structure/i, 'verify: must prescribe structure over text');
 });
 
 test('B — third-party tools are exempt, and the exemption is explicit', () => {


### PR DESCRIPTION
The symmetric half of the rule shipped in 1.0.12, added because its absence cost two defects in one day — both in the gate I wrote to enforce the original half.

## The rule as it stood

`verify` said: **before you trust a home-grown gate's pass, watch it fail** on a known-bad input. The RED principle applied to the checker. Good rule; it closed a real class of failure (fail-open) and it is why the integrity gate exists at all.

## What it was missing

It only ever asked about one direction. So `eval-integrity.js` shipped in 1.0.14 with **twelve mutants proving it could fail** — and not one asking whether it could pass. It over-blocked on its **first real use**, twice:

1. It flagged a transcript that merely **named** a protected path. The treatment prompt embeds the whole `SKILL.md`, and `verify/SKILL.md` itself names `02-DOCS/wiki/sdd/config.yaml`.
2. It flagged a sandbox directory whose path **contained** the protected one as a substring: `.rsc/eval-sandbox/specify/treatment-1/02-DOCS/wiki/sdd/specs/x.md` — a correct write.

Both times the filesystem was provably untouched. Both were found by checking the disk, not by any test — because no test was looking in that direction.

## What lands

Three sentences and a scar, in the section that already holds the twin rule:

- **Run the other control too: a known-GOOD input, and watch it pass.** Both directions or neither — a gate proven only against bad input is half-tested, and the untested half is the one that fires on every run.
- **Over-blocking is not the safe side.** It feels like caution and isn't: a gate that fires on correct work gets muted, worked around, or wedges the pipeline depending on it — the same damage as a gate that checks nothing, sign reversed. And it is *harder* to notice, because the failure arrives dressed as diligence.
- **"The path appears in the string" is not "the write targets that location."** Prefer matching **structure** — a parsed tool call, a resolved path, an exit code — over matching text that happens to contain the thing you care about.

The concrete case is named inline and pointed at the pattern registry, so the rule reads as something that already cost us rather than as advice.

## Verification

| Gate | Result |
|---|---|
| `npm run validate` / `manifest:check` | OK, 264 skills |
| `npm test` | **399 passed, 0 failed** |
| `eval-lint.sh` | 264 skills, 0 failures |
| `drift:check` | all claims resolve |
| manual mutation | **6/6 killed** |
| P5 | `verify` 233 / 400 lines |

**And the previous release's test caught this change**, which is the second time today that has happened and the only reason to trust either pin: extending the heading to "— and that it can pass" broke the assertion from 1.0.12 that required `prove it can fail` to end the heading line. Re-anchored to the phrase within a heading rather than at end-of-line, so extending a title no longer breaks the pin while deleting the rule still does.

**Declared limit, and it is the same one the rule itself names:** this is a presence test. It pins that the rule stays written, not that an agent obeys it. Behavioural verification would need a `capability` scenario where a gate is authored — and per the discrimination rule added in 1.0.14, that item would have to be answerable by the scenario's task and shown to discriminate before it earned a place. Not done; recorded as open.