### PR TITLE
✨ feat(doctor): cuenta los hooks que hay, y nombra sus dos costes por separado

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -93,30 +93,140 @@ function alwaysOnBytesFor(scopeRoot, settingsRaw) {
   return bytesOf(join(scopeRoot, '.rsc', 'skills', 'suggest', 'SKILL.md'));
 }
 
+// Every hook rsc wires, as a table rather than a chain of `if`s: adding one is a row, and
+// tests/doctor-hook-counts.test.js iterates it, so a hook added without a row fails the suite instead
+// of shipping uncounted. `needle` is the SCRIPT PATH, never the bare `.rsc` — a user's own hook that
+// merely mentions the directory must not be counted as ours.
+//
+// `injects` marks the two hooks that put text into the conversation. It matters because a duplicated
+// guard costs processes, not bytes, and conflating the two is how this report lied in the first place.
+export const RSC_HOOKS = [
+  { id: 'session-start', label: 'session-start', needle: '.rsc/session-start.', injects: 'sessionStart' },
+  { id: 'userprompt-gate', label: 'userprompt-gate', needle: '.rsc/userprompt-gate.', injects: 'perTurn' },
+  { id: 'worklog-checkpoint', label: 'worklog-checkpoint', needle: '.rsc/worklog-checkpoint.', injects: null },
+  { id: 'ship-guard', label: 'ship-guard', needle: '.rsc/ship-guard.', injects: null },
+  { id: 'danger-guard', label: 'danger-guard', needle: '.rsc/danger-guard.', injects: null },
+  { id: 'gitmoji-guard', label: 'gitmoji-guard', needle: '.rsc/gitmoji-guard.', injects: null },
+  // The bash-era form, still retired by unwireHook. If uninstall knows how to remove it, the report
+  // has to know how to count it.
+  { id: 'legacy-cat-form', label: 'legacy suggest hook', needle: 'skills/rsc/suggest', injects: 'sessionStart' },
+];
+
+// Separators come from whatever platform installed: JSON escapes a Windows backslash as a pair, so
+// the haystack is normalized before comparing. Same lesson as targets/claude.js, same one-liner.
+const entryWiring = (entry) => JSON.stringify(entry).replace(/\\\\/g, '/');
+
+/**
+ * How many times each rsc hook is wired, per event.
+ * @returns {{perEvent: Object<string, Object<string, number>>, indeterminate: string[]}}
+ */
+export function countHookEntries(settings) {
+  const perEvent = {};
+  const indeterminate = [];
+  const hooks = settings && typeof settings === 'object' ? settings.hooks : null;
+  if (!hooks || typeof hooks !== 'object') return { perEvent, indeterminate };
+
+  for (const [event, entries] of Object.entries(hooks)) {
+    // A hand-edited file can put anything here. An event we cannot read is REPORTED, never counted as
+    // zero — a silent zero is exactly the "all clear" this whole delivery exists to stop.
+    if (!Array.isArray(entries)) { indeterminate.push(event); continue; }
+    for (const entry of entries) {
+      const wiring = entryWiring(entry);
+      for (const hook of RSC_HOOKS) {
+        if (!wiring.includes(hook.needle)) continue;
+        perEvent[event] ||= {};
+        perEvent[event][hook.id] = (perEvent[event][hook.id] || 0) + 1;
+      }
+    }
+  }
+  return { perEvent, indeterminate };
+}
+
+// The most copies any one hook has, per injection channel — that is the multiplier that channel pays.
+function maxCopies(perEvent, channel) {
+  let most = 1;
+  for (const byHook of Object.values(perEvent)) {
+    for (const [id, n] of Object.entries(byHook)) {
+      const hook = RSC_HOOKS.find((h) => h.id === id);
+      if (hook && hook.injects === channel && n > most) most = n;
+    }
+  }
+  return most;
+}
+
 function readScope(scopeRoot, label) {
   const settingsPath = join(scopeRoot, '.claude', 'settings.json');
   if (!existsSync(settingsPath)) {
     return { label, root: scopeRoot, wired: false, status: 'ok', alwaysOnBytes: 0, perTurnBytes: 0, version: null };
   }
   let raw;
+  let settings;
   try {
     raw = readFileSync(settingsPath, 'utf8');
-    JSON.parse(raw); // a scope we cannot parse is reported, not guessed at
+    settings = JSON.parse(raw); // a scope we cannot parse is reported, not guessed at
   } catch {
     return { label, root: scopeRoot, wired: true, status: 'unknown', alwaysOnBytes: 0, perTurnBytes: 0, version: null };
   }
   const wired = raw.includes('.rsc/') || raw.includes('.rsc\\\\');
   let version = null;
   try { version = readFileSync(join(scopeRoot, '.rsc', '.version'), 'utf8').trim() || null; } catch { /* unknown */ }
+
+  const { perEvent, indeterminate } = countHookEntries(settings);
+  // The context regime is a STATIC fact, not a caveat: the repeated body is suppressed because the
+  // hook calls the single-shot guard, and that guard is a file on disk. Present → the body lands once
+  // however many entries fire. Absent (an install older than the guard) → every entry injects.
+  //
+  // Measured during clarify: four entries sharing a session_id cost ~1.27× context, not 4×. A figure
+  // that multiplied unconditionally would be the same lie that started this spec, aimed the other way.
+  const dedupeGuard = existsSync(join(scopeRoot, '.rsc', 'hook-once.mjs'));
+  const bodyCopies = dedupeGuard ? 1 : maxCopies(perEvent, 'sessionStart');
+  const gateCopies = dedupeGuard ? 1 : maxCopies(perEvent, 'perTurn');
+
   return {
     label,
     root: scopeRoot,
     wired,
     status: 'ok',
     version,
-    alwaysOnBytes: wired ? alwaysOnBytesFor(scopeRoot, raw) : 0,
-    perTurnBytes: wired && raw.includes('userprompt-gate') ? Buffer.byteLength(SDD_GATE_TEXT) : 0,
+    hookCounts: perEvent,
+    hookCountsUnknown: indeterminate.length ? indeterminate : null,
+    dedupeGuard,
+    alwaysOnBytes: wired ? alwaysOnBytesFor(scopeRoot, raw) * bodyCopies : 0,
+    perTurnBytes: wired && raw.includes('userprompt-gate') ? Buffer.byteLength(SDD_GATE_TEXT) * gateCopies : 0,
   };
+}
+
+// One finding per scope that has any hook wired more than once. Both costs are named, because they
+// are different quantities: processes are 4× unconditionally, bytes only when the guard is missing.
+function duplicateEntryFindings(scopes) {
+  const out = [];
+  for (const scope of scopes) {
+    if (scope.status !== 'ok' || !scope.hookCounts) continue;
+    const repeated = [];
+    for (const [event, byHook] of Object.entries(scope.hookCounts)) {
+      for (const [id, n] of Object.entries(byHook)) {
+        if (n > 1) repeated.push({ event, id, n, label: RSC_HOOKS.find((h) => h.id === id)?.label || id });
+      }
+    }
+    if (!repeated.length) continue;
+    const worst = Math.max(...repeated.map((r) => r.n));
+    const list = repeated.map((r) => `${r.event}/${r.label} ×${r.n}`).join(', ');
+    const contextNote = scope.dedupeGuard
+      ? 'Context cost stays near 1× — the single-shot guard suppresses the repeated always-on body '
+        + '(the residue is the banners printed outside it).'
+      : `Context cost is the full ${worst}× — this scope has no single-shot guard materialized, so every `
+        + 'entry injects the always-on body again.';
+    out.push({
+      id: 'duplicate-hook-entries',
+      severity: 'high',
+      summary: `The ${scope.label} scope wires the same hook more than once: ${list}. `
+        + `Execution cost is ${worst}× processes per event — every session start, every turn, and every `
+        + `Bash command spawns that many. ${contextNote}`,
+      action: 'Re-run an install or sync with a current rsc (`npx @ericrisco/rsc@latest`); one pass '
+        + 'collapses the extra copies. No need to hand-edit settings.json.',
+    });
+  }
+  return out;
 }
 
 // Frontmatter `description` of an installed skill — the part of a skill that is ALWAYS in
