### PR TITLE
fix(knowledge): what three adversarial refuters found that I did not

### DIFF
--- a/scripts/knowledge-doctor.js
+++ b/scripts/knowledge-doctor.js
@@ -19,9 +19,16 @@ import { diagnose, CLASSES } from './lib/knowledge-doctor.js';
 const REPO = join(dirname(fileURLToPath(import.meta.url)), '..');
 const WIKI = join(REPO, '02-DOCS', 'wiki');
 
-const walk = (dir) => readdirSync(dir).flatMap((e) => {
-  const p = join(dir, e);
-  return statSync(p).isDirectory() ? walk(p) : (p.endsWith('.md') ? [p] : []);
+// withFileTypes, NOT statSync — this matches scripts/drift-check.js:167, the precedent the plan cited
+// as exact and then diverged from. statSync FOLLOWS symlinks, so a symlink under the wiki let the walk
+// read outside the declared zone (reporting the logical path, hiding the escape), a dangling symlink
+// crashed the whole report with ENOENT, and a symlink cycle crashed it with ELOOP. dirent.isDirectory()
+// does none of that: a symlink is neither a file nor a directory here, so it is skipped.
+const walk = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+  const p = join(dir, e.name);
+  if (e.isDirectory()) return walk(p);
+  if (e.isFile() && p.endsWith('.md')) return [p];
+  return []; // symlinks, sockets, anything else: not our business, and not a crash
 });
 
 // Injected so the pure library never touches git. Cached: the same ref is asked about repeatedly.
@@ -48,19 +55,49 @@ function main() {
   const indexPath = join(WIKI, 'index.md');
   const indexText = existsSync(indexPath) ? readFileSync(indexPath, 'utf8') : null;
 
+  // AC7 says an unreadable document is a candidate with its reason, never a silent skip. The first
+  // version read "unreadable" as "frontmatter unparseable" only, so a chmod-000 file or a dangling
+  // symlink threw out of readFileSync and took the WHOLE report with it — worse than a silent skip.
+  const unreadable = [];
   const docs = files.map((p) => {
     const rel = relative(WIKI, p);
+    let text;
+    try {
+      text = readFileSync(p, 'utf8');
+    } catch (e) {
+      unreadable.push({
+        path: relative(REPO, p), line: 1, cls: 'fuera-de-sitio', uncertain: true,
+        signal: `no se pudo leer el fichero (${e.code || e.message})`,
+        expected: 'un documento legible', found: e.code || 'error de lectura',
+      });
+      return null;
+    }
     return {
       path: relative(REPO, p),
       rel,
       dir: dirname(rel) === '.' ? '' : dirname(rel),
-      text: readFileSync(p, 'utf8'),
+      text,
       // Only artifacts the chain consumes are expected in the Knowledge map; an article is not.
       indexable: rel.startsWith('sdd/specs/') || rel.startsWith('sdd/verifications/'),
     };
-  });
+  }).filter(Boolean);
 
-  const report = diagnose({ docs, indexText, refExists });
+  // Project artifacts outside the wiki: skill ids and script basenames. The library cannot read the
+  // repo (it is pure by design), so the caller that can, does.
+  const extraSlugs = [];
+  for (const [dir, strip] of [['skills', null], ['scripts', /\.(js|mjs|sh)$/], ['scripts/lib', /\.(js|mjs)$/]]) {
+    try {
+      for (const e of readdirSync(join(REPO, dir), { withFileTypes: true })) {
+        if (strip && e.isFile()) extraSlugs.push(e.name.replace(strip, ''));
+        else if (!strip && e.isDirectory()) extraSlugs.push(e.name);
+      }
+    } catch { /* a missing directory is not an error here */ }
+  }
+
+  const report = diagnose({ docs, indexText, refExists, extraSlugs });
+  // Unreadable files are candidates too, and they sort first: a document nobody can open is the one
+  // whose staleness nobody can check.
+  if (unreadable.length) report.candidates = [...unreadable, ...report.candidates];
   if (asJson) { console.log(JSON.stringify(report, null, 2)); process.exit(0); }
 
   const byClass = (c) => report.candidates.filter((x) => x.cls === c);
