### PR TITLE
✨ feat(base): el Base install pasa a ocho con show-me, eli5 y unslop

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $ rsc
   264 skills · one CLI · zero bloat
 
 What do you want to do?          ↑↓ move · enter select
-❯ Base install — the essentials (orient + suggest + bro + harness + init)
+❯ Base install — the essentials (8 skills)
   Base + Spec-Driven Development — specify → plan → implement → ship
   Pick skills by hand, by area
 ```
@@ -185,7 +185,7 @@ rsc                                  # plain-language wizard (recommended) — p
 rsc add fastapi postgresdb           # install specific skills, by name
 rsc add youtube-api remotion-video   # …grow a channel, edit with Remotion
 rsc add fastapi --target claude,codex   # install into several assistants at once
-rsc install --profile minimal        # the floor: orient + suggest + bro + harness + init
+rsc install --profile minimal        # the base: orient + suggest + bro + unslop + show-me + eli5 + harness + init
 rsc install --profile core           # floor + the full SDD workflow
 rsc install --profile full           # everything (all 264)
 rsc install --profile full --without go
@@ -259,7 +259,7 @@ just asks in plain language.
 ### 🧭 Core & control plane
 The front door and the workspace brain.
 
-[init](skills/init/) · [harness](skills/harness/) · [orient](skills/orient/) · [suggest](skills/suggest/) · [bro](skills/bro/) · [author-skill](skills/author-skill/) · [sdd-init](skills/sdd-init/)
+[init](skills/init/) · [harness](skills/harness/) · [orient](skills/orient/) · [suggest](skills/suggest/) · [bro](skills/bro/) · [unslop](skills/unslop/) · [author-skill](skills/author-skill/) · [sdd-init](skills/sdd-init/)
 
 > **harness** is the Karpathy *chaos→knowledge* engine — a `01-TOOLS/` layer (one
 > folder per provider, each with a working `test_connection`) and a `02-DOCS/`
@@ -382,7 +382,7 @@ Three engines + engine-agnostic disciplines. Every engine skill pins the current
 
 ### 🧠 Knowledge & meta
 
-[knowledge-ops](skills/knowledge-ops/) · [codebase-onboarding](skills/codebase-onboarding/) · [research-ops](skills/research-ops/) · [decision-records](skills/decision-records/) · [continuous-learning](skills/continuous-learning/) · [skill-scout](skills/skill-scout/) · [context-budget](skills/context-budget/) · [roast-me](skills/roast-me/) · [fable-operator](skills/fable-operator/)
+[knowledge-ops](skills/knowledge-ops/) · [codebase-onboarding](skills/codebase-onboarding/) · [research-ops](skills/research-ops/) · [decision-records](skills/decision-records/) · [continuous-learning](skills/continuous-learning/) · [skill-scout](skills/skill-scout/) · [context-budget](skills/context-budget/) · [roast-me](skills/roast-me/) · [show-me](skills/show-me/) · [eli5](skills/eli5/) · [fable-operator](skills/fable-operator/)
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "1.1.1",
   "counts": {
-    "skills": 278
+    "skills": 281
   },
   "skills": [
     {
@@ -565,6 +565,7 @@
         "no-jargon"
       ],
       "recommends": [
+        "unslop",
         "brand-voice",
         "technical-writing",
         "translation-l10n"
@@ -1710,6 +1711,29 @@
         "secure-coding"
       ],
       "profiles": []
+    },
+    {
+      "id": "eli5",
+      "description": "Use when a topic must be explained from zero to someone who knows nothing about it: one page, big pictures, very few words, everyday analogies, no jargon and nothing assumed. NOT the smallest in-conversation visual for someone already following (that is `show-me`), NOT a course with exercises (that is `course-builder`).",
+      "tags": [
+        "eli5",
+        "explain",
+        "beginner",
+        "simple",
+        "analogy",
+        "no-jargon",
+        "explicame"
+      ],
+      "recommends": [
+        "show-me",
+        "technical-writing",
+        "course-builder"
+      ],
+      "profiles": [
+        "minimal",
+        "core",
+        "full"
+      ]
     },
     {
       "id": "elixir",
@@ -4688,6 +4712,31 @@
       "profiles": []
     },
     {
+      "id": "show-me",
+      "description": "Use when the user needs to see how something works instead of reading about it: picks the smallest visual that carries the point — pseudocode, call tree, file tree, component tree, Mermaid, a shaped diff, or one HTML page. NOT visual identity (that is `design-loop`), NOT slides (that is `presentations`), NOT a from-zero explainer (that is `eli5`).",
+      "tags": [
+        "show-me",
+        "explain",
+        "diagram",
+        "visual",
+        "mermaid",
+        "diff",
+        "call-tree",
+        "ensename"
+      ],
+      "recommends": [
+        "eli5",
+        "presentations",
+        "technical-writing",
+        "codebase-onboarding"
+      ],
+      "profiles": [
+        "minimal",
+        "core",
+        "full"
+      ]
+    },
+    {
       "id": "simplify-code",
       "description": "Use when correct working code is unnecessarily hard to read, change or verify and needs behaviour-preserving simplification in a bounded scope. Characterizes the observable contract, removes accidental complexity one concept at a time and proves equivalence. NOT fixing a failure (`debug`), NOT read-only diff judgment (`review`/`code-review`).",
       "tags": [
@@ -5359,6 +5408,29 @@
         "unity"
       ],
       "profiles": [
+        "full"
+      ]
+    },
+    {
+      "id": "unslop",
+      "description": "Use when a written text must be audited against a named catalogue of AI tells before it ships: puffery, `not just X but Y`, the rule of three, em dashes, filler, hedging, abstract metaphor nouns. Names each hit and fixes it. NOT the register rewrite in the user's own voice (that is `bro`), NOT a reusable voice guide (that is `brand-voice`).",
+      "tags": [
+        "unslop",
+        "ai-tells",
+        "editing",
+        "audit",
+        "slop",
+        "publish-check",
+        "revisar-texto"
+      ],
+      "recommends": [
+        "bro",
+        "brand-voice",
+        "technical-writing"
+      ],
+      "profiles": [
+        "minimal",
+        "core",
         "full"
       ]
     },

--- a/scripts/lib/domains.js
+++ b/scripts/lib/domains.js
@@ -4,7 +4,7 @@
 // catalog grows deliberately, never silently.
 
 export const DOMAINS = [
-  { title: 'Core & control plane', ids: ['init', 'harness', 'orient', 'suggest', 'bro', 'author-skill', 'sdd-init'] },
+  { title: 'Core & control plane', ids: ['init', 'harness', 'orient', 'suggest', 'bro', 'unslop', 'author-skill', 'sdd-init'] },
   { title: 'Spec-Driven Development', ids: ['sdd', 'constitution', 'idea-refinement', 'specify', 'clarify', 'plan', 'tasks', 'analyze', 'decision-challenge', 'implement', 'source-grounded-development', 'verify', 'review', 'simplify-code', 'ship', 'debug', 'worktrees', 'parallel'] },
   { title: 'Run a business', ids: ['finance-ops', 'invoicing', 'bookkeeping', 'pricing', 'sales-pipeline', 'lead-gen', 'cold-outreach', 'proposals', 'contracts', 'customer-support', 'client-onboarding', 'retention', 'hiring', 'people-ops', 'inventory', 'logistics-ops', 'procurement', 'meeting-notes', 'sop-builder', 'project-ops'] },
   { title: 'Raise & model money', ids: ['pitch-deck', 'investor-materials', 'financial-model', 'fundraising', 'unit-economics', 'grants'] },
@@ -26,7 +26,7 @@ export const DOMAINS = [
   { title: 'Ship & operate — quality & security', ids: ['code-review', 'security-scan', 'secure-coding', 'testing-py', 'testing-web', 'testing-go', 'e2e-testing', 'accessibility', 'performance', 'error-handling', 'observability'] },
   { title: 'Motion & interface craft', ids: ['design-eng', 'animate', 'animate-expo', 'review-animations', 'improve-animations', 'find-animation-opportunities', 'animation-vocabulary', 'apple-design', 'prototype'] },
   { title: 'Design & content craft', ids: ['design-loop', 'design', 'design-dna', 'presentations', 'course-storytelling', 'course-builder', 'technical-writing', 'translation-l10n'] },
-  { title: 'Knowledge & meta', ids: ['knowledge-ops', 'codebase-onboarding', 'research-ops', 'decision-records', 'continuous-learning', 'skill-scout', 'context-budget', 'roast-me', 'fable-operator'] },
+  { title: 'Knowledge & meta', ids: ['knowledge-ops', 'codebase-onboarding', 'research-ops', 'decision-records', 'continuous-learning', 'skill-scout', 'context-budget', 'roast-me', 'show-me', 'eli5', 'fable-operator'] },
 ];
 
 export function allDomainIds() {

--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -161,17 +161,21 @@ async function wizard() {
   const m = loadManifest();
   await banner(m.counts.skills);
   say('  the skill catalog for your assistant (Claude Code · Codex · Cursor · Gemini · Antigravity)\n');
+  // The base set is READ from the manifest, never enumerated here: a hand-kept list in a menu
+  // label is parallel accounting (P3), and it silently starts lying the day a skill's profiles
+  // change. The exact ids are printed before the install confirmation either way.
+  const baseIds = skillsForProfile(m, 'minimal');
   // Navigable loop: esc / "← Back" / "no" all return here instead of quitting.
   for (;;) {
     const choice = await select('What do you want to do?', [
-      { key: 'base', label: 'Base install — the essentials (orient + suggest + bro + harness + init)' },
+      { key: 'base', label: `Base install — the essentials (${baseIds.length} skills)` },
       { key: 'sdd', label: 'Base + Spec-Driven Development — the specify → plan → implement → ship flow' },
       { key: 'manual', label: 'Pick skills by hand, by area' },
     ]);
     if (choice === null) { say('\nOK — nothing installed. Anytime: npx @ericrisco/rsc'); return; }
 
     let ids;
-    if (choice === 'base') ids = skillsForProfile(m, 'minimal');
+    if (choice === 'base') ids = baseIds;
     else if (choice === 'sdd') ids = skillsForProfile(m, 'core');
     else if (choice === 'manual') {
       const picked = await manualSelect();

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -41,7 +41,7 @@ self-driving: an always-on detector proposes the next skill as tasks appear.
 
 ## Facts (verifiable)
 
-- 264 skills; profiles: minimal (5), core (27), full (264).
+- 281 skills; profiles: minimal (8), core (31), full (281).
 - 17 supported coding assistants; skill files written once and symlinked per assistant.
 - Quality gate: every skill scored >= 8.5/10 on an adversarial behavioral rubric before shipping.
 - No global install and no API key required; runs via `npx`.

--- a/skills/bro/SKILL.md
+++ b/skills/bro/SKILL.md
@@ -2,7 +2,7 @@
 name: bro
 description: "Use whenever the user asks to make an answer or draft sound human, natural, plain-spoken or less AI-written — including a terse bro after the last response. Rewrites or drafts in the same language while preserving meaning, facts and channel. NOT a reusable brand voice (that is `brand-voice`), NOT translation (that is `translation-l10n`)."
 tags: [bro, human-writing, humano, plain-language, natural-language, rewrite, no-jargon]
-recommends: [brand-voice, technical-writing, translation-l10n]
+recommends: [unslop, brand-voice, technical-writing, translation-l10n]
 profiles: [minimal, core, full]
 origin: risco
 ---
@@ -56,6 +56,14 @@ plain language instead of deleting precision.
 | Use the same “casual” voice for every audience | A client email, README and condolence need different registers | Infer the room before choosing the cadence |
 | Promise the result is undetectable as AI | No rewrite can honestly guarantee that | Promise clarity and naturalness, not detector outcomes |
 | Announce and justify every edit | The preamble becomes the same friction the user asked to remove | Lead with the finished words |
+
+## Where this ends
+
+`unslop` owns the other half of this job: the **named** audit of a text that already exists, tell by
+catalogued tell (puffery, `not just X but Y`, em dashes, bold-label lists, hedging), run before the
+text ships. This skill owns the **register**: which language, which relationship, which channel, and
+the cadence that fits them. A bare "bro" is always this skill. "Check this for AI tells before I
+publish it" is `unslop`. When a text needs both, audit first, register last.
 
 ## Output boundary
 

--- a/skills/bro/evals/cases.yaml
+++ b/skills/bro/evals/cases.yaml
@@ -46,6 +46,10 @@ should_not_trigger:
     route_to: "simplify-code"
     why: "The requested source-code simplification is owned by simplify-code; 'rewrite' does not make it a prose task."
 
+  - prompt: "Revisa este README antes de publicarlo y dime qué frases suenan a IA, una por una."
+    route_to: "unslop"
+    why: "A named, per-phrase audit of an existing text before shipping is unslop's contract; bro rewrites the register instead of enumerating tells."
+
 capability:
   - scenario: "The previous assistant answer is a long Spanish status update full of headings, repeated summaries, corporate jargon and fake enthusiasm. Rewrite it for a client while preserving a June 30 deadline, a EUR 2,400 price, one unresolved risk, two URLs and the original uncertainty."
     must_include:

--- a/skills/eli5/SKILL.md
+++ b/skills/eli5/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: eli5
+description: "Use when a topic must be explained from zero to someone who knows nothing about it: one page, big pictures, very few words, everyday analogies, no jargon and nothing assumed. NOT the smallest in-conversation visual for someone already following (that is `show-me`), NOT a course with exercises (that is `course-builder`)."
+tags: [eli5, explain, beginner, simple, analogy, no-jargon, explicame]
+recommends: [show-me, technical-writing, course-builder]
+profiles: [minimal, core, full]
+origin: risco
+---
+
+# eli5 — explain it to someone who knows nothing
+
+The topic is whatever the user named. With no topic named, it is the one the conversation is already
+on. The audience is someone with **zero** background: no vocabulary, no context, no patience for a
+definition that needs another definition.
+
+## The contract
+
+1. **A page, not a paragraph.** The output is one self-contained HTML page, big visuals first, words
+   second. Open it when it is written.
+2. **Picture carries the idea, words label it.** If the page still makes sense with the text removed,
+   it is working. Aim for a caption per picture, not a paragraph per picture.
+3. **Everyday objects only.** Compare to things a person has physically handled: boxes, keys, queues
+   at a counter, post, a light switch. Never explain one unknown with another unknown.
+4. **Zero jargon, and zero smuggled jargon.** No term appears without being shown first. "It caches"
+   is jargon; "it keeps a copy nearby so it doesn't have to walk back" is the same fact.
+5. **Simple, never false.** When the simplification would make something untrue, say what got left
+   out, in one line, at the end. A comfortable lie is worse than a hard truth.
+6. **No condescension.** Simple words, adult tone. The reader is new to the topic, not a child.
+
+## The shape of the page
+
+```text
+one sentence: what this thing is, in words a stranger would use
+big picture 1 : the thing, drawn
+big picture 2 : the thing doing its job, step by step
+one line      : the part people get wrong
+one line      : what this explanation left out (only if it left something out)
+```
+
+Three to five visuals is the whole page. Inline SVG or plain HTML boxes beat any chart library here:
+the drawing has to be readable on a phone, at a glance, with no legend to study.
+
+```bash
+open path/to/eli5-<topic>.html
+```
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails | Do this instead |
+| --- | --- | --- |
+| Define a term with two more terms | The reader loses the thread on line one | Show the thing, then name it |
+| A wall of text with one decorative image | That is a blog post with a picture | Picture first, caption second |
+| "Imagine you're a packet travelling…" | Cute framing, still abstract | Compare to an object the reader has held |
+| Simplify until it is wrong | The reader now has to unlearn it | Keep it true and name what you dropped |
+| Baby talk, emoji, exclamation marks | Talks down to the reader | Plain adult words, short sentences |
+| Five diagrams of the same idea | Repetition reads as padding | One picture per genuinely new idea |
+
+## Where this ends
+
+- Someone already following the conversation who needs the shape of one mechanism: `show-me`.
+- A structured curriculum with exercises, assessment and progression: `course-builder`.
+- Documentation an informed reader will keep coming back to: `technical-writing`.
+- Making an existing text sound human rather than simpler: `bro`.

--- a/skills/eli5/evals/README.md
+++ b/skills/eli5/evals/README.md
@@ -1,0 +1,22 @@
+# Evals — eli5
+
+Two claims: that a from-zero request routes here instead of to the in-conversation visual skill or to
+teaching material, and that the loaded skill produces a page a genuine beginner can follow.
+
+## Triggering
+
+Load only `eli5` and run every prompt in 3–5 fresh sessions. A positive passes when `eli5` loads in a
+majority of trials; a negative passes when it stays quiet and the declared `route_to` skill is the
+real owner. Require at least 90% accuracy.
+
+`show-me` is the negative that matters: both are "explain it visually". The discriminator is the
+reader's starting knowledge, and it must survive any description edit on either side.
+
+## Capability
+
+Run the scenario without the skill and with it, same topic and one grader, three trials. The
+with-skill condition must satisfy at least 80% of the rubric and beat the baseline by at least 20
+percentage points.
+
+Grade the jargon point strictly: a baseline answer almost always keeps one unexplained term, which is
+exactly the failure the skill exists to prevent.

--- a/skills/eli5/evals/cases.yaml
+++ b/skills/eli5/evals/cases.yaml
@@ -1,0 +1,54 @@
+skill: eli5
+
+# `eli5` owns one move: a from-zero explanation of one topic, as a page of big
+# pictures and few words, for someone with no background at all. It does not own
+# in-conversation diagrams for someone already following, curricula, or docs.
+should_trigger:
+  - prompt: "Explícame qué es una API como si tuviera cinco años."
+    why: "The canonical from-zero request, named outright, in the user's own language."
+
+  - prompt: "My mum asked me what a VPN is. I need something she can actually look at."
+    why: "A named audience with zero background and an explicit ask for something visual."
+
+  - prompt: "eli5 how a blockchain works"
+    why: "The bare skill name plus a topic is the shortest form of the same request."
+
+  - prompt: "No tengo ni idea de esto. Empieza por lo más básico, sin palabras raras."
+    why: "Zero background plus an explicit no-jargon constraint, with no topic named: the topic is the current one."
+
+  - prompt: "Can you explain what an index is in a database, but for someone who has never programmed?"
+    why: "A technical topic aimed at a non-technical reader is the audience this skill is written for."
+
+  - prompt: "Necesito explicarle a mi cliente, que no es técnico, qué es un webhook. Que lo entienda de una."
+    why: "Explaining to a named non-technical third party is the same job, one step removed."
+
+should_not_trigger:
+  - prompt: "Show me the call order when the form is submitted, I'm lost in the code."
+    route_to: "show-me"
+    why: "The user is already inside the topic and needs one mechanism drawn, not a from-zero page."
+
+  - prompt: "Build a four-week course on SQL with exercises and a final project."
+    route_to: "course-builder"
+    why: "Curriculum, progression and assessment are course-builder; eli5 is a single explanation."
+
+  - prompt: "Write the getting-started docs for our SDK, with runnable examples."
+    route_to: "technical-writing"
+    why: "Reference and tutorial documentation is technical-writing, even when it must be beginner-friendly."
+
+  - prompt: "Make this paragraph sound less robotic before I send it."
+    route_to: "bro"
+    why: "A register and tone pass over existing text is bro; nothing here needs explaining from zero."
+
+  - prompt: "Design the hero section for our homepage so it feels premium."
+    route_to: "design-loop"
+    why: "Visual identity is the design area; eli5's visuals serve comprehension, not brand."
+
+capability:
+  - scenario: "A non-technical business owner asks what a webhook is, after two failed explanations that used the words 'endpoint', 'payload' and 'HTTP POST'."
+    must_include:
+      - "produces one self-contained page with three to five large visuals, not a wall of text"
+      - "uses an everyday physical analogy the reader has handled, not another abstraction"
+      - "introduces no term without showing the thing first, and never uses endpoint, payload or POST unexplained"
+      - "keeps the explanation true, and names in one line whatever was left out"
+      - "stays adult in tone: no baby talk, no emoji, no exclamation marks"
+      - "opens the page for the user instead of only writing the file"

--- a/skills/show-me/SKILL.md
+++ b/skills/show-me/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: show-me
+description: "Use when the user needs to see how something works instead of reading about it: picks the smallest visual that carries the point — pseudocode, call tree, file tree, component tree, Mermaid, a shaped diff, or one HTML page. NOT visual identity (that is `design-loop`), NOT slides (that is `presentations`), NOT a from-zero explainer (that is `eli5`)."
+tags: [show-me, explain, diagram, visual, mermaid, diff, call-tree, ensename]
+recommends: [eli5, presentations, technical-writing, codebase-onboarding]
+profiles: [minimal, core, full]
+origin: risco
+---
+
+# show-me — the smallest picture that answers the question
+
+A second paragraph never fixes the first one. Pick the smallest view that makes the point, put two
+lines of prose beside it, stop.
+
+## The contract
+
+1. **One form, chosen on purpose.** Read what the question is *about*, pick the matching form from
+   the table, draw that. Several forms in one answer is the failure mode, not thoroughness.
+2. **Only the parts that answer the question.** Keep the calls, files, props, states and boundaries
+   the user asked about. Everything else is noise that hides the answer.
+3. **Prose shrinks to fit.** No preamble, no "here is a diagram of". The picture leads; the words
+   caption it.
+4. **Real names.** Actual paths, actual function and component names, actual state values. A diagram
+   of `ServiceA → ServiceB` explains nothing.
+5. **Say so when there is nothing to draw.** A topic with no shape gets a straight answer in prose.
+   A decorative diagram costs the reader time and buys nothing.
+
+## Pick the form from what the topic is
+
+| The question is about | Draw | Why this one |
+| --- | --- | --- |
+| Logic, an algorithm, a decision | pseudocode | branches read top-down; syntax would distract |
+| What calls what at runtime | call tree | shows order and nesting, which prose loses |
+| UI structure | component tree, with state and module boundaries | ownership is the answer most of the time |
+| Which file is responsible for what | shallow file tree with one comment per entry | depth hides the point; one level shows it |
+| Interaction, control flow, data flow between pieces | Mermaid sequence or flow diagram | two-way traffic over time needs an axis |
+| What changes in a shape that already exists | `diff`, in the shape of the topic | the reader keeps their bearings |
+| Layout, visual state, a dense comparison | one self-contained HTML page | text cannot hold it |
+| Nothing with a shape | prose | see contract rule 5 |
+
+```text
+on(save)
+  if content is unchanged
+    return cached result
+  write new content
+  return fresh result
+```
+
+```text
+submitForm
+  createSession
+    persistPrompt
+    launchAgent
+  navigateToSession
+```
+
+```tsx
+<SessionPage> (apps/example/src/routes/session.tsx)
+  useSessionEvents()
+  <SessionToolbar>
+    <RunSkillButton> (packages/ui)
+```
+
+```text
+src/
+├── commands/       # parses user actions
+├── sessions/       # owns session state
+└── transport/      # sends API requests
+```
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant UI
+    participant Daemon
+    User->>UI: choose command
+    UI->>Daemon: send expanded prompt
+    Daemon-->>UI: stream result
+```
+
+## The diff rule
+
+Use `diff` when the surrounding shape already exists and the point is what moves. **Match the diff
+to the topic**: a component change is a component diff, a layout change is a file-tree diff, a
+control-flow change is a pseudocode diff. A unified source diff for a structural change makes the
+reader rebuild the structure in their head.
+
+```diff
+ src/
+ ├── commands/
++│   └── show-me.ts       # expands the slash command
+ ├── sessions/
+-└── transport.ts
++└── transport/
++    ├── client.ts
++    └── stream.ts
+```
+
+```diff
+ on(save)
+-  write content
++  if content is unchanged
++    return cached result
++  write new content
++  invalidate cache
+```
+
+Show the whole block instead of a diff when most of it is new, when the omitted context would hide
+ownership or order, or when the user needs something copyable.
+
+## When it earns an HTML page
+
+Layout, visual state, a side-by-side comparison, or a concept too dense for a text diagram. One
+page, self-contained, real labels and real data, readable on a phone and on a desktop. Inherit the
+product's colours, type and spacing from where it lives; this skill borrows an identity, it never
+invents one. Then open it:
+
+```bash
+open path/to/show-me-<topic>.html
+```
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails | Do this instead |
+| --- | --- | --- |
+| Ship four forms because each adds a little | The reader now has to pick; that was your job | One form, the smallest that answers it |
+| Diagram the whole system when asked about one path | The answer is in there somewhere, which is the same as absent | Draw the path, drop the rest |
+| Placeholder names (`ModuleA`, `doThing`) | Nothing maps back to the codebase | Real paths and real identifiers |
+| A unified source diff for a structural change | Forces the reader to rebuild the shape | Diff in the shape of the topic |
+| Mermaid for a layout question | Boxes and arrows cannot show visual space | One HTML page |
+| A diagram to look thorough | Costs attention, adds nothing | Answer in prose and say why there is nothing to draw |
+
+## Where this ends
+
+- The visual **identity** of an interface, a landing page or a poster is `design-loop` and `design`.
+- A **deck** someone presents from is `presentations`.
+- **Zero prior knowledge**, big pictures, few words, is `eli5`.
+- Restructuring a document, a README or a reference is `technical-writing`.
+- A guided tour of an unfamiliar repository is `codebase-onboarding`; this skill draws the pieces it
+  finds, it does not run the tour.

