### PR TITLE
feat(knowledge): a doctor for what the wiki claims, not just what it links

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "validate": "node scripts/build-manifest.js --validate",
     "drift:check": "node scripts/drift-check.js",
     "drift:knowledge": "node scripts/drift-check.js --knowledge",
+    "knowledge:doctor": "node scripts/knowledge-doctor.js",
     "routing:audit": "node scripts/routing-audit.js",
     "test": "node --test",
     "coverage": "c8 --reporter=text node --test",

--- a/scripts/knowledge-doctor.js
+++ b/scripts/knowledge-doctor.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// knowledge-doctor.js — report what the wiki claims that no longer holds.
+//
+// Usage: node scripts/knowledge-doctor.js [--json]
+//
+// Report-only, on demand. NOT in `rsc doctor`, NOT in any hook, NOT in the release gates — decided in
+// clarify (2026-08-18): the precision a check needs scales with how intrusive it is, and an asked-for
+// report tolerates noise an automatic one does not. Accepted cost, stated here so nobody has to
+// rediscover it: drift is not detected on its own. Somebody has to run this.
+//
+// It NEVER writes. Not a file, not a mkdir. `02-DOCS/` is untracked (P9): there is no undo here.
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { diagnose, CLASSES } from './lib/knowledge-doctor.js';
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WIKI = join(REPO, '02-DOCS', 'wiki');
+
+const walk = (dir) => readdirSync(dir).flatMap((e) => {
+  const p = join(dir, e);
+  return statSync(p).isDirectory() ? walk(p) : (p.endsWith('.md') ? [p] : []);
+});
+
+// Injected so the pure library never touches git. Cached: the same ref is asked about repeatedly.
+const refCache = new Map();
+const refExists = (ref) => {
+  if (refCache.has(ref)) return refCache.get(ref);
+  let ok = false;
+  for (const spec of [`${ref}^{commit}`, `refs/tags/${ref}`]) {
+    try { execFileSync('git', ['cat-file', '-e', spec], { cwd: REPO, stdio: 'ignore' }); ok = true; break; }
+    catch { /* not this kind of ref */ }
+  }
+  refCache.set(ref, ok);
+  return ok;
+};
+
+function main() {
+  const asJson = process.argv.includes('--json');
+  if (!existsSync(WIKI)) {
+    // Not a failure: a repo without the harness has nothing to audit.
+    console.log('knowledge-doctor: no hay 02-DOCS/wiki/ — nada que auditar.');
+    process.exit(0);
+  }
+  const files = walk(WIKI);
+  const indexPath = join(WIKI, 'index.md');
+  const indexText = existsSync(indexPath) ? readFileSync(indexPath, 'utf8') : null;
+
+  const docs = files.map((p) => {
+    const rel = relative(WIKI, p);
+    return {
+      path: relative(REPO, p),
+      rel,
+      dir: dirname(rel) === '.' ? '' : dirname(rel),
+      text: readFileSync(p, 'utf8'),
+      // Only artifacts the chain consumes are expected in the Knowledge map; an article is not.
+      indexable: rel.startsWith('sdd/specs/') || rel.startsWith('sdd/verifications/'),
+    };
+  });
+
+  const report = diagnose({ docs, indexText, refExists });
+  if (asJson) { console.log(JSON.stringify(report, null, 2)); process.exit(0); }
+
+  const byClass = (c) => report.candidates.filter((x) => x.cls === c);
+  console.log(`# knowledge-doctor — ${report.scanned} documentos\n`);
+  if (!report.candidates.length) {
+    console.log('Sin candidatos. Nada que triar.\n');
+  } else {
+    console.log(`${report.candidates.length} candidato(s), ordenados por coste de equivocarse:\n`);
+    for (const c of report.candidates) {
+      console.log(`- **${c.cls}** · \`${c.path}:${c.line}\`${c.uncertain ? ' · _incierto_' : ''}`);
+      console.log(`  - señal: ${c.signal}`);
+      console.log(`  - esperado: ${c.expected} · encontrado: ${c.found}`);
+    }
+    console.log('');
+    for (const [label, cls] of [['se contradice', CLASSES.CONTRADICTS], ['ya no aplica', CLASSES.STALE], ['fuera de sitio', CLASSES.MISPLACED]]) {
+      console.log(`- ${label}: ${byClass(cls).length}`);
+    }
+    console.log('');
+  }
+  console.log('## Lo que NO se miró\n');
+  for (const n of report.notLookedAt) console.log(`- ${n}`);
+  console.log('\nEl juicio es de `knowledge-ops` o tuyo: esto estrecha, no cura. No se ha escrito nada.');
+  process.exit(0);
+}
+
+main();

