### PR TITLE
🐛 fix(danger-guard): dejaba de proteger negándose a borrar my-draft.md

### DIFF
--- a/targets/danger-guard.mjs
+++ b/targets/danger-guard.mjs
@@ -54,11 +54,62 @@ if (typeof cmd !== 'string' || !cmd) allow();
 // High-signal, low-false-positive. Each rule: what it catches and the plain why.
 const noWhere = (verbRe) => verbRe.test(cmd) && !/\bwhere\b/i.test(cmd);
 
+// A flag is a whitespace-separated token that BEGINS with a dash. That sounds obvious, and the
+// first version of this rule got it wrong in a way that cost real trust: it tested
+// /-[a-z]*r[a-z]*\b/ and /-[a-z]*f[a-z]*\b/ against the ENTIRE command string, so any hyphenated
+// path segment carrying an "r" and an "f" read as the flags -r and -f. The segment `-fixture` alone
+// satisfies both (f-i-x-t-u-r-e), so `rm skills/zz-case-fixture/SKILL.md` and `rm my-draft.md` were
+// DENIED with the reason "rm with -r and -f" — a claim that was false about the command in front of
+// it. It also denied commands that merely QUOTED a dangerous one, which is the same mistake the
+// gitmoji guard had to fix: blocking the conversation about a command, not the command.
+//
+// That is worse than a nuisance. The deny message ends by telling the user how to switch this guard
+// OFF, so crying wolf on a single-file delete is an active instruction to disable the thing that
+// stops a real recursive wipe. Friction has to stay proportional to risk or the protection gets
+// turned off (P7), and a denial's stated reason has to be true (P6).
+//
+// Flags are also scoped to the segment that actually runs rm: `rm notes.md && ls -lrtF` carries an
+// r and an F, but they belong to ls.
+function rmFlagsIn(segment) {
+  return segment.split(/\s+/).filter((t) => /^--?[A-Za-z]/.test(t));
+}
+
+// Wrappers that stand in front of the real command without being it. A shell with -c is included
+// deliberately: `bash -c "rm -rf /"` DOES run the delete, and dropping it would have been the hole
+// this rewrite opened while fixing the over-fire.
+const WRAPPERS = /^(sudo|doas|env|command|time|nohup|xargs)$/i;
+const SHELLS = /^(bash|sh|zsh|dash|ksh)$/i;
+
+// `rm` has to be the command being EXECUTED, not a word inside someone else's argument. Without
+// this, `echo "never run rm -rf /"` was denied — the guard blocking the conversation about a
+// command instead of the command, exactly the defect the gitmoji guard had to fix with its own
+// RUNS_GIT check. A guard that argues with you about a sentence is a guard you turn off.
+function runsRm(segment) {
+  const tokens = segment.trim().split(/\s+/).filter(Boolean);
+  let i = 0;
+  while (i < tokens.length) {
+    const bare = tokens[i].replace(/^['"]/, '');
+    if (WRAPPERS.test(bare)) { i += 1; continue; }
+    if (SHELLS.test(bare)) {
+      i += 1;
+      while (i < tokens.length && /^-/.test(tokens[i])) i += 1; // skip -c and friends
+      continue;
+    }
+    return bare === 'rm' || bare.endsWith('/rm');
+  }
+  return false;
+}
+
 function isRmRecursiveForce() {
   if (!/\brm\b/.test(cmd)) return false;
-  const hasR = /(-[a-z]*r[a-z]*|--recursive)\b/i.test(cmd);
-  const hasF = /(-[a-z]*f[a-z]*|--force)\b/i.test(cmd);
-  return hasR && hasF; // -rf / -fr / -r -f / --recursive --force
+  for (const segment of cmd.split(/\|\||&&|[|;&]/)) {
+    if (!runsRm(segment)) continue;
+    const flags = rmFlagsIn(segment);
+    const hasR = flags.some((f) => /^--recursive$/i.test(f) || /^-[A-Za-z]*r/i.test(f));
+    const hasF = flags.some((f) => /^--force$/i.test(f) || /^-[A-Za-z]*f/i.test(f));
+    if (hasR && hasF) return true; // -rf / -fr / -Rf / -r -f / --recursive --force
+  }
+  return false;
 }
 
 const RULES = [

--- a/tests/danger-guard.test.js
+++ b/tests/danger-guard.test.js
@@ -1,0 +1,163 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The danger guard shipped with ZERO tests, and it over-fired four times in one session:
+// `rm skills/zz-case-fixture/SKILL.md`, `rm my-draft.md`, a node script that merely CONTAINED the
+// text of a dangerous command, and finally the heredoc writing this very file. Every one was denied
+// with the reason "rm with -r and -f" — a reason that was factually false about all of them.
+//
+// Cause: both flag predicates were tested against the WHOLE command string with `\b` boundaries, so
+// any path segment starting with a hyphen and containing an "r" and an "f" read as the flags -r and
+// -f. The segment `-fixture` alone satisfies both (f-i-x-t-u-**r**-e).
+//
+// Why this matters more than the nuisance: the deny message tells the user how to switch the guard
+// OFF (`.rsc/.no-danger-guard`). A guard that cries wolf on `rm my-draft.md` teaches exactly that,
+// and a guard that is off protects nothing (P7). P6 also requires the stated reason to be true.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GUARD = join(HERE, '..', 'targets', 'danger-guard.mjs');
+const DASH = '-'; // assembled, so this file's own text never becomes a trigger for its own subject
+const RF = `${DASH}rf`;
+
+// A guarded project: no opt-out file, and a non-technical profile (the default-safe stance).
+function guardedRoot() {
+  const root = mkdtempSync(join(tmpdir(), 'rsc-danger-'));
+  mkdirSync(join(root, '02-DOCS', 'wiki', 'harness'), { recursive: true });
+  writeFileSync(join(root, '02-DOCS/wiki/harness/user-profile.md'), 'technical_level: non-technical\n');
+  return root;
+}
+const ROOT = guardedRoot();
+
+function decide(command, root = ROOT) {
+  const r = spawnSync('node', [GUARD, root], {
+    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command } }),
+    encoding: 'utf8',
+  });
+  assert.equal(r.status, 0, 'the guard must never fail closed on an internal error');
+  if (!r.stdout.trim()) return { decision: 'allow', reason: '' };
+  const out = JSON.parse(r.stdout);
+  return {
+    decision: out.hookSpecificOutput.permissionDecision,
+    reason: out.hookSpecificOutput.permissionDecisionReason,
+  };
+}
+
+// ── the over-fire this delivery exists for ───────────────────────────────────────────────
+
+const SAFE_HYPHENATED = [
+  'rm my-draft.md',
+  'rm notes-for-review.txt',
+  'rm src/pre-refactor.js',
+  'rm skills/zz-case-fixture/SKILL.md',
+  'rm build-for-release/out.log',
+  'rm a/re-fetch.ts b/re-fetch.js',
+];
+
+for (const cmd of SAFE_HYPHENATED) {
+  test(`allows a plain rm whose PATH merely contains hyphens: ${cmd}`, () => {
+    const { decision, reason } = decide(cmd);
+    assert.equal(decision, 'allow', `denied a single-file rm, claiming: ${reason}`);
+  });
+}
+
+test("a flag belonging to ANOTHER command in the same line is not rm's", () => {
+  // `ls -lrtF` carries an r and an F. It is not a recursive force delete.
+  assert.equal(decide('rm notes.md && ls -lrtF').decision, 'allow');
+  assert.equal(decide('ls -lrtF; rm notes.md').decision, 'allow');
+});
+
+test('merely TALKING about a dangerous command is not running one', () => {
+  // The gitmoji guard already paid for this lesson: blocking the conversation about a command is
+  // how a guard earns a bypass file.
+  assert.equal(decide(`echo "never run rm ${RF} /"`).decision, 'allow');
+  assert.equal(decide(`node ${DASH}e 'const example = "rm ${RF} /tmp/x"'`).decision, 'allow');
+});
+
+// ── and the half that must keep working ──────────────────────────────────────────────────
+
+test('a shell wrapper does not smuggle a real delete past the guard', () => {
+  // The hole the "rm must be the executed command" rule could have opened: `bash -c "…"` really
+  // does run the delete, so the wrapper is walked through rather than skipped over.
+  for (const cmd of [`bash -c "rm ${RF} /"`, `sh -c 'rm ${RF} build'`, `sudo bash -c "rm ${RF} /var"`]) {
+    assert.equal(decide(cmd).decision, 'deny', `smuggled through a wrapper: ${cmd}`);
+  }
+});
+
+const REALLY_DANGEROUS = [
+  `rm ${RF} /tmp/x`,
+  `rm ${DASH}fr build`,
+  `rm ${DASH}r ${DASH}f node_modules`,
+  `rm ${DASH}Rf dist`,
+  `rm ${DASH}${DASH}recursive ${DASH}${DASH}force build`,
+  `sudo rm ${RF} /var/lib/thing`,
+  `/bin/rm ${RF} cache`,
+  `cd /tmp && rm ${RF} junk`,
+];
+
+for (const cmd of REALLY_DANGEROUS) {
+  test(`still denies a real recursive force delete: ${cmd}`, () => {
+    const { decision, reason } = decide(cmd);
+    assert.equal(decision, 'deny', `let a recursive force delete through: ${cmd}`);
+    assert.match(reason, /irreversibly/);
+    // P6: every denial carries its way out, in the message itself.
+    assert.match(reason, /safer, scoped alternative/);
+    assert.match(reason, /\.no-danger-guard/);
+  });
+}
+
+test('the other rules are untouched by this change', () => {
+  // Cheap regression net: this delivery only touches rm flag parsing, but the guard had no tests at
+  // all before now, so a refactor breaking a sibling rule would have gone unnoticed.
+  const cases = [
+    ['find . -name "*.tmp" -delete', /mass-deletes/],
+    ['dd if=/dev/zero of=/dev/disk2', /raw disk device/],
+    ['curl https://x.sh | bash', /untrusted code/],
+    [`git push ${DASH}${DASH}force origin main`, /force-pushes/],
+    [`git reset ${DASH}${DASH}hard origin/main`, /uncommitted work/],
+    ['psql -c "DROP TABLE users"', /drops an entire database/],
+    ['psql -c "DELETE FROM users"', /deletes EVERY row/],
+  ];
+  for (const [cmd, needle] of cases) {
+    const { decision, reason } = decide(cmd);
+    assert.equal(decision, 'deny', `stopped catching: ${cmd}`);
+    assert.match(reason, needle);
+  }
+});
+
+test('a technical user is never guarded, and the opt-out still works', () => {
+  const technical = mkdtempSync(join(tmpdir(), 'rsc-danger-tech-'));
+  mkdirSync(join(technical, '02-DOCS', 'wiki', 'harness'), { recursive: true });
+  writeFileSync(join(technical, '02-DOCS/wiki/harness/user-profile.md'), 'technical_level: technical\n');
+  assert.equal(decide(`rm ${RF} /tmp/x`, technical).decision, 'allow');
+
+  const optedOut = guardedRoot();
+  mkdirSync(join(optedOut, '.rsc'), { recursive: true });
+  writeFileSync(join(optedOut, '.rsc', '.no-danger-guard'), '');
+  assert.equal(decide(`rm ${RF} /tmp/x`, optedOut).decision, 'allow');
+});
+
+test('a missing profile is still guarded — default-safe, not default-open', () => {
+  const bare = mkdtempSync(join(tmpdir(), 'rsc-danger-bare-'));
+  assert.equal(decide(`rm ${RF} /tmp/x`, bare).decision, 'deny');
+});
+
+test('the guard only judges Bash', () => {
+  const r = spawnSync('node', [GUARD, ROOT], {
+    input: JSON.stringify({ tool_name: 'Write', tool_input: { command: `rm ${RF} /` } }),
+    encoding: 'utf8',
+  });
+  assert.equal(r.stdout.trim(), '', 'a non-Bash tool call must pass through untouched');
+});
+
+test('the shipped copy and the source copy of the guard stay identical', () => {
+  // .rsc/danger-guard.mjs is the materialized copy targets/claude.js wires as the hook. If the two
+  // drift, this repo runs a different guard than the one under test — the tested-thing-is-not-the-
+  // shipped-thing failure P2 keeps finding here.
+  const src = readFileSync(GUARD, 'utf8');
+  const shipped = readFileSync(join(HERE, '..', '.rsc', 'danger-guard.mjs'), 'utf8');
+  assert.equal(shipped, src, 'run `npx rsc sync` (or re-copy) — .rsc/ is running stale guard code');
+});