--- a/skills/show-me/evals/README.md
+++ b/skills/show-me/evals/README.md
@@ -1,0 +1,23 @@
+# Evals — show-me
+
+Two claims are under test: that "show me / I don't get it / draw me" routes here without stealing
+design, deck or beginner-explainer work, and that the loaded skill answers with **one** well-chosen
+visual instead of more prose.
+
+## Triggering
+
+Load only `show-me` and run every `should_trigger` and `should_not_trigger` prompt in 3–5 fresh
+sessions. A positive passes when `show-me` loads in a majority of trials. A negative passes when it
+stays quiet and the declared `route_to` skill is the genuine owner. Require at least 90% accuracy.
+
+The negatives that matter most are `eli5` and `design-loop`: both are adjacent enough that a sloppy
+description pulls them in. Re-run these two after any description edit.
+
+## Capability
+
+Run the scenario in two fresh conditions, without the skill and with it, same source discussion and
+one grader. Score each `must_include` point over three trials. The with-skill condition must satisfy
+at least 80% of the rubric and beat the baseline by at least 20 percentage points.
+
+The discriminating point is **form choice**: a baseline answer typically produces prose plus a
+generic box diagram. Count "picked one form, and the right one" strictly.

--- a/skills/show-me/evals/cases.yaml
+++ b/skills/show-me/evals/cases.yaml
@@ -1,0 +1,61 @@
+skill: show-me
+
+# `show-me` owns one move: the smallest visual that answers the question being
+# asked, placed inside the conversation. It does not own visual identity, decks,
+# teaching material for a beginner, or restructuring a document.
+should_trigger:
+  - prompt: "No entiendo cómo funciona el login. Enséñamelo."
+    why: "An explicit ask to be shown rather than told, about a mechanism that has a shape to draw."
+
+  - prompt: "Can you show me visually how these three services talk to each other?"
+    why: "Interaction between pieces over time is the canonical Mermaid sequence case."
+
+  - prompt: "Draw me the component tree of this page so I can see which component owns the form state."
+    why: "UI structure with an ownership question is the component-tree form, named outright."
+
+  - prompt: "Antes de tocar nada, qué archivo es responsable de qué en src/?"
+    why: "File responsibility maps to the shallow file tree; the user wants the shape before editing."
+
+  - prompt: "I read your explanation twice and still don't get the order things happen in. Picture?"
+    why: "A second failed prose attempt is the trigger this skill exists for; runtime order is a call tree."
+
+  - prompt: "Show me what would change in the folder layout if we split transport.ts into a module."
+    why: "A change to an existing shape is the shaped-diff case, with the diff in the topic's own form."
+
+  - prompt: "Explícame con un diagrama qué pasa cuando el usuario cancela a mitad del pago."
+    why: "An edge path through a flow, explicitly requested as a diagram."
+
+should_not_trigger:
+  - prompt: "Design the landing page for our new pricing tier, it should look premium."
+    route_to: "design-loop"
+    why: "Visual identity and composition are owned by the design area; show-me explains, it does not design."
+
+  - prompt: "Build me a 12-slide deck to present the roadmap to the board on Thursday."
+    route_to: "presentations"
+    why: "A deck someone presents from is presentations; this skill draws inside the conversation."
+
+  - prompt: "Explain how a database index works to someone who has never programmed, like they're five."
+    route_to: "eli5"
+    why: "Zero prior knowledge with big pictures and few words is eli5's contract, not the smallest in-context visual."
+
+  - prompt: "Reorganise this README into a proper tutorial and an API reference."
+    route_to: "technical-writing"
+    why: "Restructuring a document is technical-writing; a diagram inside it would be at most one paragraph of the job."
+
+  - prompt: "Walk me through this whole unfamiliar repo: what it does, how it's built, where to start."
+    route_to: "codebase-onboarding"
+    why: "A guided tour of an unknown codebase is its own skill; show-me only draws the pieces once they are known."
+
+  - prompt: "Build a dashboard with our monthly revenue and churn charts."
+    route_to: "dashboard"
+    why: "A standing analytics surface is dashboard; this is not an explanation of a mechanism."
+
+capability:
+  - scenario: "The user asks, after a dense prose answer, why saving a document sometimes does not trigger a re-render. The real cause is a cache check inside the save handler plus a subscription set up after navigation. Show them."
+    must_include:
+      - "picks one form rather than stacking several, and the form matches the topic (control flow or call tree, not a file tree)"
+      - "uses the real handler, cache and subscription names from the discussion instead of placeholders"
+      - "shows only the path involved in the bug, not the whole module"
+      - "puts at most two lines of prose beside the visual, with no 'here is a diagram of' preamble"
+      - "marks what changes with a diff in the topic's own shape if it proposes a fix"
+      - "does not produce an HTML page for something a text diagram already carries"