--- a/scripts/lib/knowledge-doctor.js
+++ b/scripts/lib/knowledge-doctor.js
@@ -1,0 +1,265 @@
+// knowledge-doctor.js — does what the wiki CLAIMS still hold?
+//
+// drift-check answers one question: does the path a document names exist? It is a good mechanism and
+// its scope ends there. It cannot see a claim that was true the day it was written and is not true
+// now, and on 2026-08-18 three of those were found by hand in one session while drift-check passed
+// green: a counter with three different values across three documents, four decisions-log entries
+// written by eval agents about features nobody is building, and a spec asserting "the verify.sh of
+// four stacks" when there are 189 and only 2 run coverage.
+//
+// A wiki with stale claims does not read badly. It reads with the same confidence and occasionally
+// lies — and `02-DOCS/` is untracked (P9), so there is no git log to reconstruct when a sentence
+// stopped being true.
+//
+// THIS DETECTS, IT DOES NOT CURE. `knowledge-ops` already owns the gardening (prune, archive never
+// delete, merge duplicates, kill orphans) and knows HOW; what did not exist is anything telling it
+// WHERE. Deterministic narrowing, judgment on the narrowed set (P1) — the split knowledge-drift used.
+//
+// Scope decided in clarify (2026-08-18): contradictions ONLY against a declared single source; the
+// general cross-document case needs semantic comparison whose false-positive rate nobody measured,
+// and a detector that cries wolf gets switched off (P7).
+
+// Order = cost of being wrong. Artifacts another process consumes as INPUT come first; articles a
+// human reads occasionally come last. A declared constant, not a heuristic.
+export const SEVERITY_ORDER = ['sdd/specs', 'sdd/verifications', 'sdd', 'harness', 'brand', 'stack'];
+
+export const CLASSES = { STALE: 'ya-no-aplica', MISPLACED: 'fuera-de-sitio', CONTRADICTS: 'se-contradice' };
+
+// Out of scope, named so their absence is not read as cleanliness.
+export const NOT_LOOKED_AT = [
+  'La PRIMERA instancia de una desviación de convención: las convenciones se derivan del wiki en cada corrida, así que un único fichero fuera de sitio define su propia ubicación como válida. Deliberado — hardcodear la tabla sería una segunda copia de la verdad que deriva de ella.',
+  'Contradicción general entre documentos (exige comparación semántica; fuera por clarify 18-08).',
+  'Obsolescencia semántica de prosa: si un párrafo sobre arquitectura sigue siendo cierto.',
+  'La memoria del proyecto: drift-check ya resuelve sus rutas vía memoryDir(); su auditoría semántica queda fuera.',
+  'Calidad de escritura, tono, o si un artículo merece existir.',
+];
+
+/**
+ * Whitespace-collapsed text for prose matching. Not a nicety: the single-source declaration in this
+ * repo's own pattern registry is wrapped mid-phrase (`vive **en esta tabla y en\nningún otro
+ * sitio**`), so a line-based match loses it. Third time in one day that hard wrapping defeated a
+ * prose match — twice in tests before this.
+ */
+export const normalizeProse = (text) => String(text || '').replace(/\s+/g, ' ');
+
+/** Split frontmatter from body. Returns {fields, body, ok, reason}. Unreadable => a candidate, never a skip. */
+export function parseFrontmatter(text) {
+  const t = String(text || '');
+  if (!t.startsWith('---')) return { fields: {}, body: t, ok: false, reason: 'sin frontmatter YAML' };
+  const end = t.indexOf('\n---', 3);
+  if (end === -1) return { fields: {}, body: t, ok: false, reason: 'frontmatter sin cierre' };
+  const head = t.slice(4, end);
+  const fields = {};
+  for (const line of head.split('\n')) {
+    const m = /^([a-z_]+):\s*(.*)$/i.exec(line);
+    if (m) fields[m[1].toLowerCase()] = m[2].trim();
+  }
+  return { fields, body: t.slice(end + 4), ok: true, reason: null };
+}
+
+/** Does this document declare itself the single source of a fact? Matched on normalized prose. */
+export function declaresSingleSource(text) {
+  const p = normalizeProse(text);
+  return /en ning[uú]n otro sitio|and nowhere else|fuente [uú]nica|single source of/i.test(p);
+}
+
+const WORD_NUMBERS = {
+  dos: 2, tres: 3, cuatro: 4, cinco: 5, seis: 6, siete: 7, ocho: 8, nueve: 9,
+  diez: 10, once: 11, doce: 12, trece: 13, catorce: 14, quince: 15,
+};
+
+/**
+ * A count asserted in the FRONTMATTER only. Body prose is not a usable signal: the live case's own
+ * document contains "7 veces" inside a table cell describing something else entirely.
+ */
+export function statedCountInFrontmatter(fields) {
+  for (const key of ['description', 'title']) {
+    const v = String(fields[key] || '');
+    const digits = /(\d+)\s+(?:veces|times|apariciones|occurrences)/i.exec(v);
+    if (digits) return { value: Number(digits[1]), source: key, literal: digits[0] };
+    const words = new RegExp(`\\b(${Object.keys(WORD_NUMBERS).join('|')})\\s+(?:veces|times)`, 'i').exec(v);
+    if (words) return { value: WORD_NUMBERS[words[1].toLowerCase()], source: key, literal: words[0] };
+  }
+  return null;
+}
+
+/** Data rows of the first markdown table (header and separator excluded). */
+export function firstTableRowCount(body) {
+  const lines = String(body || '').split('\n');
+  let i = lines.findIndex((l) => /^\s*\|.*\|/.test(l) && /\|/.test(l));
+  if (i === -1) return null;
+  if (!/^\s*\|[\s:|-]+\|/.test(lines[i + 1] || '')) return null; // header must be followed by a separator
+  let n = 0;
+  for (let j = i + 2; j < lines.length && /^\s*\|/.test(lines[j]); j++) n++;
+  return { rows: n, headerLine: i + 1 };
+}
+
+const lineOf = (text, needle) => {
+  const idx = String(text).indexOf(needle);
+  if (idx === -1) return 1;
+  return String(text).slice(0, idx).split('\n').length;
+};
+
+/** Class 1 — a status: citing a commit or tag that does not exist. refExists is injected. */
+export function findStaleClaims({ path, text, refExists }) {
+  const { fields } = parseFrontmatter(text);
+  const status = String(fields.status || '');
+  if (!status) return [];
+  const out = [];
+  const refs = new Set();
+  for (const m of status.matchAll(/\b([0-9a-f]{7,8})\b/g)) refs.add(m[1]);
+  for (const m of status.matchAll(/\bv?(\d+\.\d+\.\d+)\b/g)) refs.add(`v${m[1]}`);
+  for (const ref of refs) {
+    if (refExists(ref)) continue;
+    out.push({
+      path, line: lineOf(text, 'status:'), cls: CLASSES.STALE,
+      signal: `status: cita \`${ref}\`, que no existe en el repo`,
+      expected: `un commit o tag \`${ref}\``, found: 'nada con ese nombre',
+    });
+  }
+  return out;
+}
+
+/**
+ * Class 2 — out of place. Conventions are DERIVED from the wiki on every run, never hardcoded:
+ * a hardcoded table is a second copy of the truth and drifts from it.
+ */
+// A convention needs CORROBORATION, and this is the sharp edge of deriving one from the data.
+//
+// The first version of both rules below was dead code — a gate that could not fail. A misplaced file
+// added its own directory to the set of valid homes for its type, and a file missing frontmatter
+// counted inside its own denominator for "every sibling has one". In both cases the anomaly defined
+// itself as normal, so neither check could ever fire. Caught by the tests, which is exactly the
+// can-it-pass / can-it-fail symmetry from v1.0.17 doing its job on the way in rather than in
+// production.
+//
+// The fix in both: a single instance never establishes a convention, and never excuses itself.
+export const DOMINANT_HOME_SHARE = 0.75; // one directory holding this share of a type owns it
+export const MIN_DOCS_FOR_TYPE_RULE = 3; // below this a directory is too small to have a convention
+
+export function deriveConventions(docs) {
+  const typeCounts = new Map(); // type -> Map(dir -> n)
+  const dirsWithType = new Map();
+  for (const d of docs) {
+    const { fields, ok } = parseFrontmatter(d.text);
+    const has = ok && Boolean(fields.type);
+    const seen = dirsWithType.get(d.dir) || { withType: 0, total: 0 };
+    seen.total++; if (has) seen.withType++;
+    dirsWithType.set(d.dir, seen);
+    if (has) {
+      if (!typeCounts.has(fields.type)) typeCounts.set(fields.type, new Map());
+      const m = typeCounts.get(fields.type);
+      m.set(d.dir, (m.get(d.dir) || 0) + 1);
+    }
+  }
+
+  // A type is only "at home" somewhere if ONE directory holds a dominant share of it. `article` is
+  // spread across brand/harness/stack by design, so it has no dominant home and is never judged —
+  // which is the correct silence, not a gap.
+  const dominantHome = new Map();
+  for (const [type, dirs] of typeCounts) {
+    const total = [...dirs.values()].reduce((a, b) => a + b, 0);
+    const [bestDir, bestN] = [...dirs.entries()].sort((a, b) => b[1] - a[1])[0];
+    if (total >= 2 && bestN / total >= DOMINANT_HOME_SHARE) dominantHome.set(type, { dir: bestDir, share: bestN / total, total });
+  }
+
+  // Frontmatter is demanded where at most ONE document deviates — so the deviant does not veto the
+  // rule by existing, and a directory of mixed conventions still stays silent.
+  const typeRequiredDirs = new Set(
+    [...dirsWithType.entries()]
+      .filter(([, v]) => v.total >= MIN_DOCS_FOR_TYPE_RULE && v.withType >= v.total - 1)
+      .map(([k]) => k),
+  );
+  return { dominantHome, typeRequiredDirs };
+}
+
+export function findMisplaced({ doc, conventions, indexText }) {
+  const out = [];
+  const { fields, ok, reason } = parseFrontmatter(doc.text);
+  if (!ok) {
+    // The SAME derived narrowing as the missing-`type:` branch below. The first real run flagged 8
+    // documents that legitimately have no frontmatter — the SDD phase standards, decisions.md,
+    // index.md — which is over-firing on correct work: 8 of 15 candidates were noise, and a report
+    // that cries wolf gets ignored (P7). A document without frontmatter is only a candidate in a
+    // directory where every other document has one. Applying the narrowing to one branch and not the
+    // other was the bug; the fix is symmetry, not an exclusion list.
+    if (conventions.typeRequiredDirs.has(doc.dir)) {
+      out.push({
+        path: doc.path, line: 1, cls: CLASSES.MISPLACED,
+        signal: `frontmatter ilegible (${reason}), y todos los demás documentos de \`${doc.dir}\` lo tienen`,
+        expected: 'frontmatter YAML con type:', found: reason,
+        uncertain: true,
+      });
+    }
+    return out;
+  }
+  if (!fields.type) {
+    if (conventions.typeRequiredDirs.has(doc.dir)) {
+      out.push({
+        path: doc.path, line: 1, cls: CLASSES.MISPLACED,
+        signal: `sin \`type:\`, y todos los demás documentos de \`${doc.dir}\` lo tienen`,
+        expected: 'un type: no vacío', found: 'ausente',
+      });
+    }
+  } else {
+    const home = conventions.dominantHome.get(fields.type);
+    if (home && home.dir !== doc.dir) {
+      out.push({
+        path: doc.path, line: lineOf(doc.text, 'type:'), cls: CLASSES.MISPLACED,
+        // Deliberately phrased as an inconsistency: the detector cannot know which side should yield,
+        // and pretending otherwise would be inventing the answer.
+        signal: `\`type: ${fields.type}\` en \`${doc.dir}\`, pero ${Math.round(home.share * 100)}% de ese tipo (${home.total} docs) vive en \`${home.dir}\``,
+        expected: 'o el fichero en otra carpeta, o otro type:', found: 'inconsistencia — decide tú cuál cede',
+        uncertain: true,
+      });
+    }
+  }
+  if (indexText != null && doc.indexable && !indexText.includes(doc.rel)) {
+    out.push({
+      path: doc.path, line: 1, cls: CLASSES.MISPLACED,
+      signal: 'artefacto sin fila en el Knowledge map',
+      expected: `una fila citando \`${doc.rel}\``, found: 'ninguna',
+    });
+  }
+  return out;
+}
+
+/** Class 3 — a frontmatter count contradicting the table the document declares its single source. */
+export function findContradictions({ path, text }) {
+  if (!declaresSingleSource(text)) return [];
+  const { fields, body, ok } = parseFrontmatter(text);
+  if (!ok) return [];
+  const stated = statedCountInFrontmatter(fields);
+  if (!stated) return [];
+  const table = firstTableRowCount(body);
+  if (!table) return [];
+  if (stated.value === table.rows) return [];
+  return [{
+    path, line: lineOf(text, `${stated.source}:`), cls: CLASSES.CONTRADICTS,
+    signal: `el frontmatter dice "${stated.literal}" y el documento se declara fuente única, pero su primera tabla tiene ${table.rows} filas`,
+    expected: `${table.rows} (las filas de la tabla)`, found: `${stated.value} (en \`${stated.source}:\`)`,
+  }];
+}
+
+/** Rank by cost of being wrong, then by class, then by path — stable and explainable. */
+export function rank(candidates) {
+  const bucket = (p) => {
+    const i = SEVERITY_ORDER.findIndex((d) => p.includes(`/${d}/`) || p.endsWith(`/${d}`));
+    return i === -1 ? SEVERITY_ORDER.length : i;
+  };
+  const clsRank = (c) => [CLASSES.CONTRADICTS, CLASSES.STALE, CLASSES.MISPLACED].indexOf(c);
+  return [...candidates].sort((a, b) =>
+    bucket(a.path) - bucket(b.path) || clsRank(a.cls) - clsRank(b.cls) || a.path.localeCompare(b.path));
+}
+
+/** The whole pass, over already-read documents. Pure: no fs, no git — both are injected. */
+export function diagnose({ docs, indexText, refExists }) {
+  const cands = [];
+  const conventions = deriveConventions(docs);
+  for (const doc of docs) {
+    cands.push(...findStaleClaims({ path: doc.path, text: doc.text, refExists }));
+    cands.push(...findMisplaced({ doc, conventions, indexText }));
+    cands.push(...findContradictions({ path: doc.path, text: doc.text }));
+  }
+  return { candidates: rank(cands), scanned: docs.length, notLookedAt: NOT_LOOKED_AT };
+}