@@ -69,10 +106,15 @@ function main() {
     console.log('Sin candidatos. Nada que triar.\n');
   } else {
     console.log(`${report.candidates.length} candidato(s), ordenados por coste de equivocarse:\n`);
+    // Filenames are interpolated into markdown, and a filename may contain newlines and backticks. A
+    // crafted name rendered a structurally valid FORGED candidate while the tally below still read 0 —
+    // and the consumer of this report (knowledge-ops) archives and overwrites files. Neutralise the
+    // three characters that can break out of the line.
+    const safe = (s) => String(s).replace(/[\r\n]+/g, '⏎').replace(/`/g, "'");
     for (const c of report.candidates) {
-      console.log(`- **${c.cls}** · \`${c.path}:${c.line}\`${c.uncertain ? ' · _incierto_' : ''}`);
-      console.log(`  - señal: ${c.signal}`);
-      console.log(`  - esperado: ${c.expected} · encontrado: ${c.found}`);
+      console.log(`- **${c.cls}** · \`${safe(c.path)}:${c.line}\`${c.uncertain ? ' · _incierto_' : ''}`);
+      console.log(`  - señal: ${safe(c.signal)}`);
+      console.log(`  - esperado: ${safe(c.expected)} · encontrado: ${safe(c.found)}`);
     }
     console.log('');
     for (const [label, cls] of [['se contradice', CLASSES.CONTRADICTS], ['ya no aplica', CLASSES.STALE], ['fuera de sitio', CLASSES.MISPLACED]]) {

--- a/scripts/lib/knowledge-doctor.js
+++ b/scripts/lib/knowledge-doctor.js
@@ -27,7 +27,11 @@ export const CLASSES = { STALE: 'ya-no-aplica', MISPLACED: 'fuera-de-sitio', CON
 
 // Out of scope, named so their absence is not read as cleanliness.
 export const NOT_LOOKED_AT = [
-  'La PRIMERA instancia de una desviación de convención: las convenciones se derivan del wiki en cada corrida, así que un único fichero fuera de sitio define su propia ubicación como válida. Deliberado — hardcodear la tabla sería una segunda copia de la verdad que deriva de ella.',
+  // This entry described the PRE-FIX dead-code behaviour and survived the fix that removed it: a stale
+  // claim inside the tool built to find stale claims. Rewritten to name the mechanism that actually
+  // ships — the 75% dominant-share threshold — and its real blind spot.
+  'Un tipo con pocos documentos: una carpeta solo se reconoce como el hogar de un `type:` cuando concentra el 75% de sus documentos, así que un tipo con 3 o menos ejemplares no tiene hogar y su ubicación nunca se juzga. Deliberado — la alternativa es marcar trabajo correcto (`article` vive legítimamente en tres carpetas).',
+  'Documentos alcanzados por symlink: el recorrido usa `withFileTypes` y salta los enlaces, así que un `.md` enlazado dentro del wiki no se audita. Es el precio de impedir que el recorrido se escape de `02-DOCS/` siguiendo un enlace.',
   'Contradicción general entre documentos (exige comparación semántica; fuera por clarify 18-08).',
   'Obsolescencia semántica de prosa: si un párrafo sobre arquitectura sigue siendo cierto.',
   'La memoria del proyecto: drift-check ya resuelve sus rutas vía memoryDir(); su auditoría semántica queda fuera.',
@@ -58,9 +62,43 @@ export function parseFrontmatter(text) {
 }
 
 /** Does this document declare itself the single source of a fact? Matched on normalized prose. */
+/**
+ * Does this document declare ITSELF the single source of a fact?
+ *
+ * The first version matched `fuente única` / `single source of` anywhere in the file, and an adversarial
+ * review measured what that admits: on a 51-document wiki, **7 documents passed and only 1 actually
+ * declared single-sourcehood**. The other six were meta-documents merely DISCUSSING the concept — this
+ * detector's own spec, its own plan, and three verification records — and five of them had an unrelated
+ * first table sitting there as a denominator. One ordinary edit adding "probado 9 veces" to any of their
+ * descriptions would have fabricated a contradiction against a table with nothing to do with the number.
+ * That is over-firing on correct work, the direction P7 and the v1.0.17 rule both name as the dangerous
+ * one, and the whole narrow scope agreed in clarify rested on this gate being narrow.
+ *
+ * So the phrase must now be SELF-REFERENTIAL: the document has to point at itself ("esta tabla", "this
+ * table", "aquí") as the place the fact lives. Talking about single sources in the abstract no longer
+ * qualifies.
+ */
 export function declaresSingleSource(text) {
   const p = normalizeProse(text);
-  return /en ning[uú]n otro sitio|and nowhere else|fuente [uú]nica|single source of/i.test(p);
+  // A locator ("en esta tabla", "in this table", "aquí") within a short window of the exclusivity
+  // claim. The window keeps it one sentence: a doc that says "esta tabla" in one paragraph and
+  // "fuente única" three pages later is not declaring anything.
+  const claim = /(en esta (tabla|lista)|in this (table|list)|aqu[ií] y en ning|here and nowhere)/i;
+  const exclusive = /(en ning[uú]n otro sitio|and nowhere else|nowhere else|fuente [uú]nica de|single source of truth for)/i;
+  if (!claim.test(p) || !exclusive.test(p)) return false;
+  // And they must be near each other, or two unrelated sentences pass by coincidence.
+  const ci = p.search(claim);
+  const ei = p.search(exclusive);
+  if (Math.abs(ci - ei) > 160) return false;
+  // A QUOTED phrase is a citation, not a declaration. Measured: two documents still passed after the
+  // narrowing above, and both were quoting this repo's own pattern registry — a spec and a verification
+  // record. A document declares in its own voice; one discussing the idea quotes someone else's. Both
+  // are exactly the kind of document whose description naturally gains "probado 9 veces", which is how
+  // the fabricated contradiction would have arrived.
+  const around = p.slice(Math.max(0, ei - 60), ei + 60);
+  const quoted = /["«“][^"»”]{0,120}$/.test(p.slice(Math.max(0, ei - 120), ei))
+    && /^[^"«“]{0,120}["»”]/.test(p.slice(ei));
+  return !quoted || /\*\*/.test(around) === false ? !quoted : false;
 }
 
 const WORD_NUMBERS = {
@@ -72,9 +110,14 @@ const WORD_NUMBERS = {
  * A count asserted in the FRONTMATTER only. Body prose is not a usable signal: the live case's own
  * document contains "7 veces" inside a table cell describing something else entirely.
  */
+export const MAX_REFS_PER_DOC = 32;
+// A frontmatter value longer than this is not a title or a description. Bound before matching: the
+// digit-run pattern is quadratic, measured at 21.5s on an 160k-character value.
+const MAX_FM_VALUE = 2000;
+
 export function statedCountInFrontmatter(fields) {
   for (const key of ['description', 'title']) {
-    const v = String(fields[key] || '');
+    const v = String(fields[key] || '').slice(0, MAX_FM_VALUE);
     const digits = /(\d+)\s+(?:veces|times|apariciones|occurrences)/i.exec(v);
     if (digits) return { value: Number(digits[1]), source: key, literal: digits[0] };
     const words = new RegExp(`\\b(${Object.keys(WORD_NUMBERS).join('|')})\\s+(?:veces|times)`, 'i').exec(v);
@@ -83,9 +126,22 @@ export function statedCountInFrontmatter(fields) {
   return null;
 }
 
-/** Data rows of the first markdown table (header and separator excluded). */
+/**
+ * Blank out fenced code blocks, keeping the line count intact so reported line numbers stay true.
+ * Without this, an illustrative table inside ``` fences counted as the canonical one: a real 3-row
+ * table read as 1 row, and the report printed two wrong numbers as its evidence.
+ */
+export function stripFences(body) {
+  let inFence = false;
+  return String(body || '').split('\n').map((l) => {
+    if (/^\s*(```|~~~)/.test(l)) { inFence = !inFence; return ''; }
+    return inFence ? '' : l;
+  }).join('\n');
+}
+
+/** Data rows of the first markdown table (header and separator excluded), fences excluded. */
 export function firstTableRowCount(body) {
-  const lines = String(body || '').split('\n');
+  const lines = stripFences(body).split('\n');
   let i = lines.findIndex((l) => /^\s*\|.*\|/.test(l) && /\|/.test(l));
   if (i === -1) return null;
   if (!/^\s*\|[\s:|-]+\|/.test(lines[i + 1] || '')) return null; // header must be followed by a separator
@@ -107,9 +163,29 @@ export function findStaleClaims({ path, text, refExists }) {
   if (!status) return [];
   const out = [];
   const refs = new Set();
-  for (const m of status.matchAll(/\b([0-9a-f]{7,8})\b/g)) refs.add(m[1]);
-  for (const m of status.matchAll(/\bv?(\d+\.\d+\.\d+)\b/g)) refs.add(`v${m[1]}`);
-  for (const ref of refs) {
+  // A short hex run is only a commit if it is NOT all digits: `20260818` is a compact date, and the
+  // old pattern reported it as a missing commit. Verified: `status: implementada el 20260818` produced
+  // a candidate for a ref that never existed as a ref.
+  for (const m of status.matchAll(/\b([0-9a-f]{7,8})\b/g)) {
+    if (/^\d+$/.test(m[1])) continue;
+    refs.add(m[1]);
+  }
+  // A version is only a tag claim when the text presents it as one. `requiere node 18.0.0 y ajv 8.18.0`
+  // used to yield two candidates for tags `v18.0.0` and `v8.18.0` — dependency versions read as releases.
+  for (const m of status.matchAll(/\b(?:v|versión |version |publicada en |released in |released as )(\d+\.\d+\.\d+)\b/gi)) {
+    refs.add(`v${m[1]}`);
+  }
+  // Cap the spawns a single document can cause: one status: with 3000 distinct refs spawned 6002 git
+  // processes and took 76s. A document citing more than this is not making a traceable claim.
+  const capped = [...refs].slice(0, MAX_REFS_PER_DOC);
+  if (refs.size > MAX_REFS_PER_DOC) {
+    out.push({
+      path, line: lineOf(text, 'status:'), cls: CLASSES.STALE, uncertain: true,
+      signal: `status: cita ${refs.size} referencias; solo se comprobaron las primeras ${MAX_REFS_PER_DOC}`,
+      expected: `un status: con referencias acotadas`, found: `${refs.size} referencias`,
+    });
+  }
+  for (const ref of capped) {
     if (refExists(ref)) continue;
     out.push({
       path, line: lineOf(text, 'status:'), cls: CLASSES.STALE,
@@ -118,6 +194,21 @@ export function findStaleClaims({ path, text, refExists }) {
     });
   }
   return out;
+}
+
+/**
+ * Is there an actual index ROW for this path — a list item whose markdown link targets it?
+ *
+ * The first version was `indexText.includes(doc.rel)`, a substring test, so a path merely MENTIONED in
+ * prose silenced the check: "Borramos sdd/specs/x.md porque ya no aplica" counted as indexed. That is
+ * verbatim the mistake this repo recorded as having shipped twice in one day — "the path appears in the
+ * string" is not "the row exists" — and it fails in the under-firing direction, which is the quiet one.
+ */
+export function hasIndexRow(indexText, rel) {
+  if (!rel) return false;
+  const escaped = rel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const row = new RegExp(`^\\s*[-*]\\s.*\\]\\([^)]*${escaped}\\)`, 'm');
+  return row.test(String(indexText || ''));
 }
 
 /**
@@ -214,11 +305,49 @@ export function findMisplaced({ doc, conventions, indexText }) {
       });
     }
   }
-  if (indexText != null && doc.indexable && !indexText.includes(doc.rel)) {
+  if (indexText != null && doc.indexable && !hasIndexRow(indexText, doc.rel)) {
     out.push({
       path: doc.path, line: 1, cls: CLASSES.MISPLACED,
       signal: 'artefacto sin fila en el Knowledge map',
       expected: `una fila citando \`${doc.rel}\``, found: 'ninguna',
+    });
+  }
+  return out;
+}
+
+/**
+ * Class 2b — an entry in a canonical log that does not describe what that log says it contains.
+ *
+ * AC2 of the spec, and it was NOT implemented in the shipped version — found by two independent
+ * refuter lenses. It is not a nice-to-have: one of the three incidents that motivated the whole spec
+ * was four entries written into `decisions.md` by eval agents, about features nobody was building.
+ * Worse than absent, the disclosure list did not name it, so the report presented the canonical log as
+ * scanned and clean — affirming a check nobody performed.
+ *
+ * The signal has to be narrow or this becomes the noisiest detector in the tool. A canonical log
+ * declares its own subject in its opening prose ("Procedimientos que el asistente observó",
+ * "decisiones de alcance"). An entry is a candidate when its heading names a SLUG that exists nowhere
+ * in the project — because a decision about `magic-link-login` when no such spec, plan or artifact
+ * exists is either about someone else's work or about work nobody is doing.
+ */
+export function findLogIntruders({ path, text, knownSlugs }) {
+  if (!/decisions\.md$|automation-gaps\.md$/.test(path)) return [];
+  const out = [];
+  const lines = String(text || '').split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const h = /^##\s+\d{4}-\d{2}-\d{2}\s*[—·-]\s*(.+)$/.exec(lines[i]);
+    if (!h) continue;
+    // A slug-shaped token in the heading: lowercase words joined by hyphens, at least two parts.
+    const slugs = (h[1].match(/`?\b([a-z][a-z0-9]+(?:-[a-z0-9]+)+)\b`?/g) || [])
+      .map((s) => s.replace(/`/g, ''));
+    const orphans = slugs.filter((s) => !knownSlugs.has(s));
+    // Only flag when EVERY slug in the heading is unknown: a heading mixing known and unknown terms is
+    // ordinary prose, not an entry about work that does not exist.
+    if (!slugs.length || orphans.length !== slugs.length) continue;
+    out.push({
+      path, line: i + 1, cls: CLASSES.MISPLACED, uncertain: true,
+      signal: `entrada cuyo asunto (${orphans.map((s) => `\`${s}\``).join(', ')}) no corresponde a ningún artefacto del proyecto`,
+      expected: 'una entrada sobre trabajo que existe', found: 'asunto sin artefacto',
     });
   }
   return out;
@@ -253,13 +382,26 @@ export function rank(candidates) {
 }
 
 /** The whole pass, over already-read documents. Pure: no fs, no git — both are injected. */
-export function diagnose({ docs, indexText, refExists }) {
+export function diagnose({ docs, indexText, refExists, extraSlugs = [] }) {
   const cands = [];
   const conventions = deriveConventions(docs);
+  // Slugs the project actually has, derived from the documents themselves (P3: the content is the
+  // ledger). A log entry whose subject is not in here is about work that does not exist.
+  // extraSlugs comes from the CLI, which knows the repo: skill ids and script basenames are project
+  // artifacts too. Deriving only from wiki filenames flagged `drift-check` — a real script — as work
+  // that does not exist.
+  const knownSlugs = new Set(extraSlugs);
+  for (const doc of docs) {
+    const base = (doc.rel || doc.path).split('/').pop().replace(/\.md$/, '').replace(/\.plan$/, '');
+    knownSlugs.add(base);
+    const fmSlug = parseFrontmatter(doc.text).fields.slug;
+    if (fmSlug) knownSlugs.add(fmSlug);
+  }
   for (const doc of docs) {
     cands.push(...findStaleClaims({ path: doc.path, text: doc.text, refExists }));
     cands.push(...findMisplaced({ doc, conventions, indexText }));
     cands.push(...findContradictions({ path: doc.path, text: doc.text }));
+    cands.push(...findLogIntruders({ path: doc.path, text: doc.text, knownSlugs }));
   }
   return { candidates: rank(cands), scanned: docs.length, notLookedAt: NOT_LOOKED_AT };
 }

--- a/tests/knowledge-doctor.test.js
+++ b/tests/knowledge-doctor.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
 import {
   normalizeProse, parseFrontmatter, declaresSingleSource, statedCountInFrontmatter,
   firstTableRowCount, findStaleClaims, findMisplaced, findContradictions, deriveConventions,
@@ -20,8 +21,17 @@ import {
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const WIKI = join(ROOT, '02-DOCS', 'wiki');
 
+// `rel` and `path` are DELIBERATELY different, as the CLI makes them (path = repo-relative,
+// rel = wiki-relative). The first version set `rel: path`, so the single field distinction the
+// index-row check rests on was invisible to every test: swapping the field survived the suite and
+// took the real wiki from 7 candidates to 37 false ones.
 const doc = (path, text, extra = {}) => ({
-  path, rel: path, dir: dirname(path) === '.' ? '' : dirname(path), text, indexable: false, ...extra,
+  path: `02-DOCS/wiki/${path}`,
+  rel: path,
+  dir: dirname(path) === '.' ? '' : dirname(path),
+  text,
+  indexable: false,
+  ...extra,
 });
 const fm = (fields, body = '') =>
   `---\n${Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join('\n')}\n---\n${body}`;
@@ -216,18 +226,119 @@ test('diagnose composes the three detectors and reports what it did not look at'
   const r = diagnose({ docs: [doc('harness/a.md', fm({ type: 'article' }))], indexText: '# i', refExists: () => true });
   assert.equal(r.scanned, 1);
   assert.ok(r.notLookedAt.length >= 4);
-  assert.ok(r.notLookedAt.some((n) => n.startsWith('La PRIMERA instancia')),
-    'the derived-convention blind spot must be declared verbatim, not hidden or mangled');
-  assert.deepEqual(r.notLookedAt, NOT_LOOKED_AT, 'the disclosure list must reach the report intact');
+  // NOT a deepEqual against NOT_LOOKED_AT: `diagnose` returns that very array, so the comparison was
+  // an identity check dressed as a content check — unfailable by construction. Pin the content instead.
+  assert.notEqual(r.notLookedAt.length, 0);
+  const disclosed = r.notLookedAt.join(' | ');
+  for (const must of ['75%', 'symlink', 'Contradicción general', 'memoria']) {
+    assert.ok(disclosed.includes(must), `the disclosure must still name: ${must}`);
+  }
+  assert.ok(
+    !disclosed.includes('define su propia ubicación como válida'),
+    'the pre-fix mechanism must not be described as the current blind spot — that was a stale claim inside the stale-claim detector',
+  );
 });
 
 // ----------------------------------------------------------------- against the real wiki
 
-test('on the real wiki: finds the live contradiction and nothing stale', () => {
-  if (!existsSync(WIKI)) return; // public checkout has no 02-DOCS (P9) — nothing to assert
-  const walk = (d) => readdirSync(d).flatMap((e) => {
-    const p = join(d, e);
-    return statSync(p).isDirectory() ? walk(p) : (p.endsWith('.md') ? [p] : []);
+test('diagnose COMPOSES all four detectors — each one is pinned by its own candidate', () => {
+  // The composition was unpinned: the only synthetic diagnose test asserted `scanned` and
+  // `notLookedAt`, never `candidates`. Removing findMisplaced took the real wiki from 7 candidates to
+  // 1, removing findStaleClaims silently deleted a whole class, and making it fabricate one candidate
+  // per document reported 54 — all three with the suite green.
+  const docs = [
+    doc('sdd/specs/stale.md', fm({ type: 'spec', status: 'implementada (deadbee)' })),
+    doc('harness/misplaced.md', fm({ type: 'verification' })),
+    doc('sdd/verifications/a.md', fm({ type: 'verification' })),
+    doc('sdd/verifications/b.md', fm({ type: 'verification' })),
+    doc('sdd/verifications/c.md', fm({ type: 'verification' })),
+    doc('harness/contra.md', fm({ description: 'encontrado diez veces' },
+      'vive en esta tabla y en ningún otro sitio\n\n| a |\n|---|\n| 1 |\n')),
+    doc('sdd/decisions.md', '# log\n\n## 2026-08-01 — sobre `un-slug-inexistente`\n\ntexto\n'),
+  ];
+  const r = diagnose({ docs, indexText: '# i', refExists: () => false });
+  const classes = new Set(r.candidates.map((c) => c.cls));
+  assert.ok(classes.has(CLASSES.STALE), 'findStaleClaims must reach the composed output');
+  assert.ok(classes.has(CLASSES.MISPLACED), 'findMisplaced must reach the composed output');
+  assert.ok(classes.has(CLASSES.CONTRADICTS), 'findContradictions must reach the composed output');
+  assert.ok(
+    r.candidates.some((c) => /decisions\.md/.test(c.path)),
+    'findLogIntruders must reach the composed output',
+  );
+  // And it must not fabricate: no candidate may name a document that is not in the input.
+  const known = new Set(docs.map((d) => d.path));
+  for (const c of r.candidates) assert.ok(known.has(c.path), `invented a candidate for ${c.path}`);
+});
+
+test('diagnose stays SILENT on a clean input — no candidate per document', () => {
+  // AC4 as a falsifiable procedure. A mutant that emits one candidate per doc reported 54 on the real
+  // wiki and survived, because nothing asserted the empty case at the composed level.
+  const docs = [
+    doc('harness/a.md', fm({ type: 'article' })),
+    doc('harness/b.md', fm({ type: 'article' })),
+    doc('harness/c.md', fm({ type: 'article' })),
+  ];
+  const r = diagnose({ docs, indexText: '# i', refExists: () => true });
+  assert.deepEqual(r.candidates, [], 'a clean input must produce nothing at all');
+});
+
+test('the index-row check needs the ROW, not the path mentioned in prose', () => {
+  // "the path appears in the string" is not "the row exists" — the mistake this repo recorded as having
+  // shipped twice in one day.
+  const d = doc('sdd/specs/x.md', fm({ type: 'spec' }), { indexable: true });
+  const conv = deriveConventions([d, doc('sdd/specs/y.md', fm({ type: 'spec' })), doc('sdd/specs/z.md', fm({ type: 'spec' }))]);
+  const mentioned = findMisplaced({ doc: d, conventions: conv, indexText: '# map\n\nBorramos sdd/specs/x.md porque ya no aplica.\n' });
+  assert.ok(
+    mentioned.some((c) => /sin fila/.test(c.signal)),
+    'a path mentioned as DELETED must not count as indexed',
+  );
+});
+
+test('the over-firing thresholds are pinned in the LOOSENING direction too', () => {
+  // They were pinned only against tightening: every mutant that made the tool NOISIER survived, which
+  // is the direction the change claims to protect against (P7, v1.0.17).
+  const twoDocs = [doc('brand/a.md', fm({ type: 'article' })), doc('brand/b.md', 'no frontmatter')];
+  assert.equal(
+    deriveConventions(twoDocs).typeRequiredDirs.has('brand'), false,
+    'a 2-document directory is too small to have a frontmatter convention (MIN_DOCS_FOR_TYPE_RULE)',
+  );
+  const twoDeviants = [
+    doc('sdd/specs/a.md', fm({ type: 'spec' })), doc('sdd/specs/b.md', fm({ type: 'spec' })),
+    doc('sdd/specs/c.md', 'none'), doc('sdd/specs/d.md', 'none'),
+  ];
+  assert.equal(
+    deriveConventions(twoDeviants).typeRequiredDirs.has('sdd/specs'), false,
+    'two deviants means the convention is not universal — at most ONE may deviate',
+  );
+  const thin = [doc('x/a.md', fm({ type: 't' })), doc('x/b.md', fm({ type: 't' })), doc('y/c.md', fm({ type: 't' }))];
+  assert.equal(
+    deriveConventions(thin).dominantHome.has('t'), false,
+    'a 2-in-A / 1-in-B type is 0.667 — below the dominant share, so nothing is out of place',
+  );
+});
+
+test('a document with valid frontmatter but no type: is flagged where the convention is universal', () => {
+  // This branch (the missing-`type:` one, distinct from unreadable frontmatter) had ZERO coverage:
+  // gutting it survived the suite.
+  const docs = [
+    doc('sdd/specs/a.md', fm({ type: 'spec' })), doc('sdd/specs/b.md', fm({ type: 'spec' })),
+    doc('sdd/specs/c.md', fm({ type: 'spec' })), doc('sdd/specs/d.md', fm({ title: 'sin tipo' })),
+  ];
+  const out = findMisplaced({ doc: docs[3], conventions: deriveConventions(docs), indexText: null });
+  assert.equal(out.length, 1);
+  assert.match(out[0].signal, /sin `type:`/);
+});
+
+test('on the real wiki: it does not fire on correct work, and STALE is genuinely silent', () => {
+  // DECOUPLED from the live defect. The previous version REQUIRED the contradiction in
+  // puertas-y-mecanismos.md to still exist, so curing the finding the report demands broke the suite —
+  // a gate that punishes fixing what it detects. And it injected refExists:()=>true, which makes STALE
+  // structurally incapable of firing, while its title claimed "and nothing stale".
+  if (!existsSync(WIKI)) return; // 02-DOCS is untracked (P9); in CI there is nothing to read
+  const walk = (d) => readdirSync(d, { withFileTypes: true }).flatMap((e) => {
+    const p = join(d, e.name);
+    if (e.isDirectory()) return walk(p);
+    return e.isFile() && p.endsWith('.md') ? [p] : [];
   });
   const docs = walk(WIKI).map((p) => {
     const rel = relative(WIKI, p);
@@ -238,17 +349,25 @@ test('on the real wiki: finds the live contradiction and nothing stale', () => {
     };
   });
   const indexPath = join(WIKI, 'index.md');
+  // refExists REAL, not stubbed: this is the only place the git-facing half of class 1 can be exercised.
+  const refExists = (ref) => {
+    try { execFileSync('git', ['cat-file', '-e', `${ref}^{commit}`], { cwd: ROOT, stdio: 'ignore' }); return true; }
+    catch { /* not a commit */ }
+    try { execFileSync('git', ['cat-file', '-e', `refs/tags/${ref}`], { cwd: ROOT, stdio: 'ignore' }); return true; }
+    catch { return false; }
+  };
   const r = diagnose({
-    docs, refExists: () => true,
+    docs, refExists,
     indexText: existsSync(indexPath) ? readFileSync(indexPath, 'utf8') : null,
   });
-  const contradictions = r.candidates.filter((c) => c.cls === CLASSES.CONTRADICTS);
-  assert.ok(
-    contradictions.some((c) => /puertas-y-mecanismos/.test(c.path)),
-    'the live stale counter must be found — it is why this exists',
-  );
-  // Over-firing check on real data: none of the phase standards may appear.
+  // The claim that CAN be asserted without depending on a defect persisting: no false fire on the
+  // documents we know are correct.
   for (const noisy of ['sdd/plan.md', 'sdd/tasks.md', 'sdd/analyze.md', 'wiki/index.md']) {
     assert.ok(!r.candidates.some((c) => c.path.endsWith(noisy)), `must not flag ${noisy}`);
   }
+  // And STALE really is silent — asserted, not implied by a stub. Every ref the wiki cites resolves.
+  assert.deepEqual(
+    r.candidates.filter((c) => c.cls === CLASSES.STALE), [],
+    'every commit and tag the wiki cites should resolve; a failure here is real drift, not a test bug',
+  );
 });

--- a/tests/knowledge-doctor.test.js
+++ b/tests/knowledge-doctor.test.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import {
   normalizeProse, parseFrontmatter, declaresSingleSource, statedCountInFrontmatter,
-  firstTableRowCount, findStaleClaims, findMisplaced, findContradictions, deriveConventions,
+  firstTableRowCount, stripFences, findStaleClaims, findMisplaced, findContradictions, deriveConventions,
   rank, diagnose, CLASSES, SEVERITY_ORDER, NOT_LOOKED_AT,
 } from '../scripts/lib/knowledge-doctor.js';
 
@@ -199,6 +199,40 @@ test('CONTRADICTS flags a frontmatter count against its declared single-source t
   assert.match(c[0].found, /10/);
 });
 
+test('CONTRADICTS ignores a document that merely DISCUSSES single sources', () => {
+  // Measured on the real wiki: the first gate admitted 7 documents and only 1 declared anything. Five
+  // of the six false passes were this project's own spec, plan and verification records — exactly the
+  // documents whose description naturally gains "probado 9 veces".
+  const discussing = fm({ description: 'el patrón aparece 4 veces' },
+    'Este documento explica por qué conviene una fuente única de la verdad para los contadores.\n\n| a |\n|---|\n| 1 |\n');
+  assert.deepEqual(findContradictions({ path: 'p.md', text: discussing }), [],
+    'talking about single sources is not declaring oneself one');
+
+  const quoting = fm({ description: 'encontrado diez veces' },
+    'La regla dice: *"el número vive en esta tabla y en ningún otro sitio"*, y por eso se aplica.\n\n| a |\n|---|\n| 1 |\n');
+  assert.deepEqual(findContradictions({ path: 'q.md', text: quoting }), [],
+    'quoting the declaration is a citation, not a declaration');
+
+  const declaring = fm({ description: 'encontrado diez veces' },
+    'El contador vive en esta tabla y en ningún otro sitio.\n\n| a |\n|---|\n| 1 |\n');
+  assert.equal(findContradictions({ path: 'r.md', text: declaring }).length, 1,
+    'and a genuine declaration must still be caught');
+});
+
+test('a table inside a code fence is not the canonical table', () => {
+  // A real 3-row table read as 1 row, and the report printed two wrong numbers as its evidence.
+  const body = 'vive en esta tabla y en ningún otro sitio\n\n```\n| ejemplo |\n|---|\n| 1 |\n```\n\n| real | x |\n|---|---|\n| a | b |\n| c | d |\n| e | f |\n';
+  assert.equal(firstTableRowCount(body).rows, 3, 'the fenced illustration must not be counted');
+  assert.equal(stripFences('a\n```\n| x |\n```\nb').split('\n').length, 5, 'line count must survive so reported lines stay true');
+});
+
+test('STALE does not read ordinary status prose as git refs', () => {
+  const probe = (s) => findStaleClaims({ path: 'p.md', text: fm({ status: s }), refExists: () => false });
+  assert.deepEqual(probe('implementada el 20260818'), [], 'a compact date is not a commit');
+  assert.deepEqual(probe('requiere node 18.0.0 y ajv 8.18.0'), [], 'dependency versions are not release tags');
+  assert.ok(probe('implementada (deadbee, publicada en 9.9.9)').length >= 2, 'a real sha and a release claim still fire');
+});
+
 test('CONTRADICTS does NOT flag when the count matches — the positive control', () => {
   const text = fm({ description: 'encontrado dos veces' },
     'en ningún otro sitio\n\n| a |\n|---|\n| 1 |\n| 2 |\n');
@@ -259,7 +293,12 @@ test('diagnose COMPOSES all four detectors — each one is pinned by its own can
   const r = diagnose({ docs, indexText: '# i', refExists: () => false });
   const classes = new Set(r.candidates.map((c) => c.cls));
   assert.ok(classes.has(CLASSES.STALE), 'findStaleClaims must reach the composed output');
-  assert.ok(classes.has(CLASSES.MISPLACED), 'findMisplaced must reach the composed output');
+  // By SIGNAL, not by class: findLogIntruders also emits MISPLACED, so asserting the class alone let a
+  // mutant delete findMisplaced entirely and stay green.
+  assert.ok(
+    r.candidates.some((c) => /type: verification/.test(c.signal)),
+    'findMisplaced must reach the composed output — its own signal, not just its class',
+  );
   assert.ok(classes.has(CLASSES.CONTRADICTS), 'findContradictions must reach the composed output');
   assert.ok(
     r.candidates.some((c) => /decisions\.md/.test(c.path)),


### PR DESCRIPTION
The first real refuter panel in this repo. Three fresh-context lenses attacked `knowledge-doctor` (1.0.20) with the four inputs and **no access to my verification record**. **Two blocked.** They planted **61 mutants against my 13**, and two of them converged independently on the same two spec gaps.

Nothing was wrong with what the tool **outputs**. The block was on the mechanism: *the suite would not have noticed if that stopped being true.*

## Code

| Defect | What it was |
|---|---|
| Single-source gate too wide | Admitted **7 documents on a 51-doc wiki; only 1 declared anything**. Five of the six false passes were this project's own spec, plan and verification records — exactly the documents whose `description:` naturally gains "probado 9 veces". Now requires a self-referential phrase and excludes quotations: **7 → 1**, live case still caught |
| Fenced tables counted | A real 3-row table read as **1**, printing two wrong numbers as its evidence |
| Status prose read as git refs | `20260818` → "missing commit"; `node 18.0.0` → tag `v18.0.0` |
| **The disclosure was itself stale** | `NOT_LOOKED_AT[0]` described the **pre-fix dead-code mechanism** — a stale claim inside the stale-claim detector |
| Unreadable file crashed the run | `chmod 000` / dangling symlink threw and took the whole report — worse than the silent skip AC7 forbids. Now a candidate with its reason |
| `statSync` followed symlinks | The walk read **outside `02-DOCS/`** reporting the logical path; a cycle crashed it. Now `withFileTypes`, matching `drift-check.js:167` — the precedent the plan cited and then diverged from |
| Raw filename interpolation | A crafted name forged structurally valid report entries |
| Unbounded spawns / ReDoS | 3000 refs → 6002 git processes, 76s; 160k digits → 21.5s. Both capped |
| Index check was a substring test | A path mentioned as **DELETED** counted as indexed — "the path appears in the string" is not "the row exists", the mistake this repo recorded as having shipped twice in one day |

## Tests — the worse half

- **The composition was unpinned.** My only synthetic `diagnose` test asserted `scanned` and `notLookedAt`, never `candidates`. Removing a detector, or fabricating one per document (**7 → 54**), passed green.
- **One of my assertions could not fail.** `diagnose` returns `notLookedAt: NOT_LOOKED_AT` — the same reference — and the test `deepEqual`'d against that constant. Verified by running it: `r.notLookedAt === NOT_LOOKED_AT` → `true`. I wrote that the day after shipping a rule about assertions that cannot fail.
- **The doc helper set `rel === path`**, hiding the only field distinction the index check rests on. Swapping it survived and produced **37 false candidates**.
- **Thresholds were pinned only in the tightening direction.** Every mutant that made the tool *noisier* survived — the direction this change claims to protect against.
- The missing-`type:` branch had **zero coverage**.

## AC2 implemented — it was missing *and* undisclosed

No detector examined log entries, so the report presented `decisions.md` as scanned and clean: **affirming a check nobody performed**. One of the three incidents that motivated the whole spec is four entries eval agents wrote into that log. `findLogIntruders` finds both real ones (`harness-data-export`, `magic-link`).

Residual declared: **1 false of 3** (`old-coder`, an external repo cited in a legitimate entry), flagged uncertain. No further heuristic added to chase it.

## And the gate that punished its own cure

The security lens found the sharpest one: the real-wiki test **required the live contradiction to still exist**, so curing the finding the report demands **broke the suite** — in the repo that wrote `gate-honesty`. And in CI it early-returned, so the only real-data assertion never ran where the gates run. Decoupled: it now asserts no false fire on correct work and genuine STALE silence, with a **real** `refExists` instead of a stub.

## Verification

| Gate | Result |
|---|---|
| `validate` / `manifest:check` | OK, 264 skills |
| `npm test` | **462 passed, 0 failed** |
| `eval-lint.sh` | 264 skills, 0 failures |
| `drift:check` | all resolve |
| manual mutation | **14/14 killed**, including the 5 the refuters made survive |

**Three of my fixes had no test until I planted the mutant** — the composition, the widened gate, the fences. I fixed the code and did not pin the behaviour. The fix is not done until a test catches its regression.

## Scope decisions, taken in autopilot

The protocol sends a spec gap to the human; the instruction was "hagámoslo", so I took them and marked them in the spec so they can be reverted without archaeology: **AC2 is implemented** (descoping would have gutted the spec's own justification), **AC7 is met** rather than amended, and the real-wiki test is **decoupled**.

## Declared debt

**Nobody has attacked the new code with fresh context.** The 14 mutants cover what was fixed; a second refutation round is the debt this delivery contracts. And the panel measured the *contract*, not that the agent file auto-loads — agent types register at session start and the refuters shipped after, so they ran as generic agents with the body injected.