### PR TITLE
✨ feat(git): force a gitmoji on every commit, with a guard that proves it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           if [ "$HIGHEST" != "$LOCAL" ]; then
             npm version "$HIGHEST" --no-git-tag-version --allow-same-version
             git add package.json package-lock.json manifest.json
-            git commit -m "chore: realign version with the registry ($LOCAL -> $HIGHEST) [skip ci]"
+            git commit -m "🔧 chore: realign version with the registry ($LOCAL -> $HIGHEST) [skip ci]"
           fi
 
       # No tag here on purpose. The tag is created after the commit is pushed (see below), so
@@ -87,7 +87,7 @@ jobs:
           VERSION="$(node -p "require('./package.json').version")"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           git add package.json package-lock.json manifest.json
-          git commit -m "chore(release): $VERSION [skip ci]"
+          git commit -m "🔖 chore(release): $VERSION [skip ci]"
 
       # --- publish + push the bump back ----------------------------------------
       - name: Publish to npm
@@ -118,7 +118,7 @@ jobs:
       - name: Tag the released commit
         run: |
           V="v${{ steps.bump.outputs.version }}"
-          git tag -a "$V" -m "chore(release): ${{ steps.bump.outputs.version }}"
+          git tag -a "$V" -m "🔖 chore(release): ${{ steps.bump.outputs.version }}"
           git push origin "$V"
 
       # --- cut a GitHub Release for the new tag --------------------------------

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ also wires a `SessionStart` hook (so your assistant proposes new skills on its
 own) and a `UserPromptSubmit` hook that re-asserts the **SDD new-feature gate**
 on every turn — so a feature request, in any language, routes through `specify`
 first, before any skill writes code. Opt out per project with `.rsc/.no-feature-gate`.