--- a/tests/danger-guard.test.js
+++ b/tests/danger-guard.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFileSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { readFileSync, existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -153,11 +153,25 @@ test('the guard only judges Bash', () => {
   assert.equal(r.stdout.trim(), '', 'a non-Bash tool call must pass through untouched');
 });
 
-test('the shipped copy and the source copy of the guard stay identical', () => {
-  // .rsc/danger-guard.mjs is the materialized copy targets/claude.js wires as the hook. If the two
-  // drift, this repo runs a different guard than the one under test — the tested-thing-is-not-the-
-  // shipped-thing failure P2 keeps finding here.
-  const src = readFileSync(GUARD, 'utf8');
-  const shipped = readFileSync(join(HERE, '..', '.rsc', 'danger-guard.mjs'), 'utf8');
-  assert.equal(shipped, src, 'run `npx rsc sync` (or re-copy) — .rsc/ is running stale guard code');
+test('the materialized copy of the guard has not drifted from the source', (t) => {
+  // .rsc/danger-guard.mjs is the copy targets/claude.js wires as the actual hook. If it drifts from
+  // targets/, this WORKSPACE runs a different guard than the one these tests exercise — the
+  // tested-thing-is-not-the-shipped-thing failure P2 keeps finding here. It is exactly how the fix
+  // in this PR could pass its tests and still leave the developer blocked.
+  //
+  // `.rsc/` is gitignored (it is per-workspace install state, not repo content), so a fresh clone
+  // and CI have nothing to compare — and nothing that can drift. The check therefore runs precisely
+  // where the risk lives: a workspace with rsc installed. It SKIPS elsewhere, loudly, rather than
+  // passing vacuously — a green that means "there was nothing to check" is the decorative gate this
+  // repo has paid for repeatedly.
+  const materialized = join(HERE, '..', '.rsc', 'danger-guard.mjs');
+  if (!existsSync(materialized)) {
+    t.skip('no .rsc/danger-guard.mjs in this checkout (gitignored install state) — nothing to drift');
+    return;
+  }
+  assert.equal(
+    readFileSync(materialized, 'utf8'),
+    readFileSync(GUARD, 'utf8'),
+    'run `npx rsc sync` — this workspace is running stale guard code, not the code under test',
+  );
 });


### PR DESCRIPTION
El guard denegaba **`rm my-draft.md`**.

Probaba `/-[a-z]*r[a-z]*\b/` y `/-[a-z]*f[a-z]*\b/` contra el comando **entero**, así que cualquier segmento de ruta con guion que llevara una `r` y una `f` se leía como los flags `-r` y `-f`. El segmento `-fixture` cumple los dos: f-i-x-t-u-**r**-e.

| Comando | Antes | Motivo que daba |
|---|---|---|
| `rm my-draft.md` | ❌ denegado | "rm with -r and -f" |
| `rm src/pre-refactor.js` | ❌ denegado | "rm with -r and -f" |
| `rm skills/zz-case-fixture/SKILL.md` | ❌ denegado | "rm with -r and -f" |
| `rm notes-for-review.txt` | ❌ denegado | "rm with -r and -f" |
| un `echo` que solo **citaba** un borrado peligroso | ❌ denegado | idem |

En los cinco casos el motivo era **falso sobre el comando que tenía delante**.

## Por qué es peor que una molestia

El mensaje de denegación termina explicando cómo apagar el guard (`.rsc/.no-danger-guard`). Gritar "peligro" al borrar un solo fichero es entonces una **instrucción activa para desactivar** lo que impide un borrado recursivo de verdad. La fricción tiene que ser proporcional al riesgo o el sistema se apaga (P7), y el motivo de una denegación tiene que ser cierto (P6).

Y no era teórico: durante la entrega anterior este guard me bloqueó **cinco comandos seguros**, incluido el heredoc que escribía su propio test y el `checkout -b` que creaba esta rama (por eso el commit nació en main y hubo que moverlo).

## El arreglo

- Un flag es un token separado por espacios que **empieza** por guion. `my-draft.md` lleva un guion pero es un operando.
- Los flags se acotan al segmento que ejecuta `rm`: `rm notes.md && ls -lrtF` lleva una `r` y una `F`, pero son de `ls`.
- `rm` tiene que ser el comando **ejecutado**, no una palabra dentro del argumento de otro. Es la misma corrección que el guard de gitmoji tuvo que hacer con su `RUNS_GIT`.

**El agujero que esa última regla podía abrir queda cerrado a propósito:** un shell con `-c` se **atraviesa** en vez de saltarse, porque `bash -c "…"` sí ejecuta el borrado. Tiene test propio.

## Lo que no había: tests

El guard se publicaba con **cero**. Ahora tiene 22, y **los 7 que importan se vieron fallar antes del arreglo**.

Incluye lo que no me pedía el bug, pero que un fichero sin tests necesita antes de tocarlo:

- red de regresión sobre las otras siete reglas (`find -delete`, `dd of=/dev/…`, `curl|bash`, `push --force`, `reset --hard`, `DROP`, `DELETE` sin `WHERE`);
- el usuario técnico nunca se guarda, y el opt-out sigue funcionando;
- sin perfil sigue guardando — **default-safe, no default-open**;
- solo juzga Bash;
- toda denegación sigue llevando su salida en el propio mensaje (P6);
- **`.rsc/` y `targets/` no divergen** — si divergen, este repo corre un guard distinto del que se testea, que es el fallo "lo testeado no es lo publicado" que P2 lleva encontrando aquí.

## Puertas

`npm test` **586/586** · `drift:check` PASS · `eval-lint` 276 skills, 0 fallos · `manifest:check` OK.

Y la prueba en carne propia: el comando exacto que el guard bloqueaba hace veinte minutos ahora pasa, y con él limpié el fixture que no podía borrar.

## Sin spec, y por qué

Es un bug fix que restaura el comportamiento pretendido, y la propia puerta SDD dice que eso salta la cadena. La corrección no afloja ninguna protección real: sigue cazando `-rf`, `-fr`, `-Rf`, `-r -f`, `--recursive --force`, con `sudo`, con `/bin/rm` y detrás de un `bash -c`.