--- a/skills/unslop/SKILL.md
+++ b/skills/unslop/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: unslop
+description: "Use when a written text must be audited against a named catalogue of AI tells before it ships: puffery, `not just X but Y`, the rule of three, em dashes, filler, hedging, abstract metaphor nouns. Names each hit and fixes it. NOT the register rewrite in the user's own voice (that is `bro`), NOT a reusable voice guide (that is `brand-voice`)."
+tags: [unslop, ai-tells, editing, audit, slop, publish-check, revisar-texto]
+recommends: [bro, brand-voice, technical-writing]
+profiles: [minimal, core, full]
+origin: risco
+---
+
+# unslop: the named-tell audit a text passes before it ships
+
+`bro` decides how a text should *sound*. This decides whether a text still carries the marks of a
+machine, tell by named tell, on the words that are actually there. Run it on anything about to leave
+the session: a README, a post, an email, a landing page, a commit body.
+
+## The pass
+
+1. **Scan against the tables below.** Every hit gets located, not sensed. If you cannot name the
+   tell, it is not a finding.
+2. **Rewrite in place.** Preserve meaning, facts, numbers, links, commitments and the intended tone.
+3. **Restore the voice** (next section). A text stripped of tells and nothing else reads as sterile,
+   which is its own tell.
+4. **Self-audit once more.** Ask: what still makes this obviously machine written? Fix that too.
+5. **Return the text.** On request, return the list of named hits alongside it.
+
+## Removing tells is half the job
+
+Voiceless writing is as obvious as slopped writing. After the cuts, put something back:
+
+- **Have an opinion.** React to the facts instead of listing balanced pros and cons.
+- **Vary the rhythm.** Short sentence. Then a longer one that takes its time and earns the length.
+- **Admit complexity.** "Impressive and slightly unsettling" beats "impressive".
+- **Use "I" when it fits.** First person is not unprofessional.
+- **Allow some mess.** Perfect symmetry looks manufactured.
+- **Be specific.** Not "this is concerning" but "it churns for six hours at 3am and nobody is watching".
+
+## Content tells
+
+| Tell | Fix |
+| --- | --- |
+| Puffery: "pivotal moment", "testament to", "evolving landscape", "indelible mark" | State what happened |
+| Name dropping outlets with no context | Pick one, quote what it said |
+| Decorative `-ing` clauses: "highlighting...", "ensuring...", "showcasing..." | Delete, or expand into a real claim with a source |
+| Promotional adjectives: "nestled", "vibrant", "breathtaking", "renowned", "must-visit" | Neutral description |
+| Vague attribution: "experts believe", "reports suggest", "critics argue" | Name the source or cut the claim |
+| The formulaic challenge arc: "despite challenges, X continues to thrive" | Specific facts instead of the arc |
+
+## Language tells
+
+| Tell | Fix |
+| --- | --- |
+| AI vocabulary: additionally, crucial, delve, enhance, foster, garner, interplay, intricate, landscape, pivotal, showcase, tapestry, testament, underscore, vibrant | The plain word |
+| Fancy ways to say "is": "serves as", "stands as", "boasts", "features" | "is", "has" |
+| "Not just X, but Y" | State the point directly |
+| Rule of three: forcing every list into three items | The number the facts have |
+| Synonym cycling: protagonist, main character, central figure, hero in one paragraph | Pick one and repeat it |
+| False ranges: "from X to Y" where X and Y share no scale | List the items |
+| Abstract metaphor nouns: substrate, wedge, vector, locus, nexus, primitive, surface, bedrock, scaffolding, paradigm, flywheel, north star, gold-plating, ratchet, evacuate | The concrete word: base, add, way, more than the job needs, move out |
+
+## Style and punctuation tells
+
+| Tell | Fix |
+| --- | --- |
+| Em dashes, anywhere | End the sentence, or use a comma. Swapping in parentheses trades one tell for another |
+| Colons as mid-sentence connectors | Let the point stand as its own sentence. Colons are for lists and examples |
+| Bold on every proper noun and acronym | Bold what the reader must not miss, nothing else |
+| Inline-header lists whose bold label restates the line: "**Performance:** performance improved" | Prose. A bold lead-in that ends in a period and is followed by genuinely new detail is fine |
+| Title Case Headings | Sentence case |
+| Decorative emoji in headings and bullets | Remove |
+| Curly quotes | Straight quotes |
+
+## Filler, hedging and plain speech
+
+| Tell | Fix |
+| --- | --- |
+| "In order to", "due to the fact that", "it is important to note that" | "To", "because", delete |
+| Stacked hedges: "could potentially possibly be argued that it might" | "may", or the claim itself |
+| Generic conclusion: "the future looks bright" | A specific plan, date or number |
+| Chatbot phrases: "I hope this helps", "let me know if", "certainly", "great question" | Remove |
+| Cutoff disclaimers: "while specific details are limited" | Find the detail or drop the sentence |
+| Sycophancy: "you're absolutely right" | Answer directly |
+| Feeling instead of mechanism: "the database stays close at hand" | The mechanism or the number: "`.toSQL()` returns the exact string sent to the database" |
+| A sentence that would fit unchanged in another project's docs | Cut it. It says nothing about this one |
+| Dense sentences the reader has to reparse | One idea per sentence |
+| Passive with a hidden actor: "queries are validated" | Name the actor: "the compiler validates queries" |
+| Adverbs propping up weak verbs: "runs quickly", "significantly improves" | A stronger verb or the measured number |
+| Fancy synonyms: utilize, leverage, facilitate, numerous, in the event that | use, use, help, many, if |
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails | Do this instead |
+| --- | --- | --- |
+| Report the tells and leave the text unfixed | The user asked for a clean text, not a diagnosis | Fix in place, list on request |
+| Cut every tell and stop | Sterile prose is the other AI tell | Restore opinion, rhythm and specifics |
+| Rewrite the meaning while cleaning the style | The edit silently changes the claim | Facts, numbers, links and commitments stay exact |
+| Strip a term because it sounds technical | Precision lost to style is a defect | Keep the term, explain it once |
+| Touch code, commands, URLs, quotes or regulated wording | Those are not prose | Leave them byte for byte |
+| Claim the result will pass an AI detector | Nobody can promise that | Promise named tells removed, nothing more |
+| Flatten a voice the author chose on purpose | Some authors do write long, warm or formal | Match the intended tone, cut only the machine marks |
+
+## Output boundary
+
+Return the cleaned text as an artifact, with no preface. Keep harness commentary, the findings list
+and any compass block clearly outside it, so nothing that is not the text can be copied into an
+email or a document by accident.
+
+## Where this ends
+
+- **`bro`** owns the register pass: make it sound like a person, in the user's language, fitted to the
+  channel and the relationship. A bare "bro" after an answer is always `bro`. This skill is the named
+  audit of a text that already exists, before it goes out.
+- **`brand-voice`** owns the standing voice system across writers and channels.
+- **`technical-writing`** owns structure: what belongs in a tutorial, a reference, a README.
+- **`landing-copy`** owns conversion architecture. Clean its words only after it has chosen them.