--- a/tests/knowledge-doctor.test.js
+++ b/tests/knowledge-doctor.test.js
@@ -147,6 +147,24 @@ test('REGRESSION: no frontmatter is only a candidate where every sibling has one
   assert.match(out[0].signal, /todos los demás/);
 });
 
+test('a type with NO dominant home is never judged — the over-firing control', () => {
+  // `article` genuinely lives in brand/, harness/ and stack/. Without the corroboration threshold every
+  // type would get a "home" (whichever dir happens to hold most) and the minority dirs would all be
+  // flagged — noise about correct work, on day one. Mutant M6 survived until this test existed.
+  const spread = [
+    doc('brand/a.md', fm({ type: 'article' })),
+    doc('brand/b.md', fm({ type: 'article' })),
+    doc('harness/c.md', fm({ type: 'article' })),
+    doc('stack/d.md', fm({ type: 'article' })),
+  ];
+  const conv = conventionsFrom(spread);
+  assert.equal(conv.dominantHome.has('article'), false, 'an evenly spread type has no home to be outside of');
+  for (const d of spread) {
+    assert.deepEqual(findMisplaced({ doc: d, conventions: conv, indexText: null }), [],
+      `${d.path} must stay silent — it is where it belongs`);
+  }
+});
+
 test('MISPLACED flags an indexable artifact with no row, and not a non-indexable one', () => {
   const d = doc('sdd/specs/x.plan.md', fm({ type: 'plan' }), { indexable: true });
   const conv = conventionsFrom([d, doc('sdd/specs/y.md', fm({ type: 'plan' })), doc('sdd/specs/z.md', fm({ type: 'plan' }))]);
@@ -198,8 +216,9 @@ test('diagnose composes the three detectors and reports what it did not look at'
   const r = diagnose({ docs: [doc('harness/a.md', fm({ type: 'article' }))], indexText: '# i', refExists: () => true });
   assert.equal(r.scanned, 1);
   assert.ok(r.notLookedAt.length >= 4);
-  assert.ok(r.notLookedAt.some((n) => /PRIMERA instancia/.test(n)),
-    'the derived-convention blind spot must be declared, not hidden');
+  assert.ok(r.notLookedAt.some((n) => n.startsWith('La PRIMERA instancia')),
+    'the derived-convention blind spot must be declared verbatim, not hidden or mangled');
+  assert.deepEqual(r.notLookedAt, NOT_LOOKED_AT, 'the disclosure list must reach the report intact');
 });
 
 // ----------------------------------------------------------------- against the real wiki

--- a/tests/knowledge-doctor.test.js
+++ b/tests/knowledge-doctor.test.js
@@ -1,0 +1,235 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  normalizeProse, parseFrontmatter, declaresSingleSource, statedCountInFrontmatter,
+  firstTableRowCount, findStaleClaims, findMisplaced, findContradictions, deriveConventions,
+  rank, diagnose, CLASSES, SEVERITY_ORDER, NOT_LOOKED_AT,
+} from '../scripts/lib/knowledge-doctor.js';
+
+// drift-check asks whether the path a document names exists. Nothing asked whether what it CLAIMS
+// still holds, and on 2026-08-18 three stale claims were found by hand while drift-check passed green.
+// Spec: 02-DOCS/wiki/sdd/specs/knowledge-doctor.md
+//
+// EVERY detector is tested in BOTH directions — it flags its known-bad input AND it does not flag its
+// known-good one. That symmetry is the rule shipped in v1.0.17, and it exists because its absence let
+// an over-blocking gate reach production twice in one day. Half of these tests look redundant and are
+// the half that matters.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WIKI = join(ROOT, '02-DOCS', 'wiki');
+
+const doc = (path, text, extra = {}) => ({
+  path, rel: path, dir: dirname(path) === '.' ? '' : dirname(path), text, indexable: false, ...extra,
+});
+const fm = (fields, body = '') =>
+  `---\n${Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join('\n')}\n---\n${body}`;
+
+// ----------------------------------------------------------------- prose normalization
+
+test('normalizeProse survives the hard wrap that defeated three previous matches', () => {
+  // The real declaration in this repo's pattern registry is wrapped mid-phrase. A line-based match
+  // loses it — third time in one day that hard wrapping beat a prose match.
+  const wrapped = 'el número de apariciones vive **en esta tabla y en\nningún otro sitio**.';
+  assert.equal(declaresSingleSource(wrapped), true, 'wrapped declaration must still match');
+  assert.match(normalizeProse(wrapped), /en esta tabla y en ningún otro sitio/);
+});
+
+test('declaresSingleSource is false for an ordinary document', () => {
+  assert.equal(declaresSingleSource('un artículo normal que no declara nada'), false);
+});
+
+// ----------------------------------------------------------------- frontmatter
+
+test('parseFrontmatter reads fields, and reports unreadable rather than guessing', () => {
+  const ok = parseFrontmatter(fm({ type: 'spec', title: 'X' }, 'body'));
+  assert.equal(ok.ok, true);
+  assert.equal(ok.fields.type, 'spec');
+  assert.equal(parseFrontmatter('no frontmatter here').ok, false);
+  assert.equal(parseFrontmatter('---\ntype: x\nnever closed').ok, false);
+  assert.match(parseFrontmatter('---\ntype: x').reason, /sin cierre/);
+});
+
+// ----------------------------------------------------------------- counts and tables
+
+test('a count is read from the frontmatter only, never from body prose', () => {
+  // The live case's own document contains "7 veces" inside a table cell about something else.
+  const f = parseFrontmatter(fm({ description: 'encontrado diez veces en este repo' },
+    '| a | b |\n|---|---|\n| leyó 7 veces | x |\n')).fields;
+  const stated = statedCountInFrontmatter(f);
+  assert.equal(stated.value, 10, 'word numbers must be understood');
+  assert.equal(stated.source, 'description');
+  assert.equal(statedCountInFrontmatter({ description: 'encontrado 12 veces' }).value, 12);
+  assert.equal(statedCountInFrontmatter({ description: 'sin cifras' }), null);
+});
+
+test('firstTableRowCount counts data rows and demands a separator', () => {
+  assert.equal(firstTableRowCount('| a | b |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |\n').rows, 2);
+  assert.equal(firstTableRowCount('| a | b |\n| 1 | 2 |\n'), null, 'no separator = not a table');
+  assert.equal(firstTableRowCount('sin tablas'), null);
+});
+
+// ----------------------------------------------------------------- class 1: stale claims
+
+test('STALE flags a status citing a ref that does not exist', () => {
+  const c = findStaleClaims({
+    path: 'p.md', text: fm({ status: 'implementada (PR #1 → deadbee, v9.9.9)' }),
+    refExists: () => false,
+  });
+  assert.ok(c.length >= 2, 'both the sha and the version are refs');
+  assert.equal(c[0].cls, CLASSES.STALE);
+  assert.match(c[0].signal, /no existe/);
+});
+
+test('STALE does NOT flag a status whose refs all exist — the positive control', () => {
+  const c = findStaleClaims({
+    path: 'p.md', text: fm({ status: 'implementada (c384ff5, v1.0.13)' }), refExists: () => true,
+  });
+  assert.deepEqual(c, []);
+});
+
+test('STALE says nothing when there is no status at all', () => {
+  assert.deepEqual(findStaleClaims({ path: 'p.md', text: fm({ type: 'article' }), refExists: () => false }), []);
+});
+
+// ----------------------------------------------------------------- class 2: misplaced
+
+const conventionsFrom = (docs) => deriveConventions(docs);
+
+test('MISPLACED flags a type living outside every directory that type is seen in', () => {
+  // A single instance must never establish its own directory as a valid home: the first version of
+  // this rule was dead code because the anomaly added itself to the set of homes.
+  const docs = [
+    doc('sdd/verifications/a.md', fm({ type: 'verification' })),
+    doc('sdd/verifications/b.md', fm({ type: 'verification' })),
+    doc('sdd/verifications/c.md', fm({ type: 'verification' })),
+    doc('harness/d.md', fm({ type: 'verification' })),
+  ];
+  const out = findMisplaced({ doc: docs[3], conventions: conventionsFrom(docs), indexText: null });
+  assert.equal(out.length, 1);
+  assert.match(out[0].signal, /type: verification/);
+  // Phrased as an inconsistency: the detector cannot know which side should yield.
+  assert.match(out[0].found, /decide tú/);
+  assert.equal(out[0].uncertain, true);
+});
+
+test('MISPLACED does NOT flag a type in a directory that type genuinely lives in', () => {
+  const docs = [doc('sdd/specs/a.md', fm({ type: 'spec' })), doc('sdd/specs/b.md', fm({ type: 'spec' }))];
+  assert.deepEqual(findMisplaced({ doc: docs[0], conventions: conventionsFrom(docs), indexText: null }), []);
+});
+
+test('REGRESSION: no frontmatter is only a candidate where every sibling has one', () => {
+  // The first real run flagged 8 documents that legitimately have none — the SDD phase standards,
+  // decisions.md, index.md. 8 of 15 candidates were noise about correct work: the 1.0.14 failure
+  // repeating. The bug was applying the derived narrowing to one branch and not the other.
+  const mixed = [
+    doc('sdd/plan.md', 'no frontmatter'),
+    doc('sdd/tasks.md', 'no frontmatter'),
+    doc('sdd/analyze.md', 'no frontmatter'),
+    doc('sdd/constitution.md', fm({ type: 'constitution' })),
+  ];
+  const conv = conventionsFrom(mixed);
+  assert.deepEqual(
+    findMisplaced({ doc: mixed[0], conventions: conv, indexText: null }), [],
+    'a directory where frontmatter is not universal must stay silent',
+  );
+
+  // At most ONE deviant, so the deviant cannot veto the rule simply by existing.
+  const strict = [
+    doc('sdd/specs/a.md', fm({ type: 'spec' })),
+    doc('sdd/specs/b.md', fm({ type: 'spec' })),
+    doc('sdd/specs/d.md', fm({ type: 'spec' })),
+    doc('sdd/specs/c.md', 'no frontmatter'),
+  ];
+  const out = findMisplaced({ doc: strict[3], conventions: conventionsFrom(strict), indexText: null });
+  assert.equal(out.length, 1, 'where every sibling has frontmatter, its absence is a candidate');
+  assert.match(out[0].signal, /todos los demás/);
+});
+
+test('MISPLACED flags an indexable artifact with no row, and not a non-indexable one', () => {
+  const d = doc('sdd/specs/x.plan.md', fm({ type: 'plan' }), { indexable: true });
+  const conv = conventionsFrom([d, doc('sdd/specs/y.md', fm({ type: 'plan' })), doc('sdd/specs/z.md', fm({ type: 'plan' }))]);
+  assert.ok(findMisplaced({ doc: d, conventions: conv, indexText: '# index\n' })
+    .some((c) => /sin fila/.test(c.signal)));
+  assert.ok(!findMisplaced({ doc: d, conventions: conv, indexText: '- [x](sdd/specs/x.plan.md) row' })
+    .some((c) => /sin fila/.test(c.signal)), 'a present row must silence it');
+  const article = doc('harness/a.md', fm({ type: 'article' }));
+  assert.ok(!findMisplaced({ doc: article, conventions: conventionsFrom([article]), indexText: '# index' })
+    .some((c) => /sin fila/.test(c.signal)), 'articles are not expected in the map');
+});
+
+// ----------------------------------------------------------------- class 3: contradictions
+
+test('CONTRADICTS flags a frontmatter count against its declared single-source table', () => {
+  const text = fm({ description: 'encontrado diez veces' },
+    'vive **en esta tabla y en\nningún otro sitio**\n\n| a | b |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |\n| 5 | 6 |\n');
+  const c = findContradictions({ path: 'p.md', text });
+  assert.equal(c.length, 1);
+  assert.equal(c[0].cls, CLASSES.CONTRADICTS);
+  assert.match(c[0].expected, /3/);
+  assert.match(c[0].found, /10/);
+});
+
+test('CONTRADICTS does NOT flag when the count matches — the positive control', () => {
+  const text = fm({ description: 'encontrado dos veces' },
+    'en ningún otro sitio\n\n| a |\n|---|\n| 1 |\n| 2 |\n');
+  assert.deepEqual(findContradictions({ path: 'p.md', text }), []);
+});
+
+test('CONTRADICTS stays out of documents that do not declare single-sourcehood', () => {
+  const text = fm({ description: 'encontrado diez veces' }, '| a |\n|---|\n| 1 |\n');
+  assert.deepEqual(findContradictions({ path: 'p.md', text }), [],
+    'without a declared single source this is out of scope by clarify');
+});
+
+// ----------------------------------------------------------------- ranking & wiring
+
+test('rank puts what another process consumes first', () => {
+  const ranked = rank([
+    { path: 'x/brand/a.md', cls: CLASSES.MISPLACED },
+    { path: 'x/sdd/specs/b.md', cls: CLASSES.MISPLACED },
+  ]);
+  assert.match(ranked[0].path, /sdd\/specs/);
+  assert.equal(SEVERITY_ORDER[0], 'sdd/specs');
+});
+
+test('diagnose composes the three detectors and reports what it did not look at', () => {
+  const r = diagnose({ docs: [doc('harness/a.md', fm({ type: 'article' }))], indexText: '# i', refExists: () => true });
+  assert.equal(r.scanned, 1);
+  assert.ok(r.notLookedAt.length >= 4);
+  assert.ok(r.notLookedAt.some((n) => /PRIMERA instancia/.test(n)),
+    'the derived-convention blind spot must be declared, not hidden');
+});
+
+// ----------------------------------------------------------------- against the real wiki
+
+test('on the real wiki: finds the live contradiction and nothing stale', () => {
+  if (!existsSync(WIKI)) return; // public checkout has no 02-DOCS (P9) — nothing to assert
+  const walk = (d) => readdirSync(d).flatMap((e) => {
+    const p = join(d, e);
+    return statSync(p).isDirectory() ? walk(p) : (p.endsWith('.md') ? [p] : []);
+  });
+  const docs = walk(WIKI).map((p) => {
+    const rel = relative(WIKI, p);
+    return {
+      path: relative(ROOT, p), rel, dir: dirname(rel) === '.' ? '' : dirname(rel),
+      text: readFileSync(p, 'utf8'),
+      indexable: rel.startsWith('sdd/specs/') || rel.startsWith('sdd/verifications/'),
+    };
+  });
+  const indexPath = join(WIKI, 'index.md');
+  const r = diagnose({
+    docs, refExists: () => true,
+    indexText: existsSync(indexPath) ? readFileSync(indexPath, 'utf8') : null,
+  });
+  const contradictions = r.candidates.filter((c) => c.cls === CLASSES.CONTRADICTS);
+  assert.ok(
+    contradictions.some((c) => /puertas-y-mecanismos/.test(c.path)),
+    'the live stale counter must be found — it is why this exists',
+  );
+  // Over-firing check on real data: none of the phase standards may appear.
+  for (const noisy of ['sdd/plan.md', 'sdd/tasks.md', 'sdd/analyze.md', 'wiki/index.md']) {
+    assert.ok(!r.candidates.some((c) => c.path.endsWith(noisy)), `must not flag ${noisy}`);
+  }
+});