@@ -165,7 +275,18 @@ export function contextBudget({ target, home = homedir(), cwd = process.cwd() } 
         + 'root, or update both to a version that de-duplicates at runtime.',
     });
   }
+  findings.push(...duplicateEntryFindings(scopes));
   for (const s of scopes) {
+    if (s.hookCountsUnknown) {
+      findings.push({
+        id: 'indeterminate-hook-event',
+        severity: 'low',
+        summary: `In the ${s.label} scope, ${s.hookCountsUnknown.join(', ')} is not a list of hook entries, `
+          + 'so its copies cannot be counted. A count this report cannot make is said out loud, never '
+          + 'reported as zero.',
+        action: 'Fix that entry in settings.json (or remove it), then re-run `rsc doctor`.',
+      });
+    }
     if (s.status === 'unknown') {
       findings.push({
         id: 'unreadable-scope',

--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -144,6 +144,11 @@ function printContextBudget(b) {
   }
   for (const s of b.scopes.filter((x) => x.wired)) {
     say(`  Scope ${s.label.padEnd(8)}: ${s.root}${s.version ? ` (${s.version})` : ''}${s.status === 'unknown' ? ' — UNREADABLE' : ''}`);
+    // Copies are printed only when there is something to see. A line saying "×1" on every healthy
+    // box is noise, and noise is what gets a report skimmed instead of read.
+    const repeated = Object.entries(s.hookCounts || {})
+      .flatMap(([event, byHook]) => Object.entries(byHook).filter(([, n]) => n > 1).map(([id, n]) => `${event}/${id} ×${n}`));
+    if (repeated.length) say(`  Hook copies     : ${repeated.join(' · ')}`);
   }
   for (const f of b.findings) {
     say(`\n  [${f.severity.toUpperCase()}] ${f.summary}`);

--- a/tests/doctor-hook-counts.test.js
+++ b/tests/doctor-hook-counts.test.js
@@ -1,0 +1,200 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { contextBudget, countHookEntries, RSC_HOOKS } from '../scripts/doctor.js';
+
+// `doctor` is the only command whose job is telling the user what the harness costs. On the Windows
+// box that had four copies of every hook, it printed a clean report: 5.4 KB per session start and NO
+// finding at all. The existing duplication finding is about being wired in two SCOPES, so a hook
+// repeated four times inside one scope was invisible in the one place built to see it.
+//
+// What the duplication actually costs, measured during clarify (and NOT what the first draft of the
+// spec claimed): 4× processes per event unconditionally, but only ~1.27× context — the single-shot
+// guard suppresses the repeated body. Without that guard it is a true 4×. So the report has to name
+// two different costs, and it must not present either as the other.
+//
+// Spec: 02-DOCS/wiki/sdd/specs/doctor-counts-hooks.md · Plan: doctor-counts-hooks.plan.md
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI = join(HERE, '..', 'scripts', 'rsc.js');
+
+// A wired scope, built by hand so the separator style under test never depends on the host.
+function wiredScope({ style = 'posix', copies = 1, guard = true, extra = {} } = {}) {
+  const root = mkdtempSync(join(tmpdir(), `rsc-hc-${style}-`));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  mkdirSync(join(root, '.rsc', 'skills', 'suggest'), { recursive: true });
+  writeFileSync(join(root, '.rsc', '.version'), '1.0.32\n');
+  writeFileSync(join(root, '.rsc', 'skills', 'suggest', 'SKILL.md'), 'x'.repeat(5000));
+  // The single-shot guard, materialized or not: this is what decides the context regime.
+  if (guard) writeFileSync(join(root, '.rsc', 'hook-once.mjs'), '// guard\n');
+
+  const path = (script) => (style === 'windows'
+    ? `C:\\proj\\.rsc\\${script}`
+    : join(root, '.rsc', script));
+  const entry = (script) => ({ hooks: [{ type: 'command', command: `node "${path(script)}" "${root}"` }] });
+  const many = (script) => Array.from({ length: copies }, () => entry(script));
+
+  const hooks = {
+    SessionStart: many('session-start.mjs'),
+    PreCompact: many('worklog-checkpoint.mjs'),
+    SessionEnd: many('worklog-checkpoint.mjs'),
+    PreToolUse: [...many('ship-guard.mjs'), ...many('danger-guard.mjs'), ...many('gitmoji-guard.mjs')],
+    UserPromptSubmit: many('userprompt-gate.mjs'),
+    ...extra,
+  };
+  writeFileSync(join(root, '.claude', 'settings.json'), JSON.stringify({ hooks }, null, 2) + '\n');
+  return root;
+}
+
+const emptyHome = () => mkdtempSync(join(tmpdir(), 'rsc-hc-home-'));
+const budgetOf = (cwd) => contextBudget({ target: 'claude', home: emptyHome(), cwd });
+const dupFinding = (b) => b.findings.find((f) => f.id === 'duplicate-hook-entries');
+
+// ── the registry ─────────────────────────────────────────────────────────────────────────
+
+test('the hook registry is a real table, and every row is filled', () => {
+  // A registry with a missing row is a hook nobody counts. Iterated here so adding one without a row
+  // fails the suite instead of shipping uncounted.
+  assert.ok(Array.isArray(RSC_HOOKS) && RSC_HOOKS.length >= 6, `registry too small: ${RSC_HOOKS.length}`);
+  for (const h of RSC_HOOKS) {
+    assert.ok(h.id && /^[a-z0-9-]+$/.test(h.id), `bad id: ${h.id}`);
+    assert.ok(h.needle && h.needle.length > 4, `row ${h.id} has no usable needle`);
+    assert.ok(h.label && h.label.length > 3, `row ${h.id} has no human label`);
+  }
+  const ids = RSC_HOOKS.map((h) => h.id);
+  assert.equal(new Set(ids).size, ids.length, `duplicate ids in the registry: ${ids.join(', ')}`);
+});
+
+for (const style of ['posix', 'windows']) {
+  test(`every registered hook is counted on a ${style}-wired scope`, () => {
+    const root = wiredScope({ style, copies: 4 });
+    const counts = countHookEntries(JSON.parse(readFileSync(join(root, '.claude', 'settings.json'), 'utf8')));
+    for (const h of RSC_HOOKS) {
+      if (h.id === 'legacy-cat-form') continue; // not wired by the fixture; covered by its own test
+      const seen = Object.values(counts.perEvent).some((byHook) => byHook[h.id] === 4);
+      assert.ok(seen, `${h.id} was not counted 4× on a ${style} scope: ${JSON.stringify(counts.perEvent)}`);
+    }
+  });
+}
+
+// ── the finding ──────────────────────────────────────────────────────────────────────────
+
+for (const style of ['posix', 'windows']) {
+  test(`four copies on a ${style} scope produce a finding naming the count`, () => {
+    const b = budgetOf(wiredScope({ style, copies: 4 }));
+    const f = dupFinding(b);
+    assert.ok(f, `no duplicate-hook-entries finding on a ${style} scope with 4 copies`);
+    assert.match(f.summary, /4/, `the finding does not carry the count: ${f.summary}`);
+    assert.match(f.summary, /session-start/, `the finding does not name the hook: ${f.summary}`);
+  });
+}
+
+test('the finding names BOTH costs, and does not present one as the other', () => {
+  // The whole point of the delivery. Reporting only bytes would move the headline from 5.4 to 6.9 KB
+  // and leave the 4× of processes invisible — the same blindness in a new costume.
+  const f = dupFinding(budgetOf(wiredScope({ copies: 4 })));
+  assert.match(f.summary + f.action, /process|proceso/i, 'the execution surcharge is not named');
+  assert.match(f.summary + f.action, /context/i, 'the context surcharge is not named');
+  assert.match(f.summary, /4×|4x/, 'the execution multiplier is not stated');
+});
+
+test('the finding carries the command that collapses the copies (P6)', () => {
+  const f = dupFinding(budgetOf(wiredScope({ copies: 4 })));
+  assert.match(f.action, /rsc/, `no way out in the action: ${f.action}`);
+});
+
+test('the finding is separate from duplicate-wiring, not folded into it', () => {
+  // Decided in clarify: different remedies, so different findings. Folding them would give the user
+  // one finding with two actions and no way to tell which one is theirs.
+  const b = budgetOf(wiredScope({ copies: 4 }));
+  assert.ok(dupFinding(b), 'the entry-duplication finding is missing');
+  assert.ok(!b.findings.some((f) => f.id === 'duplicate-wiring'), 'only one scope is wired here');
+});
+
+// ── the two context regimes ──────────────────────────────────────────────────────────────
+
+test('with the single-shot guard present, the body is NOT multiplied by the copies', () => {
+  // Measured in clarify: four entries sharing a session_id inject the body once. A figure that
+  // multiplied here would be the same lie as the one that started this spec, pointing the other way.
+  const one = budgetOf(wiredScope({ copies: 1, guard: true }));
+  const four = budgetOf(wiredScope({ copies: 4, guard: true }));
+  assert.equal(four.sessionStartBytes, one.sessionStartBytes,
+    'the body was multiplied even though the guard suppresses the repeat');
+  assert.match(dupFinding(four).summary, /suppress|suprim/i, 'the finding does not say the body is suppressed');
+});
+
+test('with the guard ABSENT, the body IS multiplied by the copies', () => {
+  const one = budgetOf(wiredScope({ copies: 1, guard: false }));
+  const four = budgetOf(wiredScope({ copies: 4, guard: false }));
+  assert.equal(four.sessionStartBytes, one.sessionStartBytes * 4,
+    `an install without the guard pays 4×, and the figure must say so: ${four.sessionStartBytes} vs ${one.sessionStartBytes}`);
+});
+
+// ── the half that must not change ────────────────────────────────────────────────────────
+
+test('a healthy scope gets no new finding and the same figures as before', () => {
+  const b = budgetOf(wiredScope({ copies: 1 }));
+  assert.equal(dupFinding(b), undefined, `a healthy box got a duplication finding: ${JSON.stringify(b.findings)}`);
+  assert.ok(b.sessionStartBytes >= 5000, 'the always-on body is still counted');
+  assert.ok(b.perTurnBytes > 0, 'the per-turn gate is still counted');
+});
+
+test("a user's own hook in the same event is not counted as rsc's", () => {
+  const mine = { hooks: [{ type: 'command', command: 'node "/p/scripts/my-own.mjs" --rsc-like' }] };
+  const root = wiredScope({ copies: 1, extra: { SessionStart: [mine] } });
+  const b = budgetOf(root);
+  assert.equal(dupFinding(b), undefined, 'a foreign hook was counted as a duplicate rsc hook');
+});
+
+test('the legacy cat-form is counted as an rsc hook', () => {
+  // If uninstall knows how to retire that form, the report has to know how to count it.
+  const legacy = { hooks: [{ type: 'command', command: 'cat .claude/skills/rsc/suggest/SKILL.md' }] };
+  const root = wiredScope({ copies: 1, extra: { SessionStart: [legacy, legacy] } });
+  const f = dupFinding(budgetOf(root));
+  assert.ok(f, 'two legacy entries were not reported as duplication');
+});
+
+test('an event whose value is not a list is reported indeterminate, not crashed', () => {
+  const root = wiredScope({ copies: 1, extra: { SessionStart: 'hand-edited nonsense' } });
+  const b = budgetOf(root);
+  assert.ok(Array.isArray(b.findings), 'the report survived');
+  assert.ok(
+    b.findings.some((f) => /indetermin/i.test(f.summary + f.id)) || b.scopes.some((s) => s.hookCountsUnknown),
+    `a malformed event was neither reported nor survived visibly: ${JSON.stringify(b.findings)}`,
+  );
+});
+
+test('a scope with no rsc hooks at all reports nothing new', () => {
+  const root = mkdtempSync(join(tmpdir(), 'rsc-hc-bare-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  writeFileSync(join(root, '.claude', 'settings.json'), JSON.stringify({ hooks: {} }, null, 2) + '\n');
+  assert.equal(dupFinding(budgetOf(root)), undefined);
+});
+
+test('an unreadable settings.json behaves exactly as before', () => {
+  const root = wiredScope({ copies: 4 });
+  writeFileSync(join(root, '.claude', 'settings.json'), '{ not json');
+  const b = budgetOf(root);
+  assert.ok(b.scopes.some((s) => s.status === 'unknown'), 'the unreadable scope is still reported');
+  assert.equal(dupFinding(b), undefined, 'nothing is invented for a scope we cannot parse');
+});
+
+// ── the exit code, decided in clarify ────────────────────────────────────────────────────
+
+test('the CLI still exits 0 when duplication is found', () => {
+  // doctor is a report, not a gate. Turning it into one would break every published script that runs
+  // it expecting 0 — decided in clarify, and this is the test that keeps the decision.
+  const root = wiredScope({ copies: 4 });
+  const r = spawnSync('node', [CLI, 'doctor'], { cwd: root, encoding: 'utf8', env: { ...process.env, HOME: emptyHome() } });
+  assert.equal(r.status, 0, `doctor exited ${r.status}:\n${r.stdout}${r.stderr}`);
+  assert.match(r.stdout, /session-start/, 'the duplication is actually printed for a human');
+});
+
+test('the printed report shows the duplication to a human, not only in JSON', () => {
+  const root = wiredScope({ copies: 4 });
+  const r = spawnSync('node', [CLI, 'doctor'], { cwd: root, encoding: 'utf8', env: { ...process.env, HOME: emptyHome() } });
+  assert.match(r.stdout, /4×|4x/, `the multiplier is not visible in the printed report:\n${r.stdout}`);
+});


### PR DESCRIPTION
`doctor` es el único comando cuyo trabajo es decir cuánto cuesta el arnés. En la caja Windows con **cuatro copias de cada hook** imprimía esto:

```text
Per session start : 5.4 KB   (always-on body, per wired scope)
Per user turn     : 0.9 KB
```

**Cero hallazgos.** El hallazgo de duplicación que ya existía habla de estar cableado en dos *scopes*, no de la misma entrada repetida dentro de uno. El usuario tuvo que encontrarlo **a mano**, leyendo `settings.json`, con el único comando que existe para verlo diciéndole que todo estaba bien.

## Lo que la duplicación cuesta de verdad

Medido en `clarify`, y **no era lo que decían ni el reporte ni mi primera redacción de la spec**:

| | Coste |
|---|---|
| Ejecución, incondicional | **4× procesos** por evento — latencia en cada arrancada, cada turno y cada comando Bash |
| Contexto, con `session_id` | **~1.27×** — el guard de una sola vez suprime el cuerpo repetido |
| Contexto, sin `session_id` | **4.00×** — el guard falla en abierto |

Yo había escrito "~21.6 KB por arrancada" en el problema. Era la cifra que uno *supone* sin medir. Eso importa más que la corrección, porque es el mismo error que la entrega persigue: **un número plausible sustituyendo a un número medido.**

Por eso el informe nombra los **dos costes por separado**. Reportar solo bytes habría movido el titular de 5.4 a 6.9 KB dejando invisible el 4× de procesos — la misma ceguera con otro disfraz.

## Lo que el plan aporta y la spec no podía

El régimen de contexto **no es un aviso genérico, es un hecho estático**. El cuerpo repetido se suprime porque el hook llama al guard de una sola vez, y ese guard es un fichero en `.rsc/`. Está o no está, y `doctor` lo mira.

Verificado sobre la misma caja de 4 copias:

```text
con hook-once.mjs    ->  Per session start :  5.4 KB
sin hook-once.mjs    ->  Per session start : 21.4 KB
```

## Cómo queda el informe

```text
  Scope project : /ruta/al/proyecto (1.0.24)
  Hook copies     : SessionStart/session-start ×4 · PreToolUse/danger-guard ×4 · …

  [HIGH] The project scope wires the same hook more than once: … Execution cost is 4×
  processes per event — every session start, every turn, and every Bash command spawns
  that many. Context cost stays near 1× — the single-shot guard suppresses the repeated
  always-on body (the residue is the banners printed outside it).
  → Re-run an install or sync with a current rsc (`npx @ericrisco/rsc@latest`); one pass
    collapses the extra copies. No need to hand-edit settings.json.
```

La línea de copias solo se imprime cuando hay algo que ver: un `×1` en cada caja sana es ruido, y el ruido es lo que hace que un informe se ojee en vez de leerse.

## Detalles que son decisiones

- **`RSC_HOOKS` es un registro iterado desde el test**, así que un hook nuevo sin fila hace fallar la suite en vez de quedar sin contar.
- **La aguja es la ruta del script, nunca `.rsc` a secas.** Un hook propio del usuario que mencione el directorio no se cuenta como nuestro, y hay test.
- **Se cuenta la forma heredada**: si `unwireHook` sabe retirarla, esto sabe contarla.
- **Un evento que no es una lista se reporta indeterminado, nunca como cero.** Un cero silencioso es exactamente el "todo bien" que originó la entrega.
- El separador da igual, que es la lección de 1.0.31.

## El código de salida sigue siendo 0

Decidido en `clarify` y con test que lo sostiene. `doctor` es un informe, no una puerta; convertirlo en puerta rompería cualquier script publicado que hoy lo ejecute esperando 0. Descartada también la bandera `--strict` opt-in: quien no sabe del problema tampoco sabe que existe la bandera.

## Evidencia

| | |
|---|---|
| Tests nuevos | 18 |
| Suite | **629/629** |
| Mutantes | **10/10 muertos** — incluidos los dos simétricos: "multiplica siempre" y "no multiplica nunca" |
| Corrida real | la caja de 4 copias que antes decía que todo estaba bien |
| Puertas | `drift:check` PASS · `eval-lint` PASS · `routing:audit` PASS · `manifest:check` OK |

## Deuda nombrada, no arreglada a medias

La suma entre scopes de `sessionStartBytes` sigue siendo el territorio de `duplicate-wiring`: otro hallazgo con otro remedio. Meter mano ahí desde esta entrega habría mezclado dos problemas.

Spec, plan y el registro del pase de clarify en `02-DOCS/wiki/sdd/` (no trackeado, P9). Aprobada **en autopilot**, no punto por punto.