--- a/skills/unslop/evals/README.md
+++ b/skills/unslop/evals/README.md
@@ -1,0 +1,25 @@
+# Evals — unslop
+
+The claim under test is the boundary as much as the capability. `bro` sits directly next to this
+skill in the base install, and a description that blurs them costs every user two owners for one
+turn. Half the negatives here exist to prove the split holds.
+
+## Triggering
+
+Load only `unslop` and run every prompt in 3–5 fresh sessions. A positive passes when `unslop` loads
+in a majority of trials; a negative passes when it stays quiet and the declared `route_to` skill is
+the real owner. Require at least 90% accuracy, and treat any failure on the two `bro` negatives as
+blocking rather than statistical: those are the cases the split was designed for.
+
+Run the mirror direction too. `bro`'s own suite carries a negative that routes here; both must pass
+in the same round, or the boundary only exists on one side.
+
+## Capability
+
+Run the scenario without the skill and with it, same post and one grader, three trials. The
+with-skill condition must satisfy at least 80% of the rubric and beat the baseline by at least 20
+percentage points.
+
+Two points discriminate hardest: **naming** the tells by category (a baseline rewrites silently) and
+**preserving** the code block, the price and the URLs (a baseline edits them while tidying). Grade
+both strictly.

--- a/skills/unslop/evals/cases.yaml
+++ b/skills/unslop/evals/cases.yaml
@@ -1,0 +1,60 @@
+skill: unslop
+
+# `unslop` is the named-tell audit of a text that already exists, run before it
+# ships. `bro` is the register pass: sound like a person, in the user's language,
+# fitted to the channel. A bare "bro" is always `bro`; "check this for AI tells
+# before I publish it" is always this skill.
+should_trigger:
+  - prompt: "Revisa este README antes de publicarlo y quítale todo lo que huela a IA."
+    why: "A pre-publication audit of an existing text is the exact contract, in the user's own words."
+
+  - prompt: "Unslop this."
+    why: "The bare skill name over a text in context is the shortest form of the request."
+
+  - prompt: "Can you go through this post and tell me which bits read as AI-written, then fix them?"
+    why: "Named findings plus a fix is what distinguishes this from a general tone rewrite."
+
+  - prompt: "Este texto está lleno de guiones largos y de 'no solo X, sino Y'. Límpialo."
+    why: "The user names two catalogued tells outright; the fix is the enumerated pass."
+
+  - prompt: "I keep getting told my docs sound like ChatGPT wrote them. What exactly am I doing?"
+    why: "The user wants the tells named, which no other writing skill in the catalog does."
+
+  - prompt: "Before this goes to the client, strip the puffery and the hedging but keep every number exact."
+    why: "A ship gate over existing prose with a preserve-the-facts constraint."
+
+should_not_trigger:
+  - prompt: "Bro."
+    route_to: "bro"
+    why: "A bare bro after an answer is the register pass over the last message, not an audit of a supplied text."
+
+  - prompt: "Haz que este correo suene más cercano y menos formal para un cliente de confianza."
+    route_to: "bro"
+    why: "Choosing a warmer register for a specific relationship is bro's job; no tell is being audited."
+
+  - prompt: "Define how our company should sound across the blog, support replies and job ads."
+    route_to: "brand-voice"
+    why: "A standing voice system across channels is brand-voice, not a one-text audit."
+
+  - prompt: "Split this mixed README into a tutorial and an API reference with runnable examples."
+    route_to: "technical-writing"
+    why: "Document structure is technical-writing; unslop edits words, it does not decide document modes."
+
+  - prompt: "Write the hero headline, the offer and the CTA for our pricing page."
+    route_to: "landing-copy"
+    why: "Conversion architecture and net-new copy belong to landing-copy; the audit comes after."
+
+  - prompt: "Translate this announcement into Catalan and adapt the date formats."
+    route_to: "translation-l10n"
+    why: "Translation and locale adaptation are owned elsewhere, even though good prose matters there too."
+
+capability:
+  - scenario: "A 400-word product-launch blog post that opens with 'In today's rapidly evolving landscape', uses four em dashes, three bold-label bullets whose labels restate their lines, 'not just faster, but smarter', 'experts agree', two stacked hedges, and closes with 'the future looks bright'. It also contains a code block, a pricing figure of EUR 39/month and two URLs."
+    must_include:
+      - "names the tells it found by category rather than reporting a general impression"
+      - "removes every em dash without substituting parentheses or en dashes"
+      - "converts the bold-label bullets whose label restates the line into prose, and leaves any bold lead-in that adds new detail"
+      - "replaces 'experts agree' with a named source or cuts the claim"
+      - "keeps the code block, the EUR 39/month figure and both URLs byte for byte"
+      - "leaves the text with a voice: at least one specific, opinionated sentence rather than sterile neutrality"
+      - "returns the cleaned text as the artifact, with the findings list kept outside it"