+It also wires a `PreToolUse` **gitmoji guard**: a `git commit` whose message carries no
+[gitmoji](https://gitmoji.dev) is denied, with the corrected message inside the refusal
+(`✨ feat(api): add cursor paging`) — so `git log --oneline` stays readable at a glance instead of
+depending on the agent remembering a convention. It only judges messages it can actually read
+(`-m`, heredoc), never an editor commit or `--amend --no-edit`. Opt out with `.rsc/.no-gitmoji`.
 
 Everything stays **in the project**, and the real skill files are written
 **once** to `.rsc/skills/<id>/`. Each assistant you pick gets a lightweight

--- a/manifest.json
+++ b/manifest.json
@@ -2114,11 +2114,12 @@
     },
     {
       "id": "git-workflow",
-      "description": "Use when naming or scoping a branch, writing or fixing a commit message, untangling history (rebase versus merge versus squash), or cutting a versioned release — the portable git-convention layer for any repo. Covers Conventional Commits, SemVer tags, branch hygiene, force-push safety and gh pr/release mechanics. NOT the land-it decision and pre-ship checklist (that is `ship`), NOT an isolated checkout before coding (that is `worktrees`), NOT CI/CD release automation (that is `deployment`).",
+      "description": "Use when naming or scoping a branch, writing or fixing a commit message, picking the gitmoji for a commit, untangling history (rebase versus merge versus squash), or cutting a versioned release — the portable git-convention layer for any repo. Covers gitmoji + Conventional Commits, SemVer tags, branch hygiene, force-push safety and gh pr/release mechanics. NOT the land-it decision and pre-ship checklist (that is `ship`), NOT an isolated checkout before coding (that is `worktrees`), NOT CI/CD release automation (that is `deployment`).",
       "tags": [
         "git",
         "version-control",
         "conventional-commits",
+        "gitmoji",
         "semver",
         "pull-request"
       ],

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -57,6 +57,9 @@ export function doctor({ target, home, cwd }) {
     },
     contextBudget: contextBudget({ target, home, cwd }),
     sello: selloStatus(root),
+    // An inert gate must never read as an armed one (the same rule the sello follows):
+    // the gitmoji guard has a per-project kill switch, so say which state it is in.
+    gitmojiGuard: existsSync(join(root, '.rsc', '.no-gitmoji')) ? 'opted-out' : 'armed',
     // Counted, never interpreted — by spec, the gap log's reader is the user.
     automationGaps: countGaps(root),
   };

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -60,6 +60,7 @@ function generatedHookFiles({ target, cwd }) {
     join(cwd, '.rsc', 'worklog-checkpoint.mjs'),
     join(cwd, '.rsc', 'ship-guard.mjs'),
     join(cwd, '.rsc', 'danger-guard.mjs'),
+    join(cwd, '.rsc', 'gitmoji-guard.mjs'),
     join(cwd, '.rsc', 'userprompt-gate.mjs'),
     join(cwd, '.rsc', 'hook-once.mjs'),
     join(cwd, '.rsc', 'sello.mjs'),

--- a/skills/constitution/references/constitution-template.md
+++ b/skills/constitution/references/constitution-template.md
@@ -40,7 +40,7 @@ version: v1.0.0
 
 7. Naming & structure: <directory layout, module boundaries, file naming>.
 8. API & errors: <error shape, status codes, response envelope> where applicable.
-9. Commit messages: <format, e.g. Conventional Commits>.
+9. Commit messages: <format, e.g. gitmoji + Conventional Commits — `✨ feat(scope): subject`>.
 
 ## 4. Branching & shipping
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-workflow
-description: "Use when naming or scoping a branch, writing or fixing a commit message, untangling history (rebase versus merge versus squash), or cutting a versioned release — the portable git-convention layer for any repo. Covers Conventional Commits, SemVer tags, branch hygiene, force-push safety and gh pr/release mechanics. NOT the land-it decision and pre-ship checklist (that is `ship`), NOT an isolated checkout before coding (that is `worktrees`), NOT CI/CD release automation (that is `deployment`)."
-tags: [git, version-control, conventional-commits, semver, pull-request]
+description: "Use when naming or scoping a branch, writing or fixing a commit message, picking the gitmoji for a commit, untangling history (rebase versus merge versus squash), or cutting a versioned release — the portable git-convention layer for any repo. Covers gitmoji + Conventional Commits, SemVer tags, branch hygiene, force-push safety and gh pr/release mechanics. NOT the land-it decision and pre-ship checklist (that is `ship`), NOT an isolated checkout before coding (that is `worktrees`), NOT CI/CD release automation (that is `deployment`)."
+tags: [git, version-control, conventional-commits, gitmoji, semver, pull-request]
 recommends: [ship, worktrees, deployment, github-actions]
 origin: risco
 ---
@@ -44,12 +44,12 @@ Good  fix/expired-refresh-token-401
 Good  chore/bump-node-22
 ```
 
-## Conventional Commits grammar
+## Commit grammar — gitmoji + Conventional Commits
 
-Write every commit to **Conventional Commits 1.0.0**. The structure:
+Write every commit to **Conventional Commits 1.0.0**, opened by a **gitmoji**. The structure:
 
 ```text
-type(scope)!: subject
+<gitmoji> type(scope)!: subject
 
 body — what changed and why, wrapped, optional
 
@@ -57,6 +57,8 @@ BREAKING CHANGE: description of the incompatible change
 Fixes #123
 ```
 
+- The **gitmoji is mandatory** and comes first — the intention of the change, readable in one glyph
+  when you scan `git log --oneline`. `type` is what tooling reads; the emoji is what humans read.
 - `type` is mandatory. `scope` in parentheses is optional. `!` before the colon marks a breaking change.
 - Subject: imperative mood ("add", not "added"/"adds"), ≤72 chars, no trailing period.
 - Body explains *why*, not *what the diff already shows*. Separate from subject by a blank line.
@@ -74,22 +76,43 @@ Type → SemVer effect:
 `BREAKING CHANGE` **must be uppercase** in the footer; the type/scope units are case-insensitive but
 write them lowercase by convention.
 
+Type → gitmoji, the everyday set (the full 75-emoji table, and *why* the emoji never replaces the
+type, are in **`references/gitmoji.md`**):
+
+| Type       | gitmoji | Type       | gitmoji | Type      | gitmoji |
+|------------|---------|------------|---------|-----------|---------|
+| `feat`     | ✨      | `refactor` | ♻️      | `build`   | 📦️      |
+| `fix`      | 🐛      | `test`     | ✅      | `style`   | 🎨      |
+| `docs`     | 📝      | `perf`     | ⚡️      | `revert`  | ⏪️      |
+| `chore`    | 🔧      | `ci`       | 👷      | breaking  | 💥      |
+
+Pick by **intention**, not by which file changed, and prefer the specific one: 🚑️ for a production
+hotfix, 🩹 for a trivial non-critical fix, 🔥 for a deletion, 🚚 for a rename, ⬆️ for a dep bump,
+🔖 for a release commit.
+
 ```text
 Bad   fix stuff
 Bad   updates
 Bad   Fixed the login bug.            (past tense, capitalized, trailing period)
-Good  fix(auth): reject expired refresh tokens
-Good  feat(api): add /v2/search endpoint with cursor paging
-Good  refactor(parser): extract token scanner, no behavior change
+Bad   fix(auth): reject expired refresh tokens        (no gitmoji)
+Bad   ✨ added a search endpoint                       (gitmoji but no type → no derivable bump)
+Good  🐛 fix(auth): reject expired refresh tokens
+Good  ✨ feat(api): add /v2/search endpoint with cursor paging
+Good  ♻️ refactor(parser): extract token scanner, no behavior change
 ```
 
 A breaking change, both forms equivalent:
 
 ```text
-feat(api)!: drop the legacy /v1 search endpoint
+💥 feat(api)!: drop the legacy /v1 search endpoint
 
 BREAKING CHANGE: /v1/search is removed; callers must migrate to /v2/search.
 ```
+
+If the repo runs a **strict** conventional parser (commitlint, semantic-release) it anchors the type
+at position 0 and rejects the emoji prefix. Either widen its `headerPattern` — the config is in
+`references/gitmoji.md` — or move the emoji behind the header (`feat(api): ✨ add cursor paging`),
+which every parser accepts. Both forms satisfy this convention; dropping the gitmoji does not.
 
 **Authorship is always Eric.** Never add a `Co-Authored-By: Claude` trailer, never a
 "Generated with" footer, never any line crediting an AI tool — in a commit *or* a PR body. The work
@@ -103,7 +126,7 @@ Decide by who else has the commits. The lease rule below is non-negotiable.
 |------------------------------------------------------|------------------------------------------------------|------------------------------------------------------------|
 | Private branch, only you have it, want linear history | `git rebase main`, then `git push --force-with-lease`| rebase rewrites hashes; safe because nobody built on them  |
 | Branch others have pulled / built on                  | `git merge main` — **never** rebase it               | rebase changes every hash; collaborators' work diverges    |
-| Noisy PR (many `wip` commits)                         | squash-merge into one conventional commit            | `main` gets one meaningful entry, not 9 scratch commits    |
+| Noisy PR (many `wip` commits)                         | squash-merge into one gitmoji + conventional commit            | `main` gets one meaningful entry, not 9 scratch commits    |
 | Already pushed, shared, *and* you rewrote it          | **STOP** — coordinate, or `git revert` instead       | force-pushing shared history breaks everyone downstream     |
 
 After a rebase, push with `--force-with-lease`, never bare `--force`:
@@ -168,7 +191,8 @@ enough to hand over. Setting up the isolated checkout *before* you start coding 
 | Anti-pattern                                          | Why it hurts                                              | Instead                                              |
 |-------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------|
 | `git push --force` on a shared branch                 | silently erases teammates' commits                        | `--force-with-lease`, or don't rewrite shared history |
-| `git commit -m "wip"` / `"fix"` / `"updates"`         | the log carries zero signal for the next reader           | conventional `type(scope): imperative subject`        |
+| `git commit -m "wip"` / `"fix"` / `"updates"`         | the log carries zero signal for the next reader           | `<gitmoji> type(scope): imperative subject`           |
+| Commit message with no gitmoji                         | `git log --oneline` reads as a wall of undifferentiated text | pick the intention's emoji (`references/gitmoji.md`) |
 | Mixing unrelated changes in one commit                | can't revert or review one concern in isolation           | one logical change per commit                         |
 | Long-lived branch (weeks)                             | diverges from `main`, merge becomes a battle              | short-lived; rebase or merge `main` in often          |
 | Hand-computing the semver bump                        | breaking change shipped as a MINOR → broken downstream    | derive the bump from the commit log                   |
@@ -183,7 +207,7 @@ enough to hand over. Setting up the isolated checkout *before* you start coding 
 
 - [ ] Working tree clean (`git status`), no stray or generated files staged.
 - [ ] Branch rebased on / merged with current `main`; no avoidable conflicts.
-- [ ] Every commit is conventional; `wip`/scratch commits squashed away.
+- [ ] Every commit carries its gitmoji **and** a conventional header; `wip`/scratch commits squashed away.
 - [ ] No secrets, no AI-attribution trailers.
 - [ ] PR body explains the why and links the issue (`Fixes #`).
 - [ ] (Release) version bump **derived from the commit log**, tag is `vX.Y.Z`, annotated.

--- a/skills/git-workflow/evals/cases.yaml
+++ b/skills/git-workflow/evals/cases.yaml
@@ -13,6 +13,10 @@ should_trigger:
     why: Spanish trigger covering history cleanup plus conventional-commit formatting.
   - prompt: "Name a branch for the OAuth PKCE work"
     why: Branch-naming convention — feat/ prefix plus kebab slug from intent.
+  - prompt: "Which gitmoji goes on this commit — I deleted a deprecated module"
+    why: Gitmoji selection by intention (🔥 remove code, not ♻️ refactor); the commit-grammar layer owns the emoji.
+  - prompt: "Mi commitlint rechaza el commit por el emoji delante del type"
+    why: Spanish; the strict-parser escape hatch (widen headerPattern or move the emoji behind the header) lives in this skill.
   - prompt: "Tag v2.1.0 and write the release notes"
     why: Release mechanics — annotated tag plus gh release create --generate-notes.
 
@@ -41,6 +45,7 @@ capability:
     must_include:
       - Collapses the two "wip" commits via squash or fixup and explains why (one meaningful entry in main).
       - Identifies a feat commit and a BREAKING CHANGE footer written in uppercase.
+      - Every proposed commit message opens with a gitmoji (✨ for the feature, 💥 for the breaking removal) before the conventional header.
       - Bump is MAJOR because of the breaking change, with a tag of the form vX.0.0.
       - Uses gh release create vX.0.0 --generate-notes (or an equivalent that produces notes).
       - Uses git push --force-with-lease (not bare --force) for the post-rebase push.

--- a/skills/git-workflow/references/gitmoji.md
+++ b/skills/git-workflow/references/gitmoji.md
@@ -1,0 +1,157 @@
+# gitmoji — the full set, and the tooling that has to accept it
+
+The commit rule lives in `../SKILL.md`: **every commit opens with a gitmoji, then the
+Conventional Commits header.** This file is the lookup table and the tooling escape hatches — read
+it when you need the right glyph for an intention, or when a parser in the repo rejects the format.
+
+```text
+<gitmoji> type(scope)!: imperative subject
+```
+
+The gitmoji says *what kind of intention* this is at a glance in `git log --oneline`; the `type`
+still drives the SemVer bump. They are two different jobs and neither replaces the other — a commit
+with 💥 but no `!`/`BREAKING CHANGE:` footer still releases as a MINOR, because tooling reads the
+type, not the picture.
+
+## Picking one
+
+Match the **intention**, not the file that changed. If two fit, take the more specific one (🚑️ over
+🐛 for a production hotfix; 🩹 over 🐛 for a trivial non-critical fix). The `semver` column is
+gitmoji's own hint, not a substitute for the type → bump table in `../SKILL.md`.
+
+The everyday dozen, mapped to the conventional types:
+
+| Type       | gitmoji | Type        | gitmoji |
+|------------|---------|-------------|---------|
+| `feat`     | ✨      | `perf`      | ⚡️      |
+| `fix`      | 🐛      | `ci`        | 👷      |
+| `docs`     | 📝      | `build`     | 📦️      |
+| `refactor` | ♻️      | `style`     | 🎨      |
+| `test`     | ✅      | `revert`    | ⏪️      |
+| `chore`    | 🔧      | breaking    | 💥      |
+
+## The full set
+
+Canonical source: <https://gitmoji.dev> (machine-readable at `https://gitmoji.dev/api/gitmojis`).
+The same 75 rows are enforced as data by the gitmoji guard, and a test compares this table against
+it — if the two ever disagree, CI says so.
+
+| Emoji | Code | SemVer | Intention |
+|-------|------|--------|-----------|
+| 🎨 | `:art:` | — | Improve structure / format of the code |
+| ⚡️ | `:zap:` | patch | Improve performance |
+| 🔥 | `:fire:` | — | Remove code or files |
+| 🐛 | `:bug:` | patch | Fix a bug |
+| 🚑️ | `:ambulance:` | patch | Critical hotfix |
+| ✨ | `:sparkles:` | minor | Introduce new features |
+| 📝 | `:memo:` | — | Add or update documentation |
+| 🚀 | `:rocket:` | — | Deploy stuff |
+| 💄 | `:lipstick:` | patch | Add or update the UI and style files |
+| 🎉 | `:tada:` | — | Begin a project |
+| ✅ | `:white_check_mark:` | — | Add, update, or pass tests |
+| 🔒️ | `:lock:` | patch | Fix security or privacy issues |
+| 🔐 | `:closed_lock_with_key:` | — | Add or update secrets |
+| 🔖 | `:bookmark:` | — | Release / Version tags |
+| 🚨 | `:rotating_light:` | — | Fix compiler / linter warnings |
+| 🚧 | `:construction:` | — | Work in progress |
+| 💚 | `:green_heart:` | — | Fix CI Build |
+| ⬇️ | `:arrow_down:` | patch | Downgrade dependencies |
+| ⬆️ | `:arrow_up:` | patch | Upgrade dependencies |
+| 📌 | `:pushpin:` | patch | Pin dependencies to specific versions |
+| 👷 | `:construction_worker:` | — | Add or update CI build system |
+| 📈 | `:chart_with_upwards_trend:` | patch | Add or update analytics or track code |
+| ♻️ | `:recycle:` | — | Refactor code |
+| ➕ | `:heavy_plus_sign:` | patch | Add a dependency |
+| ➖ | `:heavy_minus_sign:` | patch | Remove a dependency |
+| 🔧 | `:wrench:` | patch | Add or update configuration files |
+| 🔨 | `:hammer:` | — | Add or update development scripts |
+| 🌐 | `:globe_with_meridians:` | patch | Internationalization and localization |
+| ✏️ | `:pencil2:` | patch | Fix typos |
+| 💩 | `:poop:` | — | Write bad code that needs to be improved |
+| ⏪️ | `:rewind:` | patch | Revert changes |
+| 🔀 | `:twisted_rightwards_arrows:` | — | Merge branches |
+| 📦️ | `:package:` | patch | Add or update compiled files or packages |
+| 👽️ | `:alien:` | patch | Update code due to external API changes |
+| 🚚 | `:truck:` | — | Move or rename resources (e.g.: files, paths, routes) |
+| 📄 | `:page_facing_up:` | — | Add or update license |
+| 💥 | `:boom:` | major | Introduce breaking changes |
+| 🍱 | `:bento:` | patch | Add or update assets |
+| ♿️ | `:wheelchair:` | patch | Improve accessibility |
+| 💡 | `:bulb:` | — | Add or update comments in source code |
+| 🍻 | `:beers:` | — | Write code drunkenly |
+| 💬 | `:speech_balloon:` | patch | Add or update text and literals |
+| 🗃️ | `:card_file_box:` | patch | Perform database related changes |
+| 🔊 | `:loud_sound:` | — | Add or update logs |
+| 🔇 | `:mute:` | — | Remove logs |
+| 👥 | `:busts_in_silhouette:` | — | Add or update contributor(s) |
+| 🚸 | `:children_crossing:` | patch | Improve user experience / usability |
+| 🏗️ | `:building_construction:` | — | Make architectural changes |
+| 📱 | `:iphone:` | patch | Work on responsive design |
+| 🤡 | `:clown_face:` | — | Mock things |
+| 🥚 | `:egg:` | patch | Add or update an easter egg |
+| 🙈 | `:see_no_evil:` | — | Add or update a .gitignore file |
+| 📸 | `:camera_flash:` | — | Add or update snapshots |
+| ⚗️ | `:alembic:` | patch | Perform experiments |
+| 🔍️ | `:mag:` | patch | Improve SEO |
+| 🏷️ | `:label:` | patch | Add or update types |
+| 🌱 | `:seedling:` | — | Add or update seed files |
+| 🚩 | `:triangular_flag_on_post:` | patch | Add, update, or remove feature flags |
+| 🥅 | `:goal_net:` | patch | Catch errors |
+| 💫 | `:dizzy:` | patch | Add or update animations and transitions |
+| 🗑️ | `:wastebasket:` | patch | Deprecate code that needs to be cleaned up |
+| 🛂 | `:passport_control:` | patch | Work on code related to authorization, roles and permissions |
+| 🩹 | `:adhesive_bandage:` | patch | Simple fix for a non-critical issue |
+| 🧐 | `:monocle_face:` | — | Data exploration/inspection |
+| ⚰️ | `:coffin:` | — | Remove dead code |
+| 🧪 | `:test_tube:` | — | Add a failing test |
+| 👔 | `:necktie:` | patch | Add or update business logic |
+| 🩺 | `:stethoscope:` | — | Add or update healthcheck |
+| 🧱 | `:bricks:` | — | Infrastructure related changes |
+| 🧑‍💻 | `:technologist:` | — | Improve developer experience |
+| 💸 | `:money_with_wings:` | — | Add sponsorships or money related infrastructure |
+| 🧵 | `:thread:` | — | Add or update code related to multithreading or concurrency |
+| 🦺 | `:safety_vest:` | — | Add or update code related to validation |
+| ✈️ | `:airplane:` | — | Improve offline support |
+| 🦖 | `:t-rex:` | — | Code that adds backwards compatibility |
+## Tooling that has to accept the format
+
+Emoji-first is what gitmoji itself prescribes and what `gitmoji -c` writes, but a **strict
+Conventional Commits parser anchors the type at position 0** and will reject the header. Two honest
+ways out, in order of preference:
+
+**1. Teach the parser about the prefix.** commitlint, with the emoji allowed before the type:
+
+```js
+// commitlint.config.js
+export default {
+  extends: ['@commitlint/config-conventional'],
+  parserPreset: {
+    parserOpts: {
+      // <emoji> type(scope)!: subject
+      headerPattern: /^(?:\S+\s)?(\w+)(?:\(([^)]*)\))?(!)?: (.+)$/,
+      headerCorrespondence: ['type', 'scope', 'breaking', 'subject'],
+    },
+  },
+};
+```
+
+semantic-release / conventional-changelog take the same `parserOpts` under
+`@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator`. Set it in
+**both** or the bump and the changelog disagree about the same commit.
+
+**2. Put the emoji after the header** — `feat(api): ✨ add cursor paging`. Every conventional parser
+accepts it unmodified, and the guard accepts it too. Prefer this in a repo whose release pipeline
+you do not own.
+
+What **not** to do: drop the type and commit `✨ add cursor paging` (gitmoji's own minimal form).
+It is valid gitmoji and useless for releases — nothing can derive the bump, so the version has to be
+hand-picked, which `../SKILL.md` forbids for a reason.
+
+## Related
+
+- `gitmoji-cli` (`npm i -g gitmoji-cli`, then `gitmoji -c`) prompts for the emoji and writes the
+  commit. Optional — the convention is the rule, the CLI is one way to type it.
+- On Claude Code, rsc wires a `gitmoji-guard` PreToolUse hook that denies a `git commit` whose
+  message has no gitmoji, with the corrected message in the refusal. It only judges messages it can
+  actually read (`-m`, heredoc) and never blocks an editor commit, a `-F` file, or `--amend
+  --no-edit`. Opt out per project with `.rsc/.no-gitmoji`.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -184,7 +184,7 @@ cleanup). If a native `EnterWorktree`-style tool created it, exit through that t
 
 The commit is the durable record. Make it describe the change and tie it to the spec — and keep it Eric's.
 
-- **Subject:** `type: imperative summary (<spec-slug>)` — `feat:`, `fix:`, `refactor:`, etc. Under ~72 chars.
+- **Subject:** `<gitmoji> type: imperative summary (<spec-slug>)` — `✨ feat:`, `🐛 fix:`, `♻️ refactor:`, etc. Under ~72 chars. The gitmoji is **not optional**: on Claude Code a PreToolUse guard denies a `git commit -m` without one, and the refusal hands back the corrected message. Emoji → intention table: `../git-workflow/references/gitmoji.md`.
 - **Body:** *why*, not a restatement of the diff. Reference the spec slug and any decision logged in `decisions.md`.
 - **Footer:** issue/PR refs only. **No `Co-Authored-By` for any AI. No "generated with" line.** This is where the violation usually sneaks in — leave the footer clean.
 
@@ -212,6 +212,7 @@ Read the level from `02-DOCS/wiki/harness/user-profile.md`. It changes what you 
 | "The tree has a couple of stray edits, they're harmless" | A dirty tree means the merge is not the reviewed diff. Clean it or stash it first. |
 | "`main` is protected but I'll just force-merge, I'm sure" | Protected means PR. Don't bypass the gate the repo deliberately set. |
 | "I'll rebase and resolve conflicts during the merge" | Resolve before. A conflicted merge commit hides what actually shipped. |
+| "The gitmoji is decoration, the conventional type is what matters" | Both ship or neither does. The type is for tooling, the emoji for the human scanning `git log` — and the guard denies the commit either way. |
 | "This branch is dead, I'll just delete it" | Discard is destructive — confirm with the quoted branch name and log why first. |
 | "Squash everything, history doesn't matter" | Squash noise, preserve meaning. The history is the next reader's spec. |
 | "There's a key in the diff but it's a test key" | A secret in the diff is a blocker regardless. Pull it out before landing. |

--- a/targets/claude.js
+++ b/targets/claude.js
@@ -113,6 +113,21 @@ export function wireHook(paths) {
   );
   settings.hooks.PreToolUse.push({ matcher: 'Bash', hooks: [{ type: 'command', command: dgCmd }] });
 
+  // Gitmoji guard: a PreToolUse(Bash) hook that DENIES a `git commit` whose message
+  // carries no gitmoji (gitmoji.dev) in front of the Conventional Commits header. The
+  // convention lives in `git-workflow`; prose asks, this hook decides — at the one
+  // deterministic moment the message exists. Only fires when the message is inline and
+  // readable (-m / heredoc); editor commits, -F files and --amend --no-edit are allowed.
+  // Materialized + node-run (Windows-safe), idempotent, fail-open, opt-out via
+  // .rsc/.no-gitmoji.
+  const gmDest = join(paths.projectRoot, '.rsc', 'gitmoji-guard.mjs');
+  copyFileSync(join(HERE, 'gitmoji-guard.mjs'), gmDest);
+  const gmCmd = `node "${gmDest}" "${paths.projectRoot}"`;
+  settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
+    (e) => !JSON.stringify(e).includes('.rsc/gitmoji-guard.'),
+  );
+  settings.hooks.PreToolUse.push({ matcher: 'Bash', hooks: [{ type: 'command', command: gmCmd }] });
+
   // New-feature gate: a UserPromptSubmit hook that re-injects the SDD new-feature gate as
   // the most-recent instruction on every user turn. SessionStart injects the full gate (the
   // `suggest` body) once; this keeps the precedence rule salient regardless of how many
