### PR TITLE
🐛 fix(docs): el catálogo decía 264 skills y 21 dominios

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![npm](https://img.shields.io/npm/v/@ericrisco/rsc?color=63d68a&labelColor=12161c&label=npm)](https://www.npmjs.com/package/@ericrisco/rsc)
 [![downloads](https://img.shields.io/npm/dm/@ericrisco/rsc?color=63d68a&labelColor=12161c&label=downloads)](https://www.npmjs.com/package/@ericrisco/rsc)
-[![skills](https://img.shields.io/badge/skills-264-63d68a?labelColor=12161c)](#the-catalog)
+[![skills](https://img.shields.io/badge/skills-281-63d68a?labelColor=12161c)](#the-catalog)
 [![license](https://img.shields.io/badge/license-MIT-63d68a?labelColor=12161c)](LICENSE)
 [![stars](https://img.shields.io/github/stars/ericrisco/rsc-harness?color=63d68a&labelColor=12161c)](https://github.com/ericrisco/rsc-harness/stargazers)
 
@@ -17,7 +17,7 @@ skills that fit — one at a time — into every assistant you pick, and keeps t
 equipped as you work.
 
 From *"document my company"* to *"ship a FastAPI service"* to *"grow my YouTube
-channel"* — **264 skills across 21 domains**, every one researched against live
+channel"* — **281 skills across 23 domains**, every one researched against live
 2025-2026 sources and **adversarially scored ≥ 8.5/10** before it shipped.
 
 ```bash
@@ -26,7 +26,7 @@ npx @ericrisco/rsc            # plain-language wizard — no jargon, installs wh
 
 <br>
 
-<img src="https://raw.githubusercontent.com/ericrisco/rsc-harness/main/site/meta-harness.png" alt="rsc — the model (Claude, GPT, Gemini) is the brain your coding agent rents, and you already have that. Claude Code, Codex and opencode sit in the middle. Below them the rsc meta-harness adds everything the model lacks: memory (02-DOCS/) so it stops inventing, arms (01-TOOLS/) so it can execute, a trade (264 skills) so it stops guessing, and reflexes (deterministic hooks) so it cannot forget the rule mid-session." width="960">
+<img src="https://raw.githubusercontent.com/ericrisco/rsc-harness/main/site/meta-harness.png" alt="rsc — the model (Claude, GPT, Gemini) is the brain your coding agent rents, and you already have that. Claude Code, Codex and opencode sit in the middle. Below them the rsc meta-harness adds everything the model lacks: memory (02-DOCS/) so it stops inventing, arms (01-TOOLS/) so it can execute, a trade (281 skills) so it stops guessing, and reflexes (deterministic hooks) so it cannot forget the rule mid-session." width="960">
 
 **The model is the only part your agent already has.** `rsc` is the meta-harness that adds
 the rest: a **memory** so it stops inventing, **arms** so it can execute, a **trade** so it stops
@@ -139,7 +139,7 @@ $ rsc
  ██████╗ ███████╗ ██████╗     ← animated gradient wordmark
  ██╔══██╗██╔════╝██╔════╝
  ██████╔╝███████╗██║
-  264 skills · one CLI · zero bloat
+  281 skills · one CLI · zero bloat
 
 What do you want to do?          ↑↓ move · enter select
 ❯ Base install — the essentials (8 skills)
@@ -187,7 +187,7 @@ rsc add youtube-api remotion-video   # …grow a channel, edit with Remotion
 rsc add fastapi --target claude,codex   # install into several assistants at once
 rsc install --profile minimal        # the base: orient + suggest + bro + unslop + show-me + eli5 + harness + init
 rsc install --profile core           # floor + the full SDD workflow
-rsc install --profile full           # everything (all 264)
+rsc install --profile full           # everything (all 281 skills)
 rsc install --profile full --without go
 rsc consult "I want to launch a SaaS"  # recommend only, no install
 rsc registry refresh                 # write .rsc/skill-registry.{json,md}
@@ -253,7 +253,7 @@ just asks in plain language.
 
 ## The catalog
 
-264 skills, grouped by what you're trying to do. Click any skill to read its
+281 skills, grouped by what you're trying to do. Click any skill to read its
 `SKILL.md`. It fires on its own when a task matches.
 
 ### 🧭 Core & control plane

--- a/scripts/lib/eval-integrity.js
+++ b/scripts/lib/eval-integrity.js
@@ -9,7 +9,7 @@
 //
 // A lift measured against a control that read the answer key is a lower bound of unknown size.
 // Publishing it as a number is the claim-without-evidence this repo keeps paying for (P2), and it
-// feeds skill-harden's --holdout, which decides what enters a 264-skill catalog.
+// feeds skill-harden's --holdout, which decides what enters a 281-skill catalog.
 //
 // This module answers the question deterministically, from the transcripts themselves — never from
 // what an agent says about its own behaviour, which is the way this fails open.

--- a/site/cover-anatomy.html
+++ b/site/cover-anatomy.html
@@ -68,10 +68,10 @@
     <div class="o"><span class="bar"></span><span class="k">Arms</span>
       <span class="w">or it never touches your database</span><span class="foot"><span class="p">01-TOOLS/</span><span class="ex">Postgres &middot; Stripe &middot; Redis</span></span></div>
     <div class="o"><span class="bar"></span><span class="k">A trade</span>
-      <span class="w">or it guesses how the job is done</span><span class="foot"><span class="p">264 skills</span><span class="ex">fastapi &middot; nextjs &middot; seo-geo</span></span></div>
+      <span class="w">or it guesses how the job is done</span><span class="foot"><span class="p">281 skills</span><span class="ex">fastapi &middot; nextjs &middot; seo-geo</span></span></div>
     <div class="o"><span class="bar"></span><span class="k">Reflexes</span>
       <span class="w">or it forgets the rule mid-session</span><span class="foot"><span class="p">deterministic hooks</span><span class="ex">spec-first gate &middot; ship guard</span></span></div>
   </div>
 
-  <div class="meta">MIT &middot; 17 coding assistants &middot; 21 domains &middot; no API key &middot; installed one at a time</div>
+  <div class="meta">MIT &middot; 17 coding assistants &middot; 23 domains &middot; no API key &middot; installed one at a time</div>
 </body></html>

--- a/site/cover.html
+++ b/site/cover.html
@@ -95,10 +95,10 @@
 <body>
   <div class="left">
     <div class="brand"><div class="chip">rsc</div><div class="wm">rsc</div></div>
-    <h1>264 skills.<br>You install <em>five</em>.</h1>
+    <h1>281 skills.<br>You install <em>eight</em>.</h1>
     <p class="sub">Granular by default. Nothing you don&rsquo;t use ever touches your context window.</p>
     <div class="cta"><span class="d">$</span>npx @ericrisco/rsc@latest</div>
-    <div class="meta">MIT &middot; 17 assistants &middot; 21 domains &middot; no API key</div>
+    <div class="meta">MIT &middot; 17 assistants &middot; 23 domains &middot; no API key</div>
   </div>
 
   <div class="term">
@@ -110,7 +110,7 @@
     </div>
 <pre><span class="g">$</span> npx @ericrisco/rsc@latest
 
-<span class="dim">  264 skills · one CLI · zero bloat</span>
+<span class="dim">  281 skills · one CLI · zero bloat</span>
 
 <span class="b">Languages:</span>          <span class="dim">space toggle · enter ok</span>
 <span class="g">❯</span> <span class="g">◉</span> typescript
@@ -123,7 +123,7 @@
   <span class="g">◉</span> Codex CLI    <span class="dim">AGENTS.md</span>
   <span class="off">◯ Cursor       .cursor/rules/</span>
 
-<span class="g">✓</span> installed <span class="b">5</span> of 264 <span class="dim">— the other 259 stay</span>
+<span class="g">✓</span> installed <span class="b">8</span> of 281 <span class="dim">— the other 273 stay</span>
   <span class="dim">out of your context</span>  <span class="caret"> </span></pre>
   </div>
 </body></html>

--- a/site/es/index.html
+++ b/site/es/index.html
@@ -138,7 +138,7 @@
         </p>
       </div>
       <div class="stats reveal">
-        <div class="stat"><div class="n">264</div><div class="l">skills con control de calidad</div></div>
+        <div class="stat"><div class="n">281</div><div class="l">skills con control de calidad</div></div>
         <div class="stat"><div class="n">17</div><div class="l">asistentes de código</div></div>
         <div class="stat"><div class="n">≥ 8.5/10</div><div class="l">gate de calidad adversarial</div></div>
         <div class="stat"><div class="n">1</div><div class="l">comando para empezar</div></div>

--- a/site/index.html
+++ b/site/index.html
@@ -145,7 +145,7 @@
         </p>
       </div>
       <div class="stats reveal">
-        <div class="stat"><div class="n">264</div><div class="l">quality-gated skills</div></div>
+        <div class="stat"><div class="n">281</div><div class="l">quality-gated skills</div></div>
         <div class="stat"><div class="n">17</div><div class="l">coding assistants</div></div>
         <div class="stat"><div class="n">≥ 8.5/10</div><div class="l">adversarial quality gate</div></div>
         <div class="stat"><div class="n">1</div><div class="l">command to start</div></div>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -4,7 +4,7 @@
 > configures AI coding agents for a project. It reads the repository, asks which
 > assistants to target and what the user wants to build or manage, then installs only
 > the skills that fit — one at a time, so nothing unused touches the model's context.
-> 264 skills across 21 domains, each cleared an adversarial >= 8.5/10 quality gate.
+> 281 skills across 23 domains, each cleared an adversarial >= 8.5/10 quality gate.
 
 ## For AI agents: install rsc into the user's project
 

--- a/tests/catalog-counts.test.js
+++ b/tests/catalog-counts.test.js
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DOMAINS } from '../scripts/lib/domains.js';
+
+// Every "N skills" in the published material is a claim about the catalog, and until this file
+// existed nothing checked any of them: the README, the site and llms.txt all said 264 while the
+// catalog held 278, and the number had been wrong through fourteen releases. The count lives in
+// exactly one place (the manifest, built from the skill directories on disk) and the docs must
+// agree with it. P3: the content is the ledger, so read the ledger.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SKILLS = JSON.parse(readFileSync(join(ROOT, 'manifest.json'), 'utf8')).counts.skills;
+
+const DOCS = [
+  'README.md',
+  'site/llms.txt',
+  'site/index.html',
+  'site/es/index.html',
+  'site/cover.html',
+  'site/cover-anatomy.html',
+];
+
+// The stat blocks put the number and its label in separate elements, so tags come out first.
+const text = (file) => readFileSync(join(ROOT, file), 'utf8').replace(/<[^>]+>/g, '');
+
+test('every "N skills" claim in the published docs matches the manifest', () => {
+  const wrong = [];
+  for (const file of DOCS) {
+    const body = text(file);
+    for (const m of body.matchAll(/(\d{2,4})\s*(?:quality-gated\s+)?skills/gi)) {
+      if (Number(m[1]) !== SKILLS) wrong.push(`${file}: "${m[0].trim()}" (catalog has ${SKILLS})`);
+    }
+    // The shields.io badge carries the count inside the URL, past the label.
+    for (const m of body.matchAll(/badge\/skills-(\d+)-/g)) {
+      if (Number(m[1]) !== SKILLS) wrong.push(`${file}: badge says ${m[1]} (catalog has ${SKILLS})`);
+    }
+  }
+  assert.deepEqual(wrong, [], `stale skill counts:\n  ${wrong.join('\n  ')}`);
+});
+
+test('every "N domains" claim matches the domain map', () => {
+  const wrong = [];
+  for (const file of DOCS) {
+    for (const m of text(file).matchAll(/(\d{1,3})\s*(?:domains|dominios)/gi)) {
+      if (Number(m[1]) !== DOMAINS.length) wrong.push(`${file}: "${m[0].trim()}" (there are ${DOMAINS.length})`);
+    }
+  }
+  assert.deepEqual(wrong, [], `stale domain counts:\n  ${wrong.join('\n  ')}`);
+});
+
+// NOT checked here, on purpose: composed sentences where the number is not next to its noun
+// ("installed 8 of 281 — the other 273 stay" in the cover art), and the rendered PNGs generated
+// from those pages. Both need a human eye; naming them beats pretending the gate covers them.


### PR DESCRIPTION
## El hecho

Hay **281 skills** en disco y **23 dominios** en el mapa. El material publicado decía 264 y 21, y la cifra llevaba congelada desde la release que la escribió: catorce publicaciones anunciando un catálogo que ya no existía.

Sitios corregidos:

| Fichero | Qué decía |
|---|---|
| `README.md` | badge, claim de portada, alt del diagrama, banner del tour, `--profile full`, cabecera del catálogo |
| `site/llms.txt` | la línea que leen los agentes |
| `site/index.html`, `site/es/index.html` | el bloque de stats |
| `site/cover.html` | hero, meta, banner y el mock de terminal |
| `site/cover-anatomy.html` | el pie del diagrama |
| `scripts/lib/eval-integrity.js` | un comentario que citaba el tamaño del catálogo |

El hero del cover pasa a **"281 skills. You install eight."** y su terminal a `installed 8 of 281 — the other 273 stay`: es lo que el Base install instala desde 1.1.2. Si prefieres otro gancho para esa línea, es copy y se cambia en un minuto.

## La puerta

`tests/catalog-counts.test.js` deriva las dos cifras de su única fuente (`manifest.counts.skills` y `DOMAINS.length`) y las compara con **toda** afirmación `N skills` / `N domains` del material publicado. Quita las etiquetas HTML antes de mirar, porque los bloques de stats separan el número de su rótulo, y lee el badge de shields.io de dentro de la URL.

Lo que la puerta **no** cubre queda escrito en el propio test, no dado por hecho: las frases compuestas donde el número no toca a su sustantivo (`installed 8 of 281 — the other 273 stay`) y los PNG renderizados a partir de esas páginas, que siguen mostrando la cifra vieja hasta que se regeneren.

Mutante comprobado en rojo: devolver el badge a 264 y el claim a 21 dominios pone las dos aserciones en rojo, con fichero y cifra en el mensaje.

## Verificación

`npm test` 666/666 · `npm run validate` · `npm run drift:check` PASS.