--- a/tests/base-install.test.js
+++ b/tests/base-install.test.js
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { skillsForProfile } from '../scripts/lib/manifest.js';
+import { buildTextCorpus, cosine } from '../scripts/lib/text-rank.js';
+
+// The base install is the one set every rsc user pays for on every turn, whether or not a skill
+// fires (P5). Two things about it were declared and unchecked until this file existed: WHICH skills
+// it contains, and that the menu label and the README say the same thing the manifest says. A
+// hand-kept enumeration in a label is parallel accounting (P3) and it lies quietly.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const manifest = JSON.parse(readFileSync(join(ROOT, 'manifest.json'), 'utf8'));
+const rscCli = readFileSync(join(ROOT, 'scripts/rsc.js'), 'utf8');
+const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
+
+// The set, spelled out once. Changing the base install means changing this line ON PURPOSE.
+const BASE = ['bro', 'eli5', 'harness', 'init', 'orient', 'show-me', 'suggest', 'unslop'];
+
+test('the base install is exactly the declared set', () => {
+  assert.deepEqual(skillsForProfile(manifest, 'minimal').sort(), [...BASE].sort());
+});
+
+test('the permanent floor stays inside the base install', async () => {
+  const { DEFAULT_SKILL_FLOOR } = await import('../scripts/lib/default-skill-floor.js');
+  // The floor is what gets installed no matter what the user picked. A floor skill outside the
+  // base set would mean "Base install" quietly installs something the base set does not name.
+  for (const id of DEFAULT_SKILL_FLOOR) assert.ok(BASE.includes(id), `floor skill outside base: ${id}`);
+});
+
+test('the wizard label is read from the profile, not enumerated by hand', () => {
+  const line = rscCli.split('\n').find((l) => l.includes("key: 'base'"));
+  assert.ok(line, "the wizard still offers a 'base' choice");
+  assert.match(line, /baseIds\.length/, 'the label counts the real profile');
+  // MUTANT: re-hardcoding the roster in the label is the regression this guards.
+  for (const id of BASE) {
+    assert.doesNotMatch(line, new RegExp(`\\b${id}\\b`), `label hardcodes ${id} instead of reading the profile`);
+  }
+});
+
+test('the README names every base skill on its minimal-profile line', () => {
+  const line = readme.split('\n').find((l) => l.includes('--profile minimal'));
+  assert.ok(line, 'the README still documents the minimal profile');
+  const missing = BASE.filter((id) => !line.includes(id));
+  assert.deepEqual(missing, [], `README minimal line is missing: ${missing.join(', ')}`);
+});
+
+test('no two base skills compete for the same request', () => {
+  // The catalog at large tolerates description overlap up to 0.74 (linkedin-carousels ↔
+  // linkedin-content). The base set does not get that slack: two owners for one request, in the
+  // set every user has installed, is a routing coin flip paid on every turn. Highest pair today:
+  // harness ↔ init at 0.30.
+  const CEILING = 0.5;
+  const corpus = buildTextCorpus(manifest.skills);
+  const offenders = [];
+  for (let i = 0; i < BASE.length; i += 1) {
+    for (let j = i + 1; j < BASE.length; j += 1) {
+      const score = cosine(corpus.vectors.get(BASE[i]), corpus.vectors.get(BASE[j]));
+      if (score >= CEILING) offenders.push(`${BASE[i]} ↔ ${BASE[j]} (${score.toFixed(2)})`);
+    }
+  }
+  assert.deepEqual(offenders, [], `base-install description collisions: ${offenders.join(', ')}`);
+});
+
+test('the boundary between the two writing skills is declared on both sides', () => {
+  // A one-sided boundary is not a boundary: whichever description the ranker happens to like wins.
+  const bro = readFileSync(join(ROOT, 'skills/bro/SKILL.md'), 'utf8');
+  const unslop = readFileSync(join(ROOT, 'skills/unslop/SKILL.md'), 'utf8');
+  assert.match(bro, /`unslop`/, 'bro points at unslop');
+  assert.match(unslop, /`bro`/, 'unslop points at bro');
+  const broCases = readFileSync(join(ROOT, 'skills/bro/evals/cases.yaml'), 'utf8');
+  const unslopCases = readFileSync(join(ROOT, 'skills/unslop/evals/cases.yaml'), 'utf8');
+  assert.match(broCases, /route_to: "unslop"/, 'bro has a negative that routes to unslop');
+  assert.match(unslopCases, /route_to: "bro"/, 'unslop has a negative that routes to bro');
+});