### PR DESCRIPTION
Spec 1 of 3. `drift-check` answers whether the path a document *names* exists. Nothing asked whether what it **claims** still holds — and on 2026-08-18 three stale claims were found by hand in one session while `drift-check` passed green.

## Scope, set by clarify

This is **not** a gardener. `knowledge-ops` already owns pruning, archiving-never-deleting, merging duplicates and killing orphans — it knows *how*. What did not exist is anything telling it **where to look**. Deterministic narrowing, judgment on the narrowed set (P1), the split `knowledge-drift` established.

Decided in clarify: **contradictions only against a declared single source** (the general cross-document case needs semantic comparison whose false-positive rate nobody measured), and it **runs on demand** — `npm run knowledge:doctor`, not in `rsc doctor`, not in a hook, not in the release gates. Accepted cost, written into the tool itself: *drift is not detected on its own; somebody has to run this*.

It never writes. Not a file, not a `mkdir`. `02-DOCS/` is untracked (P9) — there is no undo here.

## What it finds on the real wiki

8 candidates over 46 documents, **zero of them about correct work**:

- **1 contradiction** — `puertas-y-mecanismos.md`'s frontmatter says *"diez veces"*; the table it declares its single source has **13 rows**. This is the live case that motivated the spec, and it got worse during the session: I added 3 rows and the frontmatter never moved.
- **1 inconsistency** — `sdd/spec.md` carries `type: spec` while **94% of that type (16 docs) lives in `sdd/specs`**. Phrased as an inconsistency to triage, not as a verdict: the detector cannot know which side should yield, and pretending otherwise would be inventing the answer.
- **6 orphans** — `.plan.md` artifacts with no row in the Knowledge map.

