### PR TITLE
🐛 fix(drift-check): la puerta dejaba de proteger en la máquina donde se desarrolla

### DIFF
--- a/scripts/drift-check.js
+++ b/scripts/drift-check.js
@@ -146,18 +146,50 @@ export function basesFor(docPath, { mode, root }) {
   return [dirname(docPath), root, join(root, '02-DOCS'), join(root, '02-DOCS', 'wiki'), join(root, 'skills')];
 }
 
-const resolves = (target, bases) => bases.some((b) => existsSync(resolve(b, target)));
+// `existsSync` asks the filesystem, and on APFS/HFS+ (macOS) and NTFS (Windows) the filesystem
+// ignores case. So a link to `AUDIT.md` resolves against a file named `audit.md` and this gate goes
+// GREEN on the maintainer's machine while Linux CI — and every installed user — sees a broken link.
+// That is P2 in its most expensive form: the gate fails open exactly where the work is done. It
+// happened for real (the motion-craft port moved references and one link kept its old casing).
+//
+// So existence is checked one path segment at a time against the parent's actual directory listing,
+// which is byte-exact on every filesystem. The walk starts at `root`, which is real by
+// construction; the declared hole is a target that resolves OUTSIDE the repo, where there is no
+// listing we can trust — the repo's own path may sit under a differently-cased volume or behind a
+// symlink, and a false positive in a blocking gate costs more than a named gap.
+// Spec: 02-DOCS/wiki/sdd/specs/drift-check-case.md
+function existsExact(absTarget, root, cache) {
+  const rel = relative(root, absTarget);
+  // Outside the repo (or the root itself): keep the old behaviour, and say so rather than guess.
+  if (rel === '' || rel.startsWith('..') || rel.startsWith('/')) return existsSync(absTarget);
+
+  let dir = root;
+  for (const segment of rel.split('/')) {
+    let entries = cache.get(dir);
+    if (entries === undefined) {
+      // An unreadable directory is not evidence of drift; fall back rather than accuse.
+      try { entries = new Set(readdirSync(dir)); } catch { return existsSync(absTarget); }
+      cache.set(dir, entries);
+    }
+    if (!entries.has(segment)) return false;
+    dir = join(dir, segment);
+  }
+  return true;
+}
+
+const resolves = (target, bases, root, cache) =>
+  bases.some((b) => existsExact(resolve(b, target), root, cache));
 
 // Knowledge mode only. The authoring standards write per-skill paths generically — "every skill
 // carries `evals/cases.yaml`" — which is a claim about a shape shared by 258 directories, not a
 // location. Resolving it against any one skill is the honest reading; treating it as drift
 // produced five findings that were never wrong.