### PR DESCRIPTION
## Qué

El Base install (perfil `minimal`) pasa de 5 a 8 skills. Las cinco de hoy gobiernan el arnés; ninguna cubre las dos peticiones más frecuentes de cualquier sesión: *«no lo entiendo, enséñamelo»* y *«esto suena a IA»*.

| Skill | Trabajo | Descripción |
|---|---|---|
| `show-me` | La forma visual más pequeña que responde la pregunta: pseudocódigo, árbol de llamadas, árbol de ficheros o componentes, Mermaid, diff con la forma del tema, o una página HTML cuando el texto no llega | 349 chars |
| `eli5` | Explicación de cero: una página, dibujos grandes, analogías de objetos que el lector ha tocado, y la línea de qué se ha dejado fuera cuando simplificar mentiría | 321 chars |
| `unslop` | Auditoría **enumerada** de señales de IA antes de publicar: ~30 tells en cuatro tablas con su fix, más la sección de devolverle voz al texto | 342 chars |

## La frontera con `bro`, en los dos lados

`bro` sigue en el Base install y sigue siendo el **paso de registro**: qué idioma, qué canal, qué relación. `unslop` es la **auditoría nombrada** de un texto que ya existe, antes de que salga. Un «bro» seco sigue siendo de `bro`.