## Two dead gates, caught on the way in

The first version of both convention rules was **code that could not fail**, and for the same reason: *a convention derived from data that includes the anomaly cannot flag the anomaly.* A misplaced file added its own directory to the set of valid homes for its type; a file missing frontmatter counted inside its own denominator for "every sibling has one". Both were structurally incapable of firing.

The fix in both is corroboration: a single instance never establishes a convention and never excuses itself. A type is only "at home" where one directory holds ≥75% of it, and frontmatter is only demanded where at most one document deviates. Consequence, and it is the point: `article` legitimately spans brand/harness/stack, has no dominant home, and is **never judged** — correct silence, not a gap.

## And an over-firing bug, caught by running it

The first real run produced **15 candidates, 8 of them noise** — it flagged the SDD phase standards and `index.md` for having no frontmatter, which they legitimately don't. I had applied the derived narrowing to one branch and not the other. That is the 1.0.14 failure repeating, and it was caught because the plan required reading a real report before writing a single test.

## Verification

| Gate | Result |
|---|---|
| `npm run validate` / `manifest:check` | OK, 264 skills |
| `npm test` | **418 passed, 0 failed** (+19) |
| `eval-lint.sh` | 264 skills, 0 failures |
| `drift:check` | all claims resolve |
| manual mutation | **13/13 killed** (2 classified equivalent, with reasons) |

Every detector is tested in **both directions** per v1.0.17 — it flags its known-bad input **and does not flag its known-good one**. Mutant M6 survived until an over-firing control existed for a type with no dominant home; that test is named after it.

Plus an assertion against the **real wiki**: it must find the live contradiction and must not flag `sdd/plan.md`, `sdd/tasks.md`, `sdd/analyze.md` or `index.md`.

**Declared blind spot, in the report's own output:** a derived convention cannot flag the *first* instance of a deviation — it absorbs it as normal. Deliberate; hardcoding the table would be a second copy of the truth that drifts from it.

The live contradiction is **left unfixed on purpose**, so the detector has something real to find.