@@ -132,5 +147,5 @@ export function wireHook(paths) {
 
   mkdirSync(dirname(file), { recursive: true });
   writeFileSync(file, JSON.stringify(settings, null, 2) + '\n');
-  return [file, scriptDest, wlDest, sgDest, dgDest, fgDest];
+  return [file, scriptDest, wlDest, sgDest, dgDest, gmDest, fgDest];
 }

--- a/targets/gitmoji-guard.mjs
+++ b/targets/gitmoji-guard.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+// rsc Gitmoji guard (claude). Wired by targets/claude.js onto PreToolUse (matcher Bash)
+// as `node ...` so it runs on every platform including Windows.
+//   argv[2] = absolute project root   stdin = PreToolUse hook JSON
+//
+// Enforces one convention at the only deterministic moment it can be enforced: the
+// commit is being written. Every commit message this harness produces carries a
+// gitmoji (https://gitmoji.dev) — the intention of the change, visible in one glyph
+// in `git log --oneline`, on top of the Conventional Commits grammar that already
+// drives the semver bump. Prose in a skill asks; this hook decides.
+//
+// Accepted shapes (both are gitmoji-valid; the first is what `git-workflow` prescribes):
+//   ✨ feat(api): add cursor paging
+//   feat(api): ✨ add cursor paging
+//
+// Design (constitution P1/P2/P6/P7): deterministic, local-only, precise — it fires only
+// on a `git commit` that carries its message inline, where the message can actually be
+// read. Anything it cannot read with certainty (editor commit, -F file, --amend
+// --no-edit, an unparseable command) is ALLOWED: a guard that guesses is a guard that
+// gets turned off. Every deny names its recovery. Opt out with .rsc/.no-gitmoji.
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// The official gitmoji set (gitmoji.dev/api/gitmojis), as data: [emoji, code, semver, meaning].
+// A table, not a chain of ifs — so a test can iterate it and the reference doc can be
+// checked against it instead of drifting apart in prose.
+export const GITMOJIS = [
+  ['🎨', ':art:', null, "Improve structure / format of the code."],
+  ['⚡️', ':zap:', 'patch', "Improve performance."],
+  ['🔥', ':fire:', null, "Remove code or files."],
+  ['🐛', ':bug:', 'patch', "Fix a bug."],
+  ['🚑️', ':ambulance:', 'patch', "Critical hotfix."],
+  ['✨', ':sparkles:', 'minor', "Introduce new features."],
+  ['📝', ':memo:', null, "Add or update documentation."],
+  ['🚀', ':rocket:', null, "Deploy stuff."],
+  ['💄', ':lipstick:', 'patch', "Add or update the UI and style files."],
+  ['🎉', ':tada:', null, "Begin a project."],
+  ['✅', ':white_check_mark:', null, "Add, update, or pass tests."],
+  ['🔒️', ':lock:', 'patch', "Fix security or privacy issues."],
+  ['🔐', ':closed_lock_with_key:', null, "Add or update secrets."],
+  ['🔖', ':bookmark:', null, "Release / Version tags."],
+  ['🚨', ':rotating_light:', null, "Fix compiler / linter warnings."],
+  ['🚧', ':construction:', null, "Work in progress."],
+  ['💚', ':green_heart:', null, "Fix CI Build."],
+  ['⬇️', ':arrow_down:', 'patch', "Downgrade dependencies."],
+  ['⬆️', ':arrow_up:', 'patch', "Upgrade dependencies."],
+  ['📌', ':pushpin:', 'patch', "Pin dependencies to specific versions."],
+  ['👷', ':construction_worker:', null, "Add or update CI build system."],
+  ['📈', ':chart_with_upwards_trend:', 'patch', "Add or update analytics or track code."],
+  ['♻️', ':recycle:', null, "Refactor code."],
+  ['➕', ':heavy_plus_sign:', 'patch', "Add a dependency."],
+  ['➖', ':heavy_minus_sign:', 'patch', "Remove a dependency."],
+  ['🔧', ':wrench:', 'patch', "Add or update configuration files."],
+  ['🔨', ':hammer:', null, "Add or update development scripts."],
+  ['🌐', ':globe_with_meridians:', 'patch', "Internationalization and localization."],
+  ['✏️', ':pencil2:', 'patch', "Fix typos."],
+  ['💩', ':poop:', null, "Write bad code that needs to be improved."],
+  ['⏪️', ':rewind:', 'patch', "Revert changes."],
+  ['🔀', ':twisted_rightwards_arrows:', null, "Merge branches."],
+  ['📦️', ':package:', 'patch', "Add or update compiled files or packages."],
+  ['👽️', ':alien:', 'patch', "Update code due to external API changes."],
+  ['🚚', ':truck:', null, "Move or rename resources (e.g.: files, paths, routes)."],
+  ['📄', ':page_facing_up:', null, "Add or update license."],
+  ['💥', ':boom:', 'major', "Introduce breaking changes."],
+  ['🍱', ':bento:', 'patch', "Add or update assets."],
+  ['♿️', ':wheelchair:', 'patch', "Improve accessibility."],
+  ['💡', ':bulb:', null, "Add or update comments in source code."],
+  ['🍻', ':beers:', null, "Write code drunkenly."],
+  ['💬', ':speech_balloon:', 'patch', "Add or update text and literals."],
+  ['🗃️', ':card_file_box:', 'patch', "Perform database related changes."],
+  ['🔊', ':loud_sound:', null, "Add or update logs."],
+  ['🔇', ':mute:', null, "Remove logs."],
+  ['👥', ':busts_in_silhouette:', null, "Add or update contributor(s)."],
+  ['🚸', ':children_crossing:', 'patch', "Improve user experience / usability."],
+  ['🏗️', ':building_construction:', null, "Make architectural changes."],
+  ['📱', ':iphone:', 'patch', "Work on responsive design."],
+  ['🤡', ':clown_face:', null, "Mock things."],
+  ['🥚', ':egg:', 'patch', "Add or update an easter egg."],
+  ['🙈', ':see_no_evil:', null, "Add or update a .gitignore file."],
+  ['📸', ':camera_flash:', null, "Add or update snapshots."],
+  ['⚗️', ':alembic:', 'patch', "Perform experiments."],
+  ['🔍️', ':mag:', 'patch', "Improve SEO."],
+  ['🏷️', ':label:', 'patch', "Add or update types."],
+  ['🌱', ':seedling:', null, "Add or update seed files."],
+  ['🚩', ':triangular_flag_on_post:', 'patch', "Add, update, or remove feature flags."],
+  ['🥅', ':goal_net:', 'patch', "Catch errors."],
+  ['💫', ':dizzy:', 'patch', "Add or update animations and transitions."],
+  ['🗑️', ':wastebasket:', 'patch', "Deprecate code that needs to be cleaned up."],
+  ['🛂', ':passport_control:', 'patch', "Work on code related to authorization, roles and permissions."],
+  ['🩹', ':adhesive_bandage:', 'patch', "Simple fix for a non-critical issue."],
+  ['🧐', ':monocle_face:', null, "Data exploration/inspection."],
+  ['⚰️', ':coffin:', null, "Remove dead code."],
+  ['🧪', ':test_tube:', null, "Add a failing test."],
+  ['👔', ':necktie:', 'patch', "Add or update business logic."],
+  ['🩺', ':stethoscope:', null, "Add or update healthcheck."],
+  ['🧱', ':bricks:', null, "Infrastructure related changes."],
+  ['🧑‍💻', ':technologist:', null, "Improve developer experience."],
+  ['💸', ':money_with_wings:', null, "Add sponsorships or money related infrastructure."],
+  ['🧵', ':thread:', null, "Add or update code related to multithreading or concurrency."],
+  ['🦺', ':safety_vest:', null, "Add or update code related to validation."],
+  ['✈️', ':airplane:', null, "Improve offline support."],
+  ['🦖', ':t-rex:', null, "Code that adds backwards compatibility."],];
+
+// Some official gitmojis carry U+FE0F (⚡️, 🔒️, 🗑️ …). A human typing the bare
+// code point means the same emoji, so compare with the variation selector stripped —
+// otherwise the guard would reject a correct commit over an invisible byte.
+const bare = (s) => s.replace(/️/g, '');
+export const EMOJI_SET = new Set(GITMOJIS.map(([e]) => bare(e)));
+export const CODE_SET = new Set(GITMOJIS.map(([, c]) => c));
+
+// git's own functional prefixes: these messages are consumed by `rebase --autosquash`,
+// not read by humans, and the final message is the target commit's. Nothing to enforce.
+const GIT_MAGIC = /^(fixup|squash|amend)!/;
+// A Conventional Commits header, optionally present before the emoji.
+const CONVENTIONAL = /^[a-zA-Z]+(\([^)\n]*\))?!?:\s*/;
+
+// Does this subject line open with a gitmoji — either before the conventional prefix
+// or immediately after it? An emoji buried mid-sentence is not an intention marker.
+export function hasGitmoji(message) {
+  const subject = String(message ?? '').split(/\r?\n/, 1)[0].trim();
+  if (!subject) return false;
+  if (GIT_MAGIC.test(subject)) return true;
+  const candidates = [subject, subject.replace(CONVENTIONAL, '')];
+  for (const c of candidates) {
+    const head = bare(c);
+    for (const e of EMOJI_SET) if (head.startsWith(e)) return true;
+    const code = head.match(/^:[a-z0-9_+-]+:/);
+    if (code && CODE_SET.has(code[0])) return true;
+  }
+  return false;
+}
+
+// ---- reading the message out of a shell command --------------------------------
+// Shell is not parseable in a regex and we do not pretend otherwise: this recognizes
+// the forms an agent or a human actually types, and returns null ("cannot tell") for
+// everything else so the caller allows it.
+
+const COMMIT = /\bgit\b(?:\s+-{1,2}\S+(?:\s+\S+)?)*\s+commit\b/;
+const NO_MESSAGE_TO_READ = /(?:^|\s)(?:-F|--file|--template|-C\s+\S*HEAD|--reuse-message|--reedit-message)\b/;
+const AMEND_NO_EDIT = /--no-edit\b/;
+const HAS_INLINE_M = /(?:^|\s)(?:-[a-zA-Z]*m|--message)(?:=|\s|$)/;
+// `git` must be the command being RUN, not text inside someone else's argument —
+// otherwise `echo "git commit -m x"` or `grep "git commit -m"` gets denied, and a guard
+// that blocks the discussion of commits is exactly the kind that gets switched off.
+const RUNS_GIT = /^\s*(?:sudo\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*git\b/;
+
+const SEPARATORS = /&&|\|\||[;\n]/;
+
+// Is this segment a `git commit` that carries its message inline and readably?
+function readableCommit(segment) {
+  return RUNS_GIT.test(segment)
+    && COMMIT.test(segment)
+    && HAS_INLINE_M.test(segment)
+    && !NO_MESSAGE_TO_READ.test(segment)
+    && !AMEND_NO_EDIT.test(segment);
+}
+
+// `-m "$(cat <<'EOF' … EOF)"` — the multi-line form. The heredoc body IS the message,
+// and it may contain && or ; so it must be lifted out before any splitting.
+function heredocBody(command) {
+  const m = command.match(/<<-?\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?\r?\n([\s\S]*?)\r?\n[ \t]*\1\b/);
+  return m ? m[2] : null;
+}
+
+// -m/--message value, quoted or bare.
+function inlineMessage(segment) {
+  const m = segment.match(/(?:^|\s)(?:-[a-zA-Z]*m|--message)(?:=|\s+)("([^"]*)"|'([^']*)'|([^\s'"][^\s]*))/);
+  if (!m) return null;
+  return m[2] ?? m[3] ?? m[4] ?? null;
+}
+
+// Every commit message this command would write, or null when nothing is checkable.
+export function commitMessages(command) {
+  const cmd = String(command ?? '');
+  if (!COMMIT.test(cmd)) return [];
+
+  // The heredoc form must be handled before any splitting: its body is the message and
+  // may legitimately contain && or ;. The command that owns it is whatever runs just
+  // before the `<<`.
+  const hIdx = cmd.search(/<<-?\s*['"]?[A-Za-z_]/);
+  if (hIdx !== -1) {
+    const owner = cmd.slice(0, hIdx).split(SEPARATORS).pop() || '';
+    if (!readableCommit(owner)) return [];
+    const body = heredocBody(cmd);
+    if (body === null) return [];
+    const first = body.split(/\r?\n/).find((l) => l.trim() !== '');
+    return first === undefined ? [] : [first];
+  }
+
+  const out = [];
+  for (const segment of cmd.split(SEPARATORS)) {
+    if (!readableCommit(segment)) continue;
+    const msg = inlineMessage(segment);
+    if (msg === null) continue;                       // editor commit — cannot read it here
+    if (/^\$/.test(msg.trim())) continue;             // a variable/substitution, not a literal
+    out.push(msg);
+  }
+  return out;
+}
+
+// ---- the deny message (P6: the recovery lives inside the refusal) ---------------
+
+export const SUGGESTIONS = [
+  ['feat', '✨'], ['fix', '🐛'], ['docs', '📝'], ['refactor', '♻️'], ['test', '✅'],
+  ['perf', '⚡️'], ['chore', '🔧'], ['ci', '👷'], ['style', '🎨'], ['revert', '⏪️'],
+];
+
+export function denyMessage(message) {
+  const subject = String(message ?? '').split(/\r?\n/, 1)[0].trim();
+  const type = subject.match(/^([a-zA-Z]+)(\([^)\n]*\))?!?:/)?.[1]?.toLowerCase();
+  const hit = SUGGESTIONS.find(([t]) => t === type);
+  const rewrite = hit
+    ? `${hit[1]} ${subject}`
+    : `${SUGGESTIONS.find(([t]) => t === 'chore')[1]} ${subject || '<type>(<scope>): <subject>'}`;
+  return [
+    `This commit message has no gitmoji: "${subject}".`,
+    'Every commit in this project opens with a gitmoji (gitmoji.dev) before the Conventional Commits header — the intention of the change, readable in one glyph in `git log --oneline`.',
+    `Recover: re-run the commit with the emoji in front — \`${rewrite}\` — picking the gitmoji that matches the intention (✨ feature · 🐛 fix · 📝 docs · ♻️ refactor · ✅ tests · ⚡️ perf · 🔧 config · 👷 CI · 💥 breaking · 🔖 release). The full table is in the \`git-workflow\` skill (references/gitmoji.md). To turn this guard off for this project, create .rsc/.no-gitmoji.`,
+  ].join('\n');
+}
+
+// ---- hook entrypoint -----------------------------------------------------------
+// Skipped when imported by a test (P2: the mechanism is testable without a subprocess).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const root = process.argv[2] || process.cwd();
+  const allow = () => process.exit(0);
+
+  if (existsSync(join(root, '.rsc', '.no-gitmoji'))) allow();
+
+  let input = {};
+  try { input = JSON.parse(readFileSync(0, 'utf8') || '{}'); } catch { allow(); }
+  if ((input.tool_name || input.toolName) !== 'Bash') allow();
+  const command = input.tool_input?.command || input.toolInput?.command || '';
+  if (typeof command !== 'string' || !command) allow();
+
+  let offender = null;
+  try {
+    offender = commitMessages(command).find((m) => !hasGitmoji(m)) ?? null;
+  } catch { allow(); } // any parsing surprise → allow (fail open, by design)
+  if (offender === null) allow();
+
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: denyMessage(offender),
+    },
+  }));
+  process.exit(0);
+}

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -451,6 +451,7 @@ test('every wired hook script is a managed path, so a backup can restore it', as
     'worklog-checkpoint.mjs',
     'ship-guard.mjs',
     'danger-guard.mjs',
+    'gitmoji-guard.mjs',
     'userprompt-gate.mjs',
     'hook-once.mjs',
   ]) {
@@ -779,6 +780,26 @@ test('claude: wires danger-guard on PreToolUse(Bash) alongside ship-guard, mater
   assert.equal(danger[0].matcher, 'Bash');
   assert.ok(danger[0].hooks[0].command.startsWith('node '));
   assert.ok(existsSync(join(cwd, '.rsc/danger-guard.mjs')), 'danger-guard.mjs materialized');
+});
+
+test('claude: wires gitmoji-guard on PreToolUse(Bash) as a third distinct guard, materialized + idempotent', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'rsc-cwd-'));
+  await applyInstall({ skillIds: ['suggest'], target: 'claude', cwd });
+  await applyInstall({ skillIds: ['suggest'], target: 'claude', cwd }); // re-install → no dupes
+
+  const settings = JSON.parse(readFileSync(join(cwd, '.claude/settings.json'), 'utf8'));
+  const gitmoji = settings.hooks.PreToolUse.filter((e) => JSON.stringify(e).includes('gitmoji-guard'));
+  assert.equal(gitmoji.length, 1, 'exactly one gitmoji-guard entry');
+  assert.equal(gitmoji[0].matcher, 'Bash');
+  assert.ok(gitmoji[0].hooks[0].command.startsWith('node '));
+  assert.ok(existsSync(join(cwd, '.rsc/gitmoji-guard.mjs')), 'gitmoji-guard.mjs materialized');
+  // The three Bash guards coexist; wiring one must never drop another.
+  for (const g of ['ship-guard', 'danger-guard']) {
+    assert.equal(
+      settings.hooks.PreToolUse.filter((e) => JSON.stringify(e).includes(g)).length, 1,
+      `${g} still wired`,
+    );
+  }
 });
 
 test('danger-guard: blocks foot-gun commands for a non-technical user', () => {

--- a/tests/gitmoji-guard.test.js
+++ b/tests/gitmoji-guard.test.js
@@ -1,0 +1,223 @@
+// gitmoji-guard.test.js — the tests the constitution demands for a new gate:
+//  P2: the gate proves it gates (real denials, real allowances — not a decorative hook).
+//  P6: every deny message carries its `Recover:` line, asserted here, not assumed.
+//  P7: friction proportional to risk — anything unreadable is allowed, and the
+//      kill-switch (.rsc/.no-gitmoji) is proven to actually disarm the guard.
+//  P3: the reference table in `git-workflow` is checked AGAINST the guard's data, so the
+//      documented emoji set and the enforced one cannot drift apart in silence.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { GITMOJIS, EMOJI_SET, hasGitmoji, commitMessages, denyMessage } from '../targets/gitmoji-guard.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..');
+const GUARD = join(REPO, 'targets', 'gitmoji-guard.mjs');
+const REFERENCE = join(REPO, 'skills', 'git-workflow', 'references', 'gitmoji.md');
+
+// Run the real guard the way Claude Code does (stdin hook JSON). A crash must NOT read
+// as "allow", or the parity tests below would pass on a guard that merely fell over.
+function runGuard(root, command) {
+  const r = spawnSync('node', [GUARD, root], {
+    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command } }),
+    encoding: 'utf8',
+  });
+  assert.equal(r.status, 0, `guard crashed (exit ${r.status}): ${r.stderr}`);
+  assert.equal(r.stderr.trim(), '', `guard wrote to stderr: ${r.stderr}`);
+  if (!r.stdout.trim()) return null; // silence = allow
+  const parsed = JSON.parse(r.stdout); // a non-JSON body is a bug — let it throw
+  return parsed.hookSpecificOutput?.permissionDecision === 'deny' ? parsed : null;
+}
+const denyReason = (root, cmd) => runGuard(root, cmd)?.hookSpecificOutput?.permissionDecisionReason ?? null;
+const freshRoot = () => mkdtempSync(join(tmpdir(), 'rsc-gitmoji-'));
+
+// ---- the data table -------------------------------------------------------------
+
+test('gitmoji: the official set is loaded as data, complete and well-formed', () => {
+  assert.equal(GITMOJIS.length, 75, 'the gitmoji.dev set has 75 entries');
+  for (const [emoji, code, semver, description] of GITMOJIS) {
+    assert.ok(emoji.length > 0, 'every row carries its emoji');
+    assert.match(code, /^:[a-z0-9_+-]+:$/, `shortcode is well-formed: ${code}`);
+    assert.ok(semver === null || ['patch', 'minor', 'major'].includes(semver), `semver is valid: ${code}`);
+    assert.ok(description.length > 0, `${code} says what it means`);
+  }
+  assert.equal(new Set(GITMOJIS.map(([, c]) => c)).size, GITMOJIS.length, 'no duplicate shortcodes');
+});
+
+test('gitmoji: the git-workflow reference table matches the enforced set (no silent drift)', () => {
+  const doc = readFileSync(REFERENCE, 'utf8');
+  // Rows look like: | 🐛 | `:bug:` | patch | Fix a bug |
+  const rows = [...doc.matchAll(/^\|\s*(\S+)\s*\|\s*`(:[a-z0-9_+-]+:)`\s*\|/gm)].map((m) => [m[1], m[2]]);
+  assert.equal(rows.length, GITMOJIS.length, 'the doc documents exactly the enforced set');
+  const byCode = new Map(GITMOJIS.map(([e, c]) => [c, e]));
+  for (const [emoji, code] of rows) {
+    assert.ok(byCode.has(code), `${code} is in the enforced set`);
+    assert.equal(emoji, byCode.get(code), `${code} renders the same emoji in the doc and the guard`);
+  }
+});
+
+// ---- the recognizer -------------------------------------------------------------
+
+test('gitmoji: both prescribed shapes are accepted, for every emoji in the set', () => {
+  for (const [emoji] of GITMOJIS) {
+    assert.ok(hasGitmoji(`${emoji} feat(api): add paging`), `emoji-first: ${emoji}`);
+    assert.ok(hasGitmoji(`feat(api): ${emoji} add paging`), `after the header: ${emoji}`);
+  }
+});
+
+test('gitmoji: shortcodes and bare code points (no U+FE0F) are accepted too', () => {
+  assert.ok(hasGitmoji(':sparkles: feat: add x'), 'shortcode form');
+  assert.ok(hasGitmoji('feat: :bug: fix x'), 'shortcode after the header');
+  assert.ok(hasGitmoji('⚡ perf: faster'), 'bare ⚡ without the variation selector');
+  assert.ok(hasGitmoji('⚡️ perf: faster'), '⚡️ with the variation selector');
+});
+
+test('gitmoji: a bare conventional message is rejected — that is the whole point', () => {
+  for (const m of [
+    'feat(api): add paging', 'fix: reject expired tokens', 'chore(release): 1.0.25',
+    'wip', 'Merge branch main', '', '   ',
+  ]) assert.ok(!hasGitmoji(m), `no gitmoji: "${m}"`);
+});
+
+test('gitmoji: an emoji buried mid-subject is not an intention marker', () => {
+  assert.ok(!hasGitmoji('feat(ui): add the ✨ sparkle toggle'));
+  assert.ok(!hasGitmoji('docs: explain 🐛 triage'));
+});
+
+test('gitmoji: a non-gitmoji emoji does not satisfy the rule', () => {
+  assert.ok(!EMOJI_SET.has('🍕'), 'fixture emoji is genuinely outside the set');
+  assert.ok(!hasGitmoji('🍕 feat: add pizza'));
+});
+
+test('gitmoji: git\'s own functional prefixes are exempt (autosquash consumes them)', () => {
+  for (const m of ['fixup! ✨ feat: add paging', 'squash! feat: add paging', 'amend! whatever']) {
+    assert.ok(hasGitmoji(m), `exempt: ${m}`);
+  }
+});
+
+test('gitmoji: only the subject line is judged, not the body', () => {
+  assert.ok(hasGitmoji('✨ feat: add paging\n\nwhy this matters'), 'gitmoji in the subject → pass');
+  assert.ok(!hasGitmoji('feat: add paging\n\n✨ mentioned in the body'), 'body emoji does not count');
+});
+
+// ---- reading the message out of the command -------------------------------------
+
+test('gitmoji: reads the message from every commit form an agent actually types', () => {
+  assert.deepEqual(commitMessages('git commit -m "feat: x"'), ['feat: x']);
+  assert.deepEqual(commitMessages("git commit -m 'feat: x'"), ['feat: x']);
+  assert.deepEqual(commitMessages('git commit -am "feat: x"'), ['feat: x']);
+  assert.deepEqual(commitMessages('git commit --message="feat: x"'), ['feat: x']);
+  assert.deepEqual(commitMessages('git -C /repo commit -m "feat: x"'), ['feat: x']);
+  assert.deepEqual(commitMessages('git add -A && git commit -m "feat: x"'), ['feat: x']);
+  assert.deepEqual(commitMessages('cd /repo && git commit -m "feat: x"'), ['feat: x']);
+  // The heredoc form: the body is the message and may itself contain && or ;
+  assert.deepEqual(
+    commitMessages('git commit -m "$(cat <<\'EOF\'\nfeat: x\n\nwhy && how; really\nEOF\n)"'),
+    ['feat: x'],
+  );
+  // Two commits in one command: both are read.
+  assert.deepEqual(
+    commitMessages('git commit -m "✨ feat: a" && git commit -m "fix: b"'),
+    ['✨ feat: a', 'fix: b'],
+  );
+});
+
+test('gitmoji: nothing readable → nothing enforced (fail open by design)', () => {
+  for (const c of [
+    'git commit',                          // editor commit
+    'git commit --amend --no-edit',        // keeps the existing message
+    'git commit -F .git/COMMITMSG',        // message from a file
+    'git commit --file=msg.txt',
+    'git commit -C HEAD',                  // reuses another commit's message
+    'git commit -m "$MSG"',                // a variable, not a literal
+    'git status',                          // not a commit at all
+    'git log --oneline -m',
+    'echo "git commit -m broken"',         // a mention, not an invocation
+    'grep -rn "git commit -m" docs/',      // searching for the string
+    'printf \'%s\' "git commit -m x" > note.txt',
+  ]) assert.deepEqual(commitMessages(c), [], `unreadable/irrelevant: ${c}`);
+});
+
+// ---- the gate, end to end -------------------------------------------------------
+
+test('gitmoji-guard: DENIES a commit with no gitmoji', () => {
+  const root = freshRoot();
+  for (const c of [
+    'git commit -m "feat(api): add paging"',
+    'git add -A && git commit -m "fix: reject expired tokens"',
+    'git commit -am "chore: bump deps"',
+    'git commit -m "$(cat <<\'EOF\'\ndocs: rewrite the readme\nEOF\n)"',
+  ]) assert.ok(runGuard(root, c), `should deny: ${c}`);
+});
+
+test('gitmoji-guard: ALLOWS a commit that carries one', () => {
+  const root = freshRoot();
+  for (const c of [
+    'git commit -m "✨ feat(api): add paging"',
+    'git commit -m "feat(api): ✨ add paging"',
+    'git commit -m ":bug: fix: reject expired tokens"',
+    'git add -A && git commit -m "🔧 chore: bump deps"',
+    'git commit -m "$(cat <<\'EOF\'\n📝 docs: rewrite the readme\n\nwhy\nEOF\n)"',
+    'git commit --amend --no-edit',
+    'git status && git log --oneline',
+  ]) assert.equal(runGuard(root, c), null, `should allow: ${c}`);
+});
+
+test('gitmoji-guard: one bad message in a chain is enough to deny', () => {
+  const root = freshRoot();
+  assert.ok(runGuard(root, 'git commit -m "✨ feat: a" && git commit -m "fix: b"'));
+});
+
+test('gitmoji-guard: only Bash tool calls are judged', () => {
+  const root = freshRoot();
+  const r = spawnSync('node', [GUARD, root], {
+    input: JSON.stringify({ tool_name: 'Write', tool_input: { command: 'git commit -m "feat: x"' } }),
+    encoding: 'utf8',
+  });
+  assert.equal(r.stdout.trim(), '', 'a non-Bash tool call is never denied');
+});
+
+test('gitmoji-guard: malformed hook input never blocks the user', () => {
+  const root = freshRoot();
+  for (const input of ['', 'not json', '{}', '{"tool_name":"Bash"}']) {
+    const r = spawnSync('node', [GUARD, root], { input, encoding: 'utf8' });
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout.trim(), '', `allowed on malformed input: ${JSON.stringify(input)}`);
+  }
+});
+
+// ---- P6: the refusal carries its own way out ------------------------------------
+
+test('gitmoji-guard: every deny names the recovery, the fix and the kill switch', () => {
+  const root = freshRoot();
+  const reason = denyReason(root, 'git commit -m "feat(api): add paging"');
+  assert.ok(reason.includes('Recover:'), 'the deny carries a Recover: line');
+  assert.ok(reason.includes('✨ feat(api): add paging'), 'it hands back the corrected message');
+  assert.ok(reason.includes('.rsc/.no-gitmoji'), 'it names the opt-out');
+  assert.ok(reason.includes('gitmoji.dev'), 'it names where the convention comes from');
+});
+
+test('gitmoji-guard: the suggested rewrite matches the commit type', () => {
+  for (const [type, emoji] of [['feat', '✨'], ['fix', '🐛'], ['docs', '📝'], ['perf', '⚡️'], ['ci', '👷']]) {
+    assert.ok(
+      denyMessage(`${type}(scope): do the thing`).includes(`${emoji} ${type}(scope): do the thing`),
+      `${type} → ${emoji}`,
+    );
+  }
+  // An unrecognized type still gets a usable rewrite rather than an empty suggestion.
+  assert.ok(denyMessage('nonsense subject').includes('🔧 nonsense subject'));
+});
+
+// ---- P7: the kill switch really kills -------------------------------------------
+
+test('gitmoji-guard: .rsc/.no-gitmoji disarms it completely', () => {
+  const root = freshRoot();
+  assert.ok(runGuard(root, 'git commit -m "feat: x"'), 'armed before the opt-out');
+  mkdirSync(join(root, '.rsc'), { recursive: true });
+  writeFileSync(join(root, '.rsc', '.no-gitmoji'), '');
+  assert.equal(runGuard(root, 'git commit -m "feat: x"'), null, 'silent after the opt-out');
+});


