### PR TITLE
feat(agents): the refuter panel becomes files, and agents.js becomes a registry

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { rmSync, existsSync, cpSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { planInstall } from './install-plan.js';
 import { targetPaths, writeSkill, wireHook, unwireHook, baseDir, TARGET_IDS } from '../targets/index.js';
-import { targetHasAgents, writeDeveloperAgent, removeDeveloperAgent, developerAgentPath } from '../targets/agents.js';
+import { targetHasAgents, writeAgents, removeAgents, agentPath, agentNames } from '../targets/agents.js';
 import { readState, writeState } from './lib/state.js';
 import { createBackup } from './lib/backups.js';
 
@@ -70,7 +70,7 @@ function managedPathsForInstall({ skillIds, target, home, cwd }) {
   const paths = targetPaths(target, home, cwd);
   const plan = planInstall({ skillIds, target, home, cwd });
   const out = [paths.stateFile, versionFile(cwd), baseVersionsFile(cwd)];
-  if (targetHasAgents(target)) out.push(developerAgentPath(target, cwd), join(cwd, '.rsc', 'developer.json'));
+  if (targetHasAgents(target)) out.push(...agentNames().map((n) => agentPath(target, cwd, n)), join(cwd, '.rsc', 'developer.json'));
   for (const step of plan) {
     if (step.kind === 'skill') {
       out.push(step.to, baseDir(step.id, cwd));
@@ -103,11 +103,18 @@ export async function applyInstall({ skillIds, target, home, cwd = process.cwd()
     }
   }
   writeBaseVersions(cwd, baseVersions);
-  // Install the `developer` subagent for targets that support file-based agents (Claude
-  // Code, Cursor, OpenCode, Gemini, Copilot, Junie, Kiro, Codex). It runs at the balanced
-  // tier by default (never light/Haiku); the tier lives in .rsc/developer.json, set by
-  // `init` at onboarding and honored on every (re)install/sync.
-  if (targetHasAgents(target)) state.agents = writeDeveloperAgent(target, cwd).length ? ['developer'] : [];
+  // Install the catalog's subagents for targets that support file-based agents (Claude
+  // Code, Cursor, OpenCode, Gemini, Copilot, Junie, Kiro, Codex): `developer` plus the three
+  // adversarial refuter lenses `review` dispatches at tier 2. They run at the balanced tier
+  // by default (never light/Haiku); the tier lives in .rsc/developer.json, set by `init` at
+  // onboarding and honored on every (re)install/sync.
+  //
+  // The recorded names come from what was WRITTEN, not from a hardcoded list: a state entry
+  // naming an agent whose file never landed answers "you have it" for something absent.
+  if (targetHasAgents(target)) {
+    const written = writeAgents(target, cwd);
+    state.agents = written.map((f) => basename(f).split('.')[0]);
+  }
   state.version = CLI_VERSION;
   writeState(paths.stateFile, state);
   mkdirSync(dirname(versionFile(cwd)), { recursive: true });
@@ -214,9 +221,12 @@ export async function purge({ home, cwd = process.cwd(), withDocs = false, dryRu
     }
     // unwireHook mutates files, so only run it for real (dry runs skip it).
     if (!dryRun) removed.push(...unwireHook(target, paths));
-    // Remove the installed developer subagent (agent-capable targets only).
-    const agentFile = developerAgentPath(target, cwd);
-    if (agentFile) drop(agentFile);
+    // Remove the subagents this catalog installed — and only those. An uninstaller that takes
+    // an agent the user wrote by hand is worse than one that leaves residue.
+    for (const n of agentNames()) {
+      const agentFile = agentPath(target, cwd, n);
+      if (agentFile) drop(agentFile);
+    }
   }
   drop(join(cwd, '.rsc'), true);
   if (withDocs) drop(join(cwd, '02-DOCS'), true);

--- a/targets/agents.js
+++ b/targets/agents.js
@@ -1,5 +1,10 @@
-// rsc developer agent — installed with the harness for every target that supports
-// file-based subagents with a per-agent model. The agent runs at the `balanced` tier
+// rsc agent registry — the agents installed with the harness for every target that supports
+// file-based subagents with a per-agent model.
+//
+// This file shipped ONE agent with its name, description and body as module constants. Adding a
+// second was therefore not "copy a block": it was turning the file into a registry without breaking
+// the `developer` installs already deployed to users. The registry is the work; the refuters are its
+// first client. See 02-DOCS/wiki/sdd/specs/refuter-agent.md. The agent runs at the `balanced` tier
 // (never `light`/Haiku): Sonnet for Anthropic-backed tools, the provider's mid model
 // elsewhere. The chosen tier (balanced default, or heavy) lives in `.rsc/developer.json`,
 // written by `init` at onboarding and read here so re-syncs honor it.
@@ -33,9 +38,31 @@ const AGENT_TARGETS = {
 export const AGENT_TARGET_IDS = Object.keys(AGENT_TARGETS);
 export function targetHasAgents(target) { return Boolean(AGENT_TARGETS[target]); }
 
-const NAME = 'developer';
-const DESC = 'Implementation worker: turns an approved spec+plan into working, tested code under strict TDD (red->green->refactor), one task at a time. The rsc SDD fan-out/implementation hand.';
-const BODY = `You are the **developer** subagent for this project — the hands of the rsc SDD chain. You execute a planned, approved task into working, tested code. You do NOT design features.
+// The contract every refuter shares, in ONE place. Three lens files each carry the lens inside them
+// (decided in clarify 2026-08-18: a lens passed as a parameter reintroduces the
+// does-anyone-remember dependency this whole spec exists to remove) — but P5 says length is a cost,
+// so the contract they share is composed, not written three times.
+const REFUTER_CONTRACT = `Your mandate is to **refute readiness**, not confirm it. A reviewer looking for confirmation finds confirmation; the asymmetry is the point.
+
+**You get exactly four inputs, and nothing else:**
+1. The task contract — the original request **plus every scope change a human explicitly approved since**. Without the approved changes, a legitimate scope revision reads as a spec gap and you will report a confident false positive.
+2. The approved spec.
+3. The exact source state (commit SHA, or a tree hash when git is absent). A verdict attaches to the state you saw, not to the project.
+4. The entry point — the one command that reruns the checks.
+
+**You do NOT get** the builder's conversation, reasoning, defences, or draft verdict. If a claim needs the builder's justification to stand, it is not proven.
+
+**Blind first, compare second.** Record what you attacked and what you found BEFORE you are shown the builder's conclusions. Only then may you compare and add findings; the blind record is append-only after that, never rewritten. Skip this and your fresh context is spent confirming their framing, which is the one thing it was bought to avoid.
+
+**The attack list is the deliverable, not just the findings.** "Nothing found" without saying where you looked is indistinguishable from not having looked.
+
+**A finding blocks only if it is caused by this change, is severe, and carries evidence** — a repro or a concrete failure scenario. A suspicion without one is a question, and questions do not block. You fix nothing: findings return through the normal loop, and a SPEC gap goes to the human, never to the builder to self-amend.`;
+
+const AGENTS = [
+  {
+    name: 'developer',
+    desc: 'Implementation worker: turns an approved spec+plan into working, tested code under strict TDD (red->green->refactor), one task at a time. The rsc SDD fan-out/implementation hand.',
+    body: `You are the **developer** subagent for this project — the hands of the rsc SDD chain. You execute a planned, approved task into working, tested code. You do NOT design features.
 
 - Work **test-first**: smallest failing test (RED), least code to pass it (GREEN), then refactor on green. A test that never failed proves nothing.
 - One task at a time; keep the diff to that task's scope — no "while I'm here".
@@ -43,7 +70,54 @@ const BODY = `You are the **developer** subagent for this project — the hands 
 - If there is no approved spec + plan for non-trivial feature work, STOP and route to \`specify\` — do not write feature code.
 - Log non-obvious decisions to \`02-DOCS/wiki/sdd/decisions.md\`. Report your diff + test output at the end.
 
-Full discipline lives in the \`implement\` skill.`;
+Full discipline lives in the \`implement\` skill.`,
+  },
+  {
+    name: 'refuter-correctness',
+    desc: 'Adversarial reviewer, correctness lens: attacks a green diff for boundary and error-path defects, and demands that any home-grown gate prove it can both fail and pass. Fresh context, mandate to refute.',
+    body: `You are the **correctness** refuter for this project — one of three adversarial lenses ${'`review`'} dispatches at tier 2. What matters is not the number of lenses but their **diversity**: the worst defect this panel ever found was found by the privacy lens, which was not looking for it.
+
+${REFUTER_CONTRACT}
+
+**Your lens — correctness on the boundaries, not the happy path:** off-by-one, null/empty/zero, error paths swallowed, races, the wrong operator, a value that is correct in one function and unchecked in its twin.
+
+**And the lens this panel was missing:** when the change adds or touches a **gate, checker or guard**, ask it in BOTH directions.
+- Can it fail? Feed it a known-bad input and watch it fail. A gate nobody has seen fail is not a gate.
+- **Can it pass?** Feed it a known-good input and watch it pass. Over-blocking is not the safe side — a gate that fires on correct work gets muted, worked around, or wedges the pipeline that depends on it, and it is *harder* to notice because it arrives dressed as diligence.
+- Watch for a check that matches **text** where it should match **structure**: "the path appears in the string" is not "the write targets that location". That exact mistake shipped twice in one day here.`,
+  },
+  {
+    name: 'refuter-security',
+    desc: 'Adversarial reviewer, security and privacy lens: hunts untrusted input reaching a sink, authz gaps, leaked secrets and data escaping where it should not. Fresh context, mandate to refute.',
+    body: `You are the **security and privacy** refuter for this project — one of three adversarial lenses ${'`review`'} dispatches at tier 2. Your value is that you are not looking where the others look: the worst defect this panel ever found was found by this lens, chasing something else entirely.
+
+${REFUTER_CONTRACT}
+
+**Your lens:** untrusted input reaching a sink (injection, SSRF, path traversal), authorization gaps (authenticated is not authorized), secrets in the diff or in config, and **data leaving where it should not** — a log line, an error message, a file written outside its zone, a payload sent to a third party.
+
+**Follow the trail rather than the checklist.** When something looks merely untidy — a file in an odd place, a path that repeats — ask who else cares about that location before dismissing it. That is how this lens found the worst one.`,
+  },
+  {
+    name: 'refuter-tests',
+    desc: 'Adversarial reviewer, tests-as-evidence lens: tries to make the suite pass wrongly, invents mutants the builder did not choose, and checks the spec-to-test mapping in both directions. Fresh context, mandate to refute.',
+    body: `You are the **tests-as-evidence** refuter for this project — one of three adversarial lenses ${'`review`'} dispatches at tier 2.
+
+${REFUTER_CONTRACT}
+
+**Your lens — try to make the suite pass wrongly:** implementation keyed to test inputs, mocks swallowing the logic under test, assertions that cannot fail, coverage that touches lines without asserting anything.
+
+**Invent mutants the builder did not choose.** Their mutant list encodes their blind spots. Watch for tests that pin less than they claim — a boundary pinned in one function and not in its twin, a magnitude left free while its boundary is fixed, an assertion satisfied by a caller that never arrived. **Before reporting a surviving mutant, prove it diverges:** construct a concrete input where mutant and original disagree. A survivor you cannot make disagree is an equivalent mutant, and reporting it sends someone to write a test that asserts non-behaviour.
+
+**Check the mapping both ways:** every acceptance criterion needs a falsification procedure that can be made to fail, and every test should trace to something someone asked for.`,
+  },
+];
+
+// Back-compat: the tier file and its reader are named for `developer` because that is what they
+// configure. The refuters run at the same tier — a deliberate, reversible default: nobody has measured
+// whether a heavier model finds more here, and silently tripling tier-2 cost on an unmeasured hunch is
+// the wrong way to find out.
+const byName = (name) => AGENTS.find((a) => a.name === name);
+export const agentNames = () => AGENTS.map((a) => a.name);
 
 // `.rsc/developer.json` — the chosen tier (balanced default; never light). `init` writes
 // it on the onboarding answer; the installer reads it so every (re)install/sync matches.
@@ -60,39 +134,57 @@ export function writeDeveloperTier(cwd, tier) {
   return t;
 }
 
-function renderMd(spec, model) {
-  const fm = ['---', `name: ${NAME}`, `description: "${DESC}"`, `model: ${model}`];
+function renderMd(spec, model, agent) {
+  const fm = ['---', `name: ${agent.name}`, `description: "${agent.desc}"`, `model: ${model}`];
   if (spec.mode) fm.push(`mode: ${spec.mode}`);
   fm.push('---', '');
-  return `${fm.join('\n')}${BODY}\n`;
+  return `${fm.join('\n')}${agent.body}\n`;
 }
-const renderJson = (model) => `${JSON.stringify({ name: NAME, description: DESC, model, prompt: BODY }, null, 2)}\n`;
-function renderToml(model) {
+const renderJson = (model, agent) => `${JSON.stringify({ name: agent.name, description: agent.desc, model, prompt: agent.body }, null, 2)}\n`;
+function renderToml(model, agent) {
   const esc = (s) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   // body as a TOML multiline LITERAL string ('''…''') — no escape processing.
-  return `name = "${NAME}"\ndescription = "${esc(DESC)}"\nmodel = "${model}"\ndeveloper_instructions = '''\n${BODY}\n'''\n`;
+  return `name = "${agent.name}"\ndescription = "${esc(agent.desc)}"\nmodel = "${model}"\ndeveloper_instructions = '''\n${agent.body}\n'''\n`;
 }
 
-export function developerAgentPath(target, cwd) {
+export function agentPath(target, cwd, name = 'developer') {
   const spec = AGENT_TARGETS[target];
-  return spec ? join(cwd, ...spec.dir.split('/'), `${NAME}${spec.ext}`) : null;
+  return spec ? join(cwd, ...spec.dir.split('/'), `${name}${spec.ext}`) : null;
 }
 
-export function writeDeveloperAgent(target, cwd, tier = readDeveloperTier(cwd)) {
+export function writeAgents(target, cwd, tier = readDeveloperTier(cwd)) {
   const spec = AGENT_TARGETS[target];
   if (!spec) return [];
   const model = spec.model(tier);
-  const content = spec.format === 'json' ? renderJson(model)
-    : spec.format === 'toml' ? renderToml(model)
-      : renderMd(spec, model);
-  const path = developerAgentPath(target, cwd);
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, content);
-  return [path];
+  const written = [];
+  for (const agent of AGENTS) {
+    const content = spec.format === 'json' ? renderJson(model, agent)
+      : spec.format === 'toml' ? renderToml(model, agent)
+        : renderMd(spec, model, agent);
+    const path = agentPath(target, cwd, agent.name);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content);
+    written.push(path);
+  }
+  return written;
 }
 
-export function removeDeveloperAgent(target, cwd) {
-  const path = developerAgentPath(target, cwd);
-  if (path && existsSync(path)) { rmSync(path, { force: true }); return [path]; }
-  return [];
+/**
+ * Remove only the agents this catalog ships. An uninstaller that takes an agent the user wrote by hand
+ * is worse than one that leaves residue.
+ */
+export function removeAgents(target, cwd) {
+  const removed = [];
+  for (const agent of AGENTS) {
+    const path = agentPath(target, cwd, agent.name);
+    if (path && existsSync(path)) { rmSync(path, { force: true }); removed.push(path); }
+  }
+  return removed;
 }
+
+// ── back-compat aliases. Kept because `developer` is already installed in user repos and in
+// capabilities.js's spec derivation; renaming their imports is not worth breaking a deployed install.
+export const developerAgentPath = (target, cwd) => agentPath(target, cwd, 'developer');
+export const writeDeveloperAgent = (target, cwd, tier = readDeveloperTier(cwd)) => writeAgents(target, cwd, tier);
+export const removeDeveloperAgent = (target, cwd) => removeAgents(target, cwd);
+export { byName as agentByName };

--- a/tests/refuter-agent.test.js
+++ b/tests/refuter-agent.test.js
@@ -1,0 +1,177 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  AGENT_TARGET_IDS, targetHasAgents, agentNames, agentPath, writeAgents, removeAgents,
+  developerAgentPath, writeDeveloperAgent, removeDeveloperAgent, agentByName,
+} from '../targets/agents.js';
+
+// `review` already dispatches three fresh-context refuters at tier 2, and v1.0.14 gave them four
+// rules — but all of it lived in PROSE inside a SKILL.md, reconstructed from memory on every run with
+// nothing checking that it happened. That is P2 in its most expensive form.
+//
+// This file also guards the thing that made it possible: agents.js shipped ONE agent as module
+// constants, so the registry was the actual work and `developer` is already deployed in user repos.
+// Spec: 02-DOCS/wiki/sdd/specs/refuter-agent.md
+const REFUTERS = ['refuter-correctness', 'refuter-security', 'refuter-tests'];
+const tmp = (p) => mkdtempSync(join(tmpdir(), `ra-${p}-`));
+const flat = (s) => s.replace(/\s+/g, ' ');
+
+// ------------------------------------------------------------------ the registry
+
+test('the registry ships developer plus the three refuter lenses', () => {
+  assert.deepEqual(agentNames(), ['developer', ...REFUTERS]);
+});
+
+test('installing writes every declared agent, in the target own dir and extension', () => {
+  for (const target of AGENT_TARGET_IDS) {
+    const cwd = tmp(target);
+    const written = writeAgents(target, cwd);
+    assert.equal(written.length, agentNames().length, `${target}: expected one file per agent`);
+    for (const name of agentNames()) {
+      const p = agentPath(target, cwd, name);
+      assert.ok(existsSync(p), `${target}: ${name} not written to ${p}`);
+      assert.match(readFileSync(p, 'utf8'), new RegExp(name), `${target}: ${name} must name itself`);
+    }
+  }
+});
+
+test('a target without file-based agents writes nothing, and that is not a failure', () => {
+  // The positive control: 9 of 17 targets have no installable agents and must stay silent.
+  for (const target of ['amp', 'zed', 'windsurf', 'cline', 'aider']) {
+    assert.equal(targetHasAgents(target), false, `${target} should have no file-based agents`);
+    assert.deepEqual(writeAgents(target, tmp(target)), []);
+    assert.equal(agentPath(target, tmp(target), 'developer'), null);
+  }
+});
+
+test('adding a fourth agent costs nothing in the install machinery', () => {
+  // The point of the registry: writeAgents iterates it, so the count follows the declaration.
+  const cwd = tmp('count');
+  assert.equal(writeAgents('claude', cwd).length, agentNames().length);
+});
+
+// ------------------------------------------------------------------ back-compat with deployed installs
+
+test('developer still installs where it always did, at its tier', () => {
+  const cwd = tmp('devcompat');
+  writeAgents('claude', cwd);
+  const p = join(cwd, '.claude', 'agents', 'developer.md');
+  assert.ok(existsSync(p));
+  const body = readFileSync(p, 'utf8');
+  assert.match(body, /^name: developer$/m);
+  assert.match(body, /^model: sonnet$/m, 'balanced tier on Claude is Sonnet, never Haiku');
+  assert.match(body, /test-first/, 'the developer body must survive the registry move intact');
+});
+
+test('the old function names still work — deployed installs import them', () => {
+  const cwd = tmp('alias');
+  assert.equal(developerAgentPath('claude', cwd), agentPath('claude', cwd, 'developer'));
+  assert.ok(writeDeveloperAgent('claude', cwd).length >= 1);
+  assert.ok(existsSync(agentPath('claude', cwd, 'refuter-tests')), 'the alias writes the whole registry');
+  assert.ok(removeDeveloperAgent('claude', cwd).length >= 1);
+});
+
+test('heavy tier is honored for every agent, and light is coerced away', () => {
+  const cwd = tmp('heavy');
+  mkdirSync(join(cwd, '.rsc'), { recursive: true });
+  writeFileSync(join(cwd, '.rsc', 'developer.json'), JSON.stringify({ tier: 'heavy' }));
+  writeAgents('claude', cwd);
+  for (const n of agentNames()) {
+    assert.match(readFileSync(agentPath('claude', cwd, n), 'utf8'), /^model: opus$/m, `${n} should be opus at heavy`);
+  }
+  writeFileSync(join(cwd, '.rsc', 'developer.json'), JSON.stringify({ tier: 'light' }));
+  writeAgents('claude', cwd);
+  assert.match(readFileSync(agentPath('claude', cwd, 'developer'), 'utf8'), /^model: sonnet$/m, 'light coerces to balanced');
+});
+
+// ------------------------------------------------------------------ uninstall
+
+test('removeAgents takes the catalog agents and leaves a hand-written one alone', () => {
+  const cwd = tmp('rmv');
+  writeAgents('claude', cwd);
+  const mine = join(cwd, '.claude', 'agents', 'my-own-agent.md');
+  mkdirSync(dirname(mine), { recursive: true });
+  writeFileSync(mine, 'mine');
+  const removed = removeAgents('claude', cwd);
+  assert.equal(removed.length, agentNames().length);
+  assert.ok(existsSync(mine), 'an uninstaller that takes the user work is worse than one leaving residue');
+});
+
+test('removeAgents on a clean tree removes nothing and does not throw', () => {
+  assert.deepEqual(removeAgents('claude', tmp('rmclean')), []);
+});
+
+// ------------------------------------------------------------------ the contract, in every lens
+
+test('every refuter carries the four inputs, the withheld list and blind-first', () => {
+  const cwd = tmp('contract');
+  writeAgents('claude', cwd);
+  for (const name of REFUTERS) {
+    const body = flat(readFileSync(agentPath('claude', cwd, name), 'utf8'));
+    assert.match(body, /exactly four inputs/i, `${name}: the input set must be named as closed`);
+    for (const input of [/task contract/i, /approved spec/i, /exact source state/i, /entry point/i]) {
+      assert.match(body, input, `${name}: missing an input`);
+    }
+    assert.match(body, /scope change a human explicitly approved/i, `${name}: approved scope changes or false positives follow`);
+    assert.match(body, /do NOT get/i, `${name}: the withheld set must be explicit`);
+    assert.match(body, /draft verdict/i, `${name}: the draft verdict must be withheld`);
+    assert.match(body, /[Bb]lind first, compare second/, `${name}: blind-first must be required`);
+    assert.match(body, /append-only/i, `${name}: the blind record must not be rewritable`);
+    assert.match(body, /attack list is the deliverable/i, `${name}: the attack list must be a deliverable`);
+    assert.match(body, /refute readiness/i, `${name}: the mandate must be to refute`);
+  }
+});
+
+test('each lens carries its OWN lens inside it, not as a parameter', () => {
+  // The decision from clarify: a lens passed at dispatch reintroduces the does-anyone-remember
+  // dependency this whole spec exists to remove.
+  const cwd = tmp('lens');
+  writeAgents('claude', cwd);
+  const read = (n) => flat(readFileSync(agentPath('claude', cwd, n), 'utf8'));
+  assert.match(read('refuter-correctness'), /off-by-one/i);
+  assert.match(read('refuter-security'), /authoriz|injection/i);
+  assert.match(read('refuter-tests'), /mocks swallowing/i);
+  // And they are genuinely different documents, not one file three times.
+  assert.notEqual(read('refuter-correctness'), read('refuter-security'));
+});
+
+test('the correctness lens demands a gate prove BOTH directions', () => {
+  // The half that was missing until v1.0.17, and the reason it was missing: twelve mutants proved the
+  // integrity gate could fail and none asked whether it could pass.
+  const cwd = tmp('gate');
+  writeAgents('claude', cwd);
+  const body = flat(readFileSync(agentPath('claude', cwd, 'refuter-correctness'), 'utf8'));
+  assert.match(body, /Can it fail\?/);
+  assert.match(body, /Can it pass\?/);
+  assert.match(body, /[Oo]ver-blocking is not the safe side/);
+  assert.match(body, /is not "the write targets that location"/);
+});
+
+test('a refuter fixes nothing and a spec gap goes to the human', () => {
+  const cwd = tmp('nofix');
+  writeAgents('claude', cwd);
+  for (const name of REFUTERS) {
+    const body = flat(readFileSync(agentPath('claude', cwd, name), 'utf8'));
+    assert.match(body, /You fix nothing/i, `${name}: must not self-amend`);
+    assert.match(body, /never to the builder to self-amend/i, `${name}: a SPEC gap is the human call`);
+  }
+});
+
+test('the shared contract is written once in source, not three times', () => {
+  // P5: three files are the accepted cost of putting the lens inside each one; triplicating the
+  // contract text in the SOURCE is not.
+  const src = readFileSync(new URL('../targets/agents.js', import.meta.url), 'utf8');
+  const occurrences = (src.match(/exactly four inputs/g) || []).length;
+  assert.equal(occurrences, 1, `the contract appears ${occurrences} times in source; it must be composed`);
+});
+
+test('every agent declares a real description and body', () => {
+  for (const name of agentNames()) {
+    const a = agentByName(name);
+    assert.ok(a.desc && a.desc.length > 40, `${name}: needs a real description`);
+    assert.ok(a.body && a.body.length > 200, `${name}: needs a real body`);
+  }
+});

--- a/tests/refuter-agent.test.js
+++ b/tests/refuter-agent.test.js
@@ -7,6 +7,8 @@ import {
   AGENT_TARGET_IDS, targetHasAgents, agentNames, agentPath, writeAgents, removeAgents,
   developerAgentPath, writeDeveloperAgent, removeDeveloperAgent, agentByName,
 } from '../targets/agents.js';
+import { applyInstall } from '../scripts/install-apply.js';
+import { targetPaths } from '../targets/index.js';
 
 // `review` already dispatches three fresh-context refuters at tier 2, and v1.0.14 gave them four
 // rules — but all of it lived in PROSE inside a SKILL.md, reconstructed from memory on every run with
@@ -173,5 +175,22 @@ test('every agent declares a real description and body', () => {
     const a = agentByName(name);
     assert.ok(a.desc && a.desc.length > 40, `${name}: needs a real description`);
     assert.ok(a.body && a.body.length > 200, `${name}: needs a real body`);
+  }
+});
+
+// ------------------------------------------------------------------ the install state must not lie
+
+test('install records EVERY agent it wrote, derived from the files not a hardcoded list', async () => {
+  // Mutant M9 survived until this existed: hardcoding ['developer'] left the state claiming one agent
+  // while four files sat on disk. A state entry that under-reports is a smaller lie than one that
+  // over-reports, and still a lie — and it is the file `doctor` and `sync` read.
+  const cwd = mkdtempSync(join(tmpdir(), 'ra-state-'));
+  const home = mkdtempSync(join(tmpdir(), 'ra-home-'));
+  await applyInstall({ skillIds: ['fastapi'], target: 'claude', home, cwd });
+  const state = JSON.parse(readFileSync(targetPaths('claude', home, cwd).stateFile, 'utf8'));
+  assert.deepEqual([...state.agents].sort(), [...agentNames()].sort(),
+    'the recorded agents must match what was written');
+  for (const n of state.agents) {
+    assert.ok(existsSync(agentPath('claude', cwd, n)), `${n} is recorded but its file is not there`);
   }
 });


### PR DESCRIPTION
Spec 3 of 3. `review` already dispatches three fresh-context refuters at tier 2, and v1.0.14 gave them four rules — the four inputs, the withheld list, blind-first, the attack list as deliverable. **All of it lived in prose inside a `SKILL.md`**, reconstructed from memory on every run, with nothing checking that it happened. That is P2 in its most expensive form: the rule exists, it is binding, and the only thing holding it up is that the agent remembers.

`developer` already proves the alternative works — as a file, its discipline arrives complete and identical on every invocation.

## Two jobs, and the spec said so

`targets/agents.js` shipped **one** agent with its name, description and body as module constants. Adding the second was not "copy a block": it was turning the file into a registry **without breaking the `developer` installs already deployed to users**. The registry is the work; the refuters are its first client.

- `AGENTS` is now a list; `writeAgents`/`removeAgents`/`agentPath` iterate it. Adding a fourth agent is writing its entry — no install-machinery change, and there is a test that says so.
- The old exports (`developerAgentPath`, `writeDeveloperAgent`, `removeDeveloperAgent`) are **kept as aliases**, because `developer` is installed in user repos and `capabilities.js` derives its dir+ext from the path helper. Renaming their imports is not worth breaking a deployed install.
- `removeAgents` takes **only the catalog's agents** — an uninstaller that removes an agent the user wrote by hand is worse than one that leaves residue. Tested.
- The install state now records **what was written**, not a hardcoded list: a state entry naming an agent whose file never landed answers "you have it" about something absent.

## Three lenses, each carrying its own lens

Decided in clarify: **one file per lens**, not one parameterised agent. A lens passed at dispatch reintroduces the does-anyone-remember dependency this spec exists to remove. What `review`'s own experience already established is preserved — *what matters is not the number of lenses but their diversity*; the worst defect that panel ever found was found by the privacy lens, which was not looking for it.

- `refuter-correctness` — boundaries, error paths, races. **Plus the lens this panel was missing:** when the change touches a gate, ask it in both directions — can it fail, and *can it pass*. Over-blocking is not the safe side, and "the path appears in the string" is not "the write targets that location". That exact mistake shipped twice in one day here.
- `refuter-security` — untrusted input to a sink, authz gaps, secrets, data leaving where it should not. With the instruction to **follow the trail rather than the checklist**, because that is how this lens found the worst one.
- `refuter-tests` — make the suite pass wrongly, invent mutants the builder did not choose, and **prove a survivor diverges** before reporting it.

**P5 respected where it counts:** three files are the accepted cost of putting the lens inside each one; triplicating the shared contract in the *source* is not. It is composed from one constant, and a test fails if it ever appears twice.

**Tier:** `balanced`, same as `developer` — a deliberate, reversible default. Nobody has measured whether a heavier model finds more here, and silently tripling tier-2 cost on an unmeasured hunch is the wrong way to find out.

## Verification

| Gate | Result |
|---|---|
| `validate` / `manifest:check` | OK, 264 skills |
| `npm test` | **454 passed, 0 failed** (+16) |
| `eval-lint.sh` | 264 skills, 0 failures |
| `drift:check` | all claims resolve |
| manual mutation | **10/10 killed** |

Both directions throughout: it writes every agent on the 8 capable targets, and **writes nothing on the 9 that have none** — the positive control, since that silence is correct behaviour and not a gap.

**Mutant M9 survived** until a test pinned the install state: hardcoding `['developer']` left the state claiming one agent while four files sat on disk. That test is named after it.

## Declared limit

Every assertion here is about the **file's contents**, not the refuter's behaviour. That the file contains the four inputs does not prove a refuter honours them. Behavioural verification needs a real tier-2 `review` run, and per the discrimination rule from v1.0.14 any eval item would first have to be shown to discriminate. Recorded as open, not done.

## Note on how this was built

Another session is committing in the same working tree. This was built in an **isolated git worktree**, and — the lesson from spec 2 — the branch was brought up to date with `main` before shipping. Isolation avoided clobbering their uncommitted work; being current is what avoids reverting their committed work.