### PR TITLE
🐛 fix(windows): los hooks se duplicaban en cada instalación, y desinstalar no borraba ninguno

### DIFF
--- a/scripts/lib/backups.js
+++ b/scripts/lib/backups.js
@@ -146,9 +146,20 @@ function safeRelative(cwd, absPath) {
   return rel.split(sep).join('/');
 }
 
+// A manifest path is split on BOTH separators, because the input is file content — readManifest()
+// reads it off disk — and not every manifest was written by safeRelative() on this platform. A path
+// stored with Windows separators (`..\..\somewhere`) has no '/' to split on, so the old check saw a
+// single segment, found no '..', and handed the raw string to join() — which honours backslashes on
+// Windows. The guard only guarded on POSIX.
+//
+// Splitting into real segments does both jobs at once: `..` becomes visible to the check, and the
+// path is rebuilt by join() rather than passed through, so the separator the manifest happened to
+// use stops mattering. Found while fixing the Windows hook-duplication bug: same family.
+const pathSegments = (value) => value.split(/[/\\]+/).filter(Boolean);
+
 function safeJoin(cwd, relPath) {
-  if (!relPath || isAbsolute(relPath) || relPath.split('/').includes('..')) {
+  if (!relPath || isAbsolute(relPath) || pathSegments(relPath).includes('..')) {
     throw new Error(`path is outside project root: ${relPath}`);
   }
-  return join(cwd, ...relPath.split('/'));
+  return join(cwd, ...pathSegments(relPath));
 }

--- a/targets/claude.js
+++ b/targets/claude.js
@@ -14,6 +14,31 @@ export function writeSkill(id, fromDir, toPath) {
   return linkOrCopy(fromDir, toPath);
 }
 
+// A hook entry, stringified with its path separators normalized to `/`.
+//
+// This exists because of a Windows bug that cost real users 4× the context budget. `join()` yields
+// `.rsc\session-start.mjs` on Windows, `JSON.stringify` escapes that to `.rsc\\session-start.mjs`,
+// and all seven dedup filters below searched for a forward-slash needle (`.rsc/session-start.`).
+// The needle never matched, so every `install` / `add` / `sync` APPENDED a hook instead of replacing
+// it: a real Windows box reported every hook present four times, which means the `suggest` always-on
+// body was injected 4× per session start and all six guards ran 4× per command.
+//
+// Worse, and unreported: `unwireHook` uses the same needles, so on Windows `uninstall` and `purge`
+// removed NONE of the hooks they claim to remove — a cleanup that silently cleans nothing.
+//
+// ONE replacement, and only the JSON-escaped form. `JSON.stringify` escapes every backslash as
+// `\\`, so a separator always arrives doubled and a LONE backslash in the JSON text is never a
+// separator — it is some other escape (`\"`, `\n`, `\uXXXX`). Collapsing those too would mangle
+// them for no gain, which is why the second `.replace(/\\/g, '/')` this started with is gone: a
+// mutation pass showed nothing depended on it.
+//
+// Normalizing the HAYSTACK (never the needle) keeps every call site readable as a plain POSIX path,
+// and keeps a user's own `C:\...\my-own-hook.mjs` from ever looking like an rsc hook.
+// `scripts/doctor.js` already handled both forms; this is that knowledge, shared.
+export function hookWiringOf(entry) {
+  return JSON.stringify(entry).replace(/\\\\/g, '/');
+}
+
 // Inverse of wireHook: drop every rsc-wired hook entry (any command pointing at a
 // .rsc/ script — session-start, worklog-checkpoint, ship-guard, danger-guard, … —
 // plus the legacy cat-form) from settings.json, across all events. User hooks and
@@ -27,7 +52,7 @@ export function unwireHook(paths) {
   if (!settings.hooks) return [];
   for (const event of Object.keys(settings.hooks)) {
     settings.hooks[event] = (settings.hooks[event] || []).filter((e) => {
-      const s = JSON.stringify(e);
+      const s = hookWiringOf(e);
       return !s.includes('.rsc/') && !s.includes('skills/rsc/suggest');
     });
     if (settings.hooks[event].length === 0) delete settings.hooks[event];
@@ -61,7 +86,7 @@ export function wireHook(paths) {
   settings.hooks ||= {};
   settings.hooks.SessionStart ||= [];
   settings.hooks.SessionStart = settings.hooks.SessionStart.filter((e) => {
-    const s = JSON.stringify(e);
+    const s = hookWiringOf(e);
     // drop legacy cat-form and any prior session-start script (.sh from the bash era, or .mjs)
     return !s.includes('skills/rsc/suggest') && !s.includes('.rsc/session-start.');
   });
@@ -78,7 +103,7 @@ export function wireHook(paths) {
   for (const event of ['PreCompact', 'SessionEnd']) {
     settings.hooks[event] ||= [];
     settings.hooks[event] = settings.hooks[event].filter(
-      (e) => !JSON.stringify(e).includes('.rsc/worklog-checkpoint.'),
+      (e) => !hookWiringOf(e).includes('.rsc/worklog-checkpoint.'),
     );
     settings.hooks[event].push({ hooks: [{ type: 'command', command: wlCmd }] });
   }
@@ -96,7 +121,7 @@ export function wireHook(paths) {
   const sgCmd = `node "${sgDest}" "${paths.projectRoot}"`;
   settings.hooks.PreToolUse ||= [];
   settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
-    (e) => !JSON.stringify(e).includes('.rsc/ship-guard.'),
+    (e) => !hookWiringOf(e).includes('.rsc/ship-guard.'),
   );
   settings.hooks.PreToolUse.push({ matcher: 'Bash', hooks: [{ type: 'command', command: sgCmd }] });
 
@@ -109,7 +134,7 @@ export function wireHook(paths) {
   copyFileSync(join(HERE, 'danger-guard.mjs'), dgDest);
   const dgCmd = `node "${dgDest}" "${paths.projectRoot}"`;
   settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
-    (e) => !JSON.stringify(e).includes('.rsc/danger-guard.'),
+    (e) => !hookWiringOf(e).includes('.rsc/danger-guard.'),
   );
   settings.hooks.PreToolUse.push({ matcher: 'Bash', hooks: [{ type: 'command', command: dgCmd }] });
 
@@ -124,7 +149,7 @@ export function wireHook(paths) {
   copyFileSync(join(HERE, 'gitmoji-guard.mjs'), gmDest);
   const gmCmd = `node "${gmDest}" "${paths.projectRoot}"`;
   settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
-    (e) => !JSON.stringify(e).includes('.rsc/gitmoji-guard.'),
+    (e) => !hookWiringOf(e).includes('.rsc/gitmoji-guard.'),
   );
   settings.hooks.PreToolUse.push({ matcher: 'Bash', hooks: [{ type: 'command', command: gmCmd }] });
 
@@ -141,7 +166,7 @@ export function wireHook(paths) {
   const fgCmd = `node "${fgDest}" "${paths.projectRoot}"`;
   settings.hooks.UserPromptSubmit ||= [];
   settings.hooks.UserPromptSubmit = settings.hooks.UserPromptSubmit.filter(
-    (e) => !JSON.stringify(e).includes('.rsc/userprompt-gate.'),
+    (e) => !hookWiringOf(e).includes('.rsc/userprompt-gate.'),
   );
   settings.hooks.UserPromptSubmit.push({ hooks: [{ type: 'command', command: fgCmd }] });
 

--- a/tests/backups.test.js
+++ b/tests/backups.test.js
@@ -120,3 +120,51 @@ test('restoreBackup rejects manifest paths outside the project root', () => {
 
   assert.throws(() => restoreBackup({ cwd, id: 'bad-snapshot', dryRun: true }), /outside project root/);
 });
+
+// --- path-traversal guard: both separators ---------------------------------
+// safeJoin's traversal check split the manifest path on '/' only, then handed the raw string to
+// join(). A manifest entry written with Windows separators — `..\..\somewhere` — has no '/' to split
+// on, so the check saw a single segment, found no '..', and passed it straight to join(), which DOES
+// honour backslashes on Windows. A guard that only guards on POSIX is the P2 pattern pointed at
+// restore, and the input is file content (readManifest), not in-process data.
+//
+// Found while fixing the Windows hook-duplication bug: same family, different subsystem.
+function manifestWith(cwd, entryPath) {
+  const snap = createBackup({
+    cwd, operation: 'install', target: 'claude',
+    paths: [join(cwd, 'AGENTS.md')], cliVersion: '0.0.0-test',
+  });
+  const file = join(backupsDir(cwd), snap.id, 'manifest.json');
+  const manifest = JSON.parse(readFileSync(file, 'utf8'));
+  manifest.entries = [{ path: entryPath, existed: false, kind: 'missing' }];
+  writeFileSync(file, JSON.stringify(manifest, null, 2) + '\n');
+  return snap.id;
+}
+
+for (const evil of ['../../escaped.txt', '..\\..\\escaped.txt', 'a/../../escaped.txt', 'a\\..\\..\\escaped.txt']) {
+  test(`restoreBackup refuses a manifest path that climbs out: ${JSON.stringify(evil)}`, () => {
+    const cwd = tmp();
+    writeFileSync(join(cwd, 'AGENTS.md'), 'x\n');
+    const id = manifestWith(cwd, evil);
+    assert.throws(
+      () => restoreBackup({ cwd, id, dryRun: true }),
+      /outside project root/,
+      `a manifest path with '..' was accepted: ${evil}`,
+    );
+  });
+}
+
+test('a legitimate nested manifest path still restores, on either separator', () => {
+  // The other half: a guard that rejects everything is as useless as one that rejects nothing.
+  for (const good of ['.claude/settings.json', '.claude\\settings.json']) {
+    const cwd = tmp();
+    writeFileSync(join(cwd, 'AGENTS.md'), 'x\n');
+    const id = manifestWith(cwd, good);
+    const r = restoreBackup({ cwd, id, dryRun: true });
+    assert.equal(r.changed.length, 1, `rejected a legitimate path: ${good}`);
+    assert.ok(
+      r.changed[0].endsWith(join('.claude', 'settings.json')),
+      `resolved to the wrong place: ${r.changed[0]}`,
+    );
+  }
+});

--- a/tests/hook-idempotency.test.js
+++ b/tests/hook-idempotency.test.js
@@ -1,0 +1,179 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { wireHook, unwireHook, hookWiringOf } from '../targets/claude.js';
+
+// On Windows every install APPENDED a hook instead of replacing it. Reported from a real Windows
+// box: after `install` + two `add` + `sync`, every hook was present FOUR times — so the `suggest`
+// always-on body was injected 4× per session start (4× the context cost it is budgeted for, P5)
+// and all six guards ran 4× per command.
+//
+// Cause: `join()` produces `.rsc\session-start.mjs` on Windows, `JSON.stringify` escapes that to
+// `.rsc\\session-start.mjs`, and all seven dedup filters searched for a FORWARD-slash needle
+// (`.rsc/session-start.`). The needle never matched, so the filter never dropped the previous entry.
+//
+// The half the report did not mention, and which is worse: `unwireHook` uses the same forward-slash
+// needle, so on Windows `uninstall`/`purge` removed NONE of the hooks it claims to remove. A
+// cleanup that silently cleans nothing is the decorative gate pattern (P2) pointed at uninstall.
+//
+// These tests run on POSIX and must be able to FAIL there: the Windows-shaped entries are written by
+// hand, so the separator under test never depends on the host. That is the whole point — a test that
+// only reproduces this on Windows could not run in this repo's CI at all.
+const HERE = new URL('.', import.meta.url).pathname;
+
+// A settings.json as a Windows install would have left it: backslash separators throughout.
+const WINDOWS_ENTRY = (script) => ({
+  hooks: [{ type: 'command', command: `node "C:\\proj\\.rsc\\${script}" "C:\\proj"` }],
+});
+const POSIX_ENTRY = (script) => ({
+  hooks: [{ type: 'command', command: `node "/home/u/proj/.rsc/${script}" "/home/u/proj"` }],
+});
+
+function workspace(settings) {
+  const root = mkdtempSync(join(tmpdir(), 'rsc-hooks-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  const hookTarget = join(root, '.claude', 'settings.json');
+  writeFileSync(hookTarget, JSON.stringify(settings, null, 2) + '\n');
+  return {
+    root,
+    hookTarget,
+    read: () => JSON.parse(readFileSync(hookTarget, 'utf8')),
+    paths: {
+      projectRoot: root,
+      hookTarget,
+      skillDir: (id) => join(root, '.claude', 'skills', id),
+    },
+  };
+}
+
+// ── the normalizer, directly ──────────────────────────────────────────────────────────────
+
+test('a Windows-shaped entry matches the same needle as a POSIX one', () => {
+  const needle = '.rsc/session-start.';
+  assert.ok(hookWiringOf(POSIX_ENTRY('session-start.mjs')).includes(needle), 'posix entry');
+  assert.ok(hookWiringOf(WINDOWS_ENTRY('session-start.mjs')).includes(needle), 'windows entry');
+});
+
+test('the normalizer does not turn unrelated entries into matches', () => {
+  // A normalizer that made everything match would delete a user's own hooks — the opposite failure,
+  // and a far more expensive one than a duplicate.
+  const mine = { hooks: [{ type: 'command', command: 'node "C:\\proj\\scripts\\my-own-hook.mjs"' }] };
+  assert.ok(!hookWiringOf(mine).includes('.rsc/'), 'a user hook must never look like an rsc hook');
+});
+
+test('a lone backslash in the JSON text is an escape, not a separator, and is left alone', () => {
+  // Why the normalizer does ONE replacement instead of two: JSON.stringify escapes every backslash
+  // as `\\`, so a separator always arrives doubled. A single backslash in the JSON text is some
+  // other escape — `\"` here — and turning it into a slash would mangle it for no gain. A mutation
+  // pass found that the second replacement this started with was dead weight; this pins that.
+  const quoted = { hooks: [{ command: 'node "C:\\p\\.rsc\\ship-guard.mjs" --msg "he said \\"hi\\""' }] };
+  const wiring = hookWiringOf(quoted);
+  assert.ok(wiring.includes('.rsc/ship-guard.'), 'the separator still normalizes');
+  assert.ok(wiring.includes('\\"'), 'an escaped quote must survive normalization untouched');
+});
+
+test('every separator form of the same path normalizes identically', () => {
+  const forms = [
+    { hooks: [{ command: 'node "C:\\p\\.rsc\\ship-guard.mjs"' }] },
+    { hooks: [{ command: 'node "C:/p/.rsc/ship-guard.mjs"' }] },
+    { hooks: [{ command: 'node "/p/.rsc/ship-guard.mjs"' }] },
+  ];
+  for (const f of forms) {
+    assert.ok(hookWiringOf(f).includes('.rsc/ship-guard.'), `missed: ${JSON.stringify(f)}`);
+  }
+});
+
+// ── wiring: replace, never append ─────────────────────────────────────────────────────────
+
+// Every hook wireHook manages, with the event it lands on. Iterated, so a new hook added without a
+// dedup filter fails this suite instead of quietly duplicating on the next Windows install.
+const MANAGED = [
+  ['SessionStart', 'session-start.mjs'],
+  ['PreCompact', 'worklog-checkpoint.mjs'],
+  ['SessionEnd', 'worklog-checkpoint.mjs'],
+  ['PreToolUse', 'ship-guard.mjs'],
+  ['PreToolUse', 'danger-guard.mjs'],
+  ['PreToolUse', 'gitmoji-guard.mjs'],
+  ['UserPromptSubmit', 'userprompt-gate.mjs'],
+];
+
+for (const [event, script] of MANAGED) {
+  test(`wireHook REPLACES a Windows-shaped ${script} on ${event}, never appends`, () => {
+    const ws = workspace({ hooks: { [event]: [WINDOWS_ENTRY(script)] } });
+    wireHook(ws.paths);
+    const entries = ws.read().hooks[event] || [];
+    const ours = entries.filter((e) => hookWiringOf(e).includes(`.rsc/${script.replace('.mjs', '.')}`));
+    assert.equal(ours.length, 1, `${script} on ${event}: ${ours.length} copies after one wire (expected 1)`);
+  });
+}
+
+test('wiring four times in a row leaves exactly one copy of each hook', () => {
+  // The reported symptom, reproduced end to end: install + two adds + sync.
+  const ws = workspace({});
+  for (let i = 0; i < 4; i += 1) wireHook(ws.paths);
+  const settings = ws.read();
+  for (const [event, script] of MANAGED) {
+    const ours = (settings.hooks[event] || []).filter(
+      (e) => hookWiringOf(e).includes(`.rsc/${script.replace('.mjs', '.')}`),
+    );
+    assert.equal(ours.length, 1, `${script} on ${event} is present ${ours.length}× after 4 wires`);
+  }
+});
+
+test('a pre-existing Windows install converges to one copy, not five', () => {
+  // The upgrade path for the boxes that already have four copies: one wire cleans them all up.
+  const ws = workspace({
+    hooks: {
+      SessionStart: [WINDOWS_ENTRY('session-start.mjs'), WINDOWS_ENTRY('session-start.mjs'),
+        WINDOWS_ENTRY('session-start.mjs'), WINDOWS_ENTRY('session-start.mjs')],
+    },
+  });
+  wireHook(ws.paths);
+  const ours = ws.read().hooks.SessionStart.filter((e) => hookWiringOf(e).includes('.rsc/session-start.'));
+  assert.equal(ours.length, 1, 'four stale Windows copies must collapse to one');
+});
+
+test("a user's own hooks on the same event survive wiring", () => {
+  const mine = { hooks: [{ type: 'command', command: 'node "/p/scripts/my-own.mjs"' }] };
+  const ws = workspace({ hooks: { SessionStart: [mine] } });
+  wireHook(ws.paths);
+  const settings = ws.read();
+  assert.ok(
+    settings.hooks.SessionStart.some((e) => JSON.stringify(e).includes('my-own.mjs')),
+    'wiring must never eat a hook it does not own',
+  );
+});
+
+// ── unwiring: the half the report missed ──────────────────────────────────────────────────
+
+test('unwireHook removes Windows-shaped rsc hooks', () => {
+  const ws = workspace({
+    hooks: {
+      SessionStart: [WINDOWS_ENTRY('session-start.mjs')],
+      PreToolUse: [WINDOWS_ENTRY('danger-guard.mjs'), WINDOWS_ENTRY('gitmoji-guard.mjs')],
+    },
+  });
+  unwireHook(ws.paths);
+  const settings = ws.read();
+  assert.equal(settings.hooks, undefined, `uninstall left hooks behind: ${JSON.stringify(settings)}`);
+});
+
+test('unwireHook keeps hooks it does not own, on both separator styles', () => {
+  const mine = { hooks: [{ type: 'command', command: 'node "C:\\proj\\scripts\\my-own.mjs"' }] };
+  const ws = workspace({ hooks: { SessionStart: [WINDOWS_ENTRY('session-start.mjs'), mine] } });
+  unwireHook(ws.paths);
+  const remaining = ws.read().hooks.SessionStart;
+  assert.equal(remaining.length, 1);
+  assert.ok(JSON.stringify(remaining[0]).includes('my-own.mjs'));
+});
+
+test('unwireHook also removes the legacy cat-form entry', () => {
+  // The bash-era form, kept working through the migration; it has no .rsc/ path at all.
+  const ws = workspace({
+    hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'cat .claude/skills/rsc/suggest/SKILL.md' }] }] },
+  });
+  unwireHook(ws.paths);
+  assert.equal(ws.read().hooks, undefined);
+});


### PR DESCRIPTION
Reportado desde una caja Windows real: tras `install` + dos `add` + `sync`, **cada hook estaba presente cuatro veces.**

Coste medido, no estimado: el cuerpo always-on de `suggest` se inyecta **4× en cada arrancada** —cuatro veces el presupuesto de contexto que P5 vigila— y los seis guards se ejecutan **4× por comando**.

## Causa

`join()` produce `.rsc\session-start.mjs` en Windows. `JSON.stringify` lo escapa a `.rsc\\session-start.mjs`. Y los **siete** filtros de deduplicación buscaban una aguja con barra normal:

```js
!JSON.stringify(e).includes('.rsc/session-start.')   // nunca coincide en Windows
```

La aguja nunca coincidía, así que cada instalación **añadía** en vez de sustituir.

## La mitad que el reporte no menciona, y es peor

`unwireHook` usa las mismas agujas. En Windows, `uninstall` y `purge` **no quitaban ninguno** de los hooks que dicen quitar. Una limpieza que limpia en silencio nada es la puerta decorativa que P2 persigue, apuntada a la desinstalación.

## El arreglo

Un helper, `hookWiringOf()`, normaliza el **pajar** (nunca la aguja) a barras normales. Los siete call sites quedan legibles como rutas POSIX, y el `C:\...\mi-hook.mjs` de un usuario nunca puede parecer un hook de rsc.

**Una sola sustitución, no dos.** `JSON.stringify` escapa *siempre* una barra invertida como `\\`, así que un backslash solitario en el texto JSON nunca es un separador — es otra secuencia de escape (`\"`, `\n`) y convertirla también sería mangling. Eso no lo dedujo el razonamiento: la primera versión llevaba dos sustituciones y **un mutante sobrevivió** demostrando que la segunda era peso muerto.

## Segundo hallazgo, más allá del reporte

Misma familia, otro subsistema. `scripts/lib/backups.js`: el guard de path traversal de `safeJoin` partía la ruta del manifest **solo por `/`**.

El input es contenido de fichero — `readManifest()` lo lee de disco —, así que un manifest con separadores Windows (`..\..\algo`) no tenía ningún `/` por el que partir: el guard veía un solo segmento, no encontraba `..`, y pasaba la cadena cruda a `join()`, que sí respeta barras invertidas en Windows. **El guard solo guardaba en POSIX.**

Severidad baja (el manifest es estado local, quien pueda escribirlo ya tiene otras vías) pero es un guard que no guarda, y el arreglo es una línea. Va en este PR por ser la misma familia; **si lo prefieres separado, lo separo.**

## Evidencia

| | |
|---|---|
| Tests nuevos | 17 de idempotencia de hooks + 5 del guard de traversal |
| Suite | **608/608** |
| Mutantes | **12/12 muertos** — y el primero es el código **pre-arreglo**: si ese sobrevive, el test nunca reprodujo el bug |
| Corrida real POSIX | `install` + 2 `add` + `sync` → **1 copia** de cada uno de los 7 hooks |
| Ruta de actualización | una caja que **ya tiene 4 copias** converge a 1 con un solo `install`. Nadie limpia a mano |

**Los tests pueden fallar en macOS**, que es lo que los hace válidos: escriben a mano las entradas con barra invertida, así que el separador bajo prueba no depende del host. Un test que solo reprodujera esto en Windows no se podría correr en el CI de este repo.

La tabla de hooks gestionados se itera desde el test, así que un hook nuevo sin filtro de deduplicación pone la suite en rojo en vez de duplicarse calladamente en la siguiente instalación de Windows.

## Sin spec

Bug fix que restaura el comportamiento pretendido; la puerta SDD dice explícitamente que eso salta la cadena.