### PR DESCRIPTION
## What

Every commit this harness writes now opens with a [gitmoji](https://gitmoji.dev), and the rule is enforced deterministically instead of being asked for in prose.

- **`git-workflow`** — the commit grammar is now `<gitmoji> type(scope)!: subject`, with the everyday type → emoji table in the body and the full official 75-row set in the new `references/gitmoji.md`.
- **`targets/gitmoji-guard.mjs`** (new) — PreToolUse(Bash) hook that **denies** a `git commit` whose message has no gitmoji, with the corrected message inside the refusal. Wired by `targets/claude.js` as the third Bash guard, next to `ship-guard` and `danger-guard`.
- **`ship`** — the commit step states the gitmoji is not optional and points at the table.
- **`release.yml`** — the release bot signs its own commits 🔖/🔧; the harness does not exempt itself from its rule.
- **`doctor`** — reports `gitmojiGuard: armed | opted-out`, so an inert gate cannot read as an armed one.

## Both placements are accepted, on purpose

`✨ feat(api): add paging` is what gitmoji prescribes, but a strict Conventional Commits parser anchors the type at position 0 and rejects the prefix. So the guard also accepts `feat(api): ✨ add paging`, and the reference carries the `headerPattern` that widens commitlint / semantic-release. Prescribing a form that breaks someone else's release pipeline is how a guard earns a kill switch.

## What is deliberately not enforced

Editor commits, `-F <file>`, `--amend --no-edit`, `-C HEAD` and `-m "$VAR"`: the message is not readable in the command, so it is allowed. `fixup!`/`squash!`/`amend!` are exempt — `rebase --autosquash` consumes them, not a human. Opt out per project with `.rsc/.no-gitmoji`.

## Evidence

- 482 tests green (was 462): 19 new in `tests/gitmoji-guard.test.js` + the wiring assertion in `tests/apply.test.js`.
- The reference table is compared against the enforced set by test — the doc and the guard cannot drift apart in silence.
- `validate`, `manifest:check`, `eval-lint`, `drift:check` and the cleanup gate all pass locally.
- Real run, not just fixtures: `rsc sync` on this repo wired all three Bash guards, and the first version's over-fire (`echo "git commit -m …"` being denied) was found and fixed that way.