- `bro` gana sección `Where this ends`, `unslop` en `recommends`, y un negativo en sus evals que enruta aquí.
- `unslop` lleva dos negativos que enrutan a `bro`.
- Solape medido de descripciones: **0.137**. El máximo que el catálogo tolera hoy es 0.74 (`linkedin-carousels ↔ linkedin-content`), y el máximo del Base install sigue siendo `harness ↔ init` con 0.30.

## La puerta nueva (P2 + P3)

La etiqueta del menú enumeraba las cinco **a mano**, y nada lo comprobaba: contabilidad paralela que empieza a mentir el día que cambia un perfil. Ahora se lee del manifest, y `tests/base-install.test.js` (6 tests) ata:

- el perfil `minimal` es exactamente el set declarado;
- el suelo permanente (`orient`/`suggest`/`bro`) vive dentro del Base install;
- la etiqueta se deriva del perfil y **no** puede volver a cablearse;
- el README nombra las ocho en su línea de `--profile minimal`;
- ningún par del Base install compite por la misma petición (techo 0.5, más estricto que el 0.74 del catálogo: este set se paga en contexto en todo turno);
- la frontera `bro` ↔ `unslop` existe en cuerpo y en evals **por los dos lados**.

Dos mutantes comprobados en rojo: quitar `minimal` de `show-me`, y recablear la etiqueta.

## Verificación

`npm test` 664/664 · `npm run validate` · `npm run manifest:check` (281 skills) · `bash scripts/eval-lint.sh` (281 escaneadas, 0 fallos) · `npm run drift:check` · `npm run routing:audit` PASS. Y un `install --profile minimal` real en un directorio limpio: las ocho aterrizan.

Recall léxico del catálogo: 45.6 → 45.1 rank-1. Dilución esperada por tres skills y 37 prompts más, no regresión; el audit es reporte, no puerta.

## Notas

- Procedencia: material propio, confirmado antes de publicar. `origin: risco` en las tres, sin fila de terceros.
- `site/llms.txt` corrige la línea de perfiles que este cambio falseaba (minimal 8, core 31). El «264 skills» del README y del sitio sigue siendo deriva anterior (hay 281) y queda anotado aparte.
- El suelo permanente no se toca.