-function resolvesInAnySkill(target, root) {
+function resolvesInAnySkill(target, root, cache) {
   if (target.startsWith('.') || target.startsWith('/')) return false;
   const skillsDir = join(root, 'skills');
   if (!existsSync(skillsDir)) return false;
   for (const e of readdirSync(skillsDir, { withFileTypes: true })) {
-    if (e.isDirectory() && existsSync(join(skillsDir, e.name, target))) return true;
+    if (e.isDirectory() && existsExact(join(skillsDir, e.name, target), root, cache)) return true;
   }
   return false;
 }
@@ -186,6 +218,9 @@ export function scanTree(dir, { mode, root = REPO, label = null } = {}) {
   const findings = [];
   let claims = 0;
   let skipped = 0;
+  // Directory listings, memoized per scan rather than per module: 824 claims share a few hundred
+  // directories, and a cache that outlived the scan would answer from a stale listing.
+  const cache = new Map();
   for (const doc of markdownFiles(dir)) {
     const text = readFileSync(doc, 'utf8');
     const raw = mode === 'catalog'
@@ -199,8 +234,8 @@ export function scanTree(dir, { mode, root = REPO, label = null } = {}) {
         continue;
       }
       claims++;
-      if (mode === 'knowledge' && resolvesInAnySkill(c.target, root)) continue;
-      if (!resolves(c.target, bases)) {
+      if (mode === 'knowledge' && resolvesInAnySkill(c.target, root, cache)) continue;
+      if (!resolves(c.target, bases, root, cache)) {
         findings.push({
           doc: relative(root, doc),
           line: c.line,

--- a/tests/drift-check.test.js
+++ b/tests/drift-check.test.js
@@ -337,3 +337,72 @@ test('drift-check: extraction helpers are exported and behave in isolation', () 
   assert.deepEqual(extractInlinePaths('`scripts/a.js`').map((c) => c.target), ['scripts/a.js']);
   assert.deepEqual(extractInlinePaths('```\n`scripts/a.js`\n```'), [], 'fences win over inline');
 });
+
+// ── case sensitivity ─────────────────────────────────────────────────────────────────────
+// The gate failed OPEN on the maintainer's own machine. `existsSync` is case-insensitive on
+// APFS/HFS+, so a link to `AUDIT.md` resolved against a file named `audit.md` and drift-check said
+// PASS locally while Linux CI said FAIL. It happened for real: the motion-craft port moved skill
+// references into references/, one link kept the old casing, local was green, CI caught it.
+//
+// These tests must be able to FAIL on macOS, which is the whole point — a test that only proves
+// the fix on Linux proves it where the bug never was.
+// Spec: 02-DOCS/wiki/sdd/specs/drift-check-case.md
+test('a link that differs from the real file only in case does NOT resolve', () => {
+  const root = tree({
+    'skills/a/SKILL.md': 'Pull the values from [AUDIT.md](AUDIT.md).\n',
+    'skills/a/audit.md': '# the real file, lowercase\n',
+  });
+  const r = checkCatalog({ root });
+  assert.deepEqual(
+    r.findings.map((f) => `${f.doc} → ${f.target}`),
+    ['skills/a/SKILL.md → AUDIT.md'],
+    'a case-mismatched link resolved — the gate is failing open on this filesystem',
+  );
+});
+
+test('the same link with exact casing resolves', () => {
+  // The other half: a checker that reports everything is as useless as one that reports nothing.
+  const root = tree({
+    'skills/a/SKILL.md': 'Pull the values from [audit.md](audit.md).\n',
+    'skills/a/audit.md': '# the real file, lowercase\n',
+  });
+  assert.deepEqual(checkCatalog({ root }).findings, []);
+});
+
+test('a miscased DIRECTORY segment does not resolve either', () => {
+  // The basename is not the only place case can drift. Checking only the last segment would let
+  // `References/audit.md` through on macOS.
+  const root = tree({
+    'skills/a/SKILL.md': 'See [it](References/audit.md).\n',
+    'skills/a/references/audit.md': '# real\n',
+  });
+  assert.deepEqual(
+    checkCatalog({ root }).findings.map((f) => f.target),
+    ['References/audit.md'],
+  );
+});
+
+test('a link that climbs out of its own directory still resolves when the case is exact', () => {
+  // `../sibling/SKILL.md` is the single most common shape in this catalog. If the exactness walk
+  // broke on `..`, hundreds of real links would turn into findings.
+  const root = tree({
+    'skills/a/SKILL.md': 'Hand off to [sibling](../b/SKILL.md).\n',
+    'skills/b/SKILL.md': '# sibling\n',
+  });
+  assert.deepEqual(checkCatalog({ root }).findings, []);
+});
+
+test('a miscased link is caught even when it climbs out of its own directory', () => {
+  const root = tree({
+    'skills/a/SKILL.md': 'Hand off to [sibling](../B/SKILL.md).\n',
+    'skills/b/SKILL.md': '# sibling\n',
+  });
+  assert.deepEqual(checkCatalog({ root }).findings.map((f) => f.target), ['../B/SKILL.md']);
+});
+
+test('the real catalog does not depend on case-insensitive resolution', () => {
+  // Measured before the change: 0 of 1117 markdown files in the catalog resolved a link only
+  // because macOS ignores case. This pins that, so the hardening cannot silently start reporting
+  // pre-existing links as broken.
+  assert.deepEqual(checkCatalog({ root: REPO }).findings, []);
+});


### PR DESCRIPTION
`drift-check` resolvía enlaces con `existsSync`, y APFS/HFS+ ignora mayúsculas. Un enlace a `AUDIT.md` resolvía contra un fichero `audit.md`: **PASS en local, FAIL en el Linux de CI** — y enlace roto para cualquiera que instale el paquete.

No es hipotético. Pasó ayer en #238: el port movió las referencias a `references/`, un enlace se quedó con el nombre viejo, mi corrida local dijo PASS, lo cazó CI. **El primer test de este PR es ese defecto exacto.**

Es P2 en su forma más cara: una puerta que da la seguridad sin dar la protección, precisamente en la máquina donde se desarrolla. El verde local no significaba lo que parecía.

## El arreglo

La existencia se comprueba **segmento a segmento** contra el listado real del directorio padre, que es byte a byte en cualquier sistema. Comprobar solo el `basename` habría dejado pasar `References/audit.md`.

Los listados se memoizan **por barrido**, no por módulo: 824 afirmaciones comparten unos cientos de directorios, pero una caché que sobreviviera al barrido contestaría con un listado viejo (P3 aplicado a un `Map`).

## El hueco, declarado en vez de tapado

Un destino que resuelve **fuera del repo** mantiene el comportamiento anterior. Ahí no hay listado del que fiarse — la ruta del repo puede estar bajo un volumen con otras mayúsculas o detrás de un symlink — y un falso positivo en una puerta bloqueante se paga con la puerta apagada (P7). Está en el código, en la spec y en el commit.

## Evidencia

**Tres de los seis tests se ven fallar EN MACOS antes del arreglo** — que es donde el bug vivía. Un test que solo lo demuestra en Linux lo demuestra donde el problema no estaba.

| Test | Antes (macOS) |
|---|---|
| enlace miscased no resuelve | ✖ fallaba |
| directorio miscased no resuelve | ✖ fallaba |
| miscased subiendo con `../` no resuelve | ✖ fallaba |
| el caso exacto sí resuelve | ✔ |
| `../` sí resuelve | ✔ |
| el catálogo real sigue limpio | ✔ |

- `npm test` → **564/564**
- `drift:check` → **824** afirmaciones antes y después. Un arreglo que redujera el conteo haría la puerta más callada, que es peor que el bug.
- Los dos hallazgos del modo conocimiento se comprobaron **previos**, no introducidos: ambos dan `false` también con `existsSync`, y este cambio solo puede convertir en `false` lo que antes era `true` por insensibilidad.

## Fuera de alcance, nombrado

Windows tiene la misma insensibilidad y el arreglo le sirve igual, pero no hay CI de Windows donde probarlo. Y queda la pregunta de si `knowledge-doctor`, que también resuelve rutas, necesita la misma dureza.

Spec en `02-DOCS/wiki/sdd/specs/drift-check-case.md` (no trackeado, P9).

