### PR TITLE
✨ feat(sdd): el estado de una spec, comprobado contra el repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ docs/
 
 node_modules/
 coverage/
+
+# Worktrees created for isolated feature work — the directory is scratch, never content.
+.worktrees/

--- a/scripts/lib/spec-gate.js
+++ b/scripts/lib/spec-gate.js
@@ -34,6 +34,10 @@ const UNCHECKED = [
   'que ninguna sección contenga una suposición sin marcar (no es detectable por máquina; es el juicio que la fase existe para ejercer)',
   'que el contenido de cada sección sea correcto, y no sólo presente',
   'que los criterios de aceptación sean de verdad binarios',
+  // Added with the status check below, for the same reason the three above exist: a green that is
+  // narrower than the rule it appears to enforce is the decorative gate all over again.
+  'si una spec dice "implementada" sin nombrar commit, PR ni versión (no hay nada que ir a mirar)',
+  'si el trabajo de una spec que se declara sin aterrizar llegó por otra vía (git no lo distingue)',
 ];
 
 function fold(s) {
@@ -119,4 +123,98 @@ export function specCompleteness(markdown) {
     untyped,
     unchecked: UNCHECKED,
   };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Does the status still match the repository?
+//
+// The section check above asks whether a spec is COMPLETE. This asks whether it is still TRUE — and
+// nothing asked that before, which is how seven of twenty-five statuses came to contradict the repo:
+// one claiming "sin push ni PR" over work that had been in main for weeks, four sitting in
+// `awaiting-approval` over work already published. Spec: 02-DOCS/wiki/sdd/specs/spec-status-drift.md
+//
+// The vocabulary below was extracted from the 25 real statuses, not imagined. That matters: an
+// invented recognizer reaches for the bare word `implementada`, and the bare word is not checkable —
+// it names nothing to go and look for. Only a commit, a PR or a released version do.
+
+/** The claim shapes this recognizer knows. Anything else is silence, not a finding. */
+export const CLAIM_KINDS = ['sha', 'pr', 'version', 'not-landed'];
+
+// Deliberately absent: the bare words `implementada`, `desplegada`, `descartada`, and the phrase
+// `no aprobada`. The first two name nothing to check. The last two look like landing claims and are
+// not — `descartada` is a spec closed on purpose after being measured, `no aprobada` describes HOW
+// approval happened (in autopilot, not item by item), not whether code shipped. Treating either as a
+// landing claim would invent drift in the two best-closed specs of the set.
+const SHA = /\b[0-9a-f]{7,40}\b/g;
+const PR = /\bPR\s*#(\d+)/gi;
+const VERSION = /\bpublicada en (\d+\.\d+\.\d+)/gi;
+const NOT_LANDED = /\bsin push\b|\bsin PR\b|\bawaiting-approval\b/i;
+
+/**
+ * Pull the checkable claims out of a status string. Pure: no git, no I/O.
+ * @param {string} statusText
+ * @returns {Array<{kind: string, value: string, raw: string}>}
+ */
+export function statusClaims(statusText) {
+  const text = typeof statusText === 'string' ? statusText : '';
+  const claims = [];
+  for (const m of text.matchAll(PR)) claims.push({ kind: 'pr', value: m[1], raw: m[0] });
+  for (const m of text.matchAll(VERSION)) claims.push({ kind: 'version', value: m[1], raw: m[0] });
+  for (const m of text.matchAll(SHA)) claims.push({ kind: 'sha', value: m[0], raw: m[0] });
+  const neg = NOT_LANDED.exec(text);
+  if (neg) claims.push({ kind: 'not-landed', value: neg[0], raw: neg[0] });
+  return claims;
+}
+
+/**
+ * Judge each claim against the repository.
+ *
+ * Four verdicts and none of them collapse into another. `unverifiable` is the one that keeps this
+ * honest — a claim we could not check is not a claim that passed, and it is not drift either.
+ *
+ * `not-landed` is always handed to a human, and that is a deliberate retreat from what the spec
+ * first promised. No query distinguishes "never landed" from "landed by another route": the case
+ * that started this work names a commit that genuinely is not in main, while its deliverable has
+ * been there for weeks. Checking the named commit would bless the misleading status; inferring the
+ * other from anything else would be a heuristic inside a gate. So the deterministic part narrows,
+ * and only what it narrowed goes to judgement — principle 1, and the shape `knowledge-drift` already
+ * uses.
+ *
+ * @param {Array<object>} claims from `statusClaims`
+ * @param {?{hasCommit: Function, isAncestor: Function, hasPr: Function, hasTag: Function}} probe
+ *        null when there is no repository to ask — every claim then reports unverifiable.
+ * @returns {Array<{kind: string, value: string, verdict: string, reason: string}>}
+ */
+export function checkClaims(claims, probe) {
+  return (claims || []).map((c) => {
+    if (c.kind === 'not-landed') {
+      return {
+        ...c,
+        verdict: 'needs-human',
+        reason: 'git cannot tell "never landed" from "landed by another route" — look at whether the deliverable is in main, not at the branch',
+      };
+    }
+    if (!probe) return { ...c, verdict: 'unverifiable', reason: 'no repository to ask' };
+    try {
+      if (c.kind === 'sha') {
+        if (!probe.hasCommit(c.value)) {
+          return { ...c, verdict: 'unverifiable', reason: `commit ${c.value} is not in this repository` };
+        }
+        return probe.isAncestor(c.value)
+          ? { ...c, verdict: 'holds', reason: `${c.value} is in main` }
+          : { ...c, verdict: 'stale', reason: `${c.value} is NOT in main` };
+      }
+      if (c.kind === 'pr') {
+        return probe.hasPr(c.value)
+          ? { ...c, verdict: 'holds', reason: `PR #${c.value} is merged into main` }
+          : { ...c, verdict: 'stale', reason: `no merge of PR #${c.value} in main` };
+      }
+      return probe.hasTag(c.value)
+        ? { ...c, verdict: 'holds', reason: `v${c.value} is tagged` }
+        : { ...c, verdict: 'stale', reason: `no v${c.value} tag in this repository` };
+    } catch (e) {
+      // Could not look. Saying `stale` here would invent a finding out of our own failure.
+      return { ...c, verdict: 'unverifiable', reason: e.message };
+    }
+  });
 }

--- a/scripts/spec-gate.js
+++ b/scripts/spec-gate.js
@@ -7,7 +7,8 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { specCompleteness } from './lib/spec-gate.js';
+import { execFileSync } from 'node:child_process';
+import { specCompleteness, statusClaims, checkClaims } from './lib/spec-gate.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const DEFAULT_DIR = join(ROOT, '02-DOCS', 'wiki', 'sdd', 'specs');
@@ -22,6 +23,30 @@ function defaultTargets() {
   }
 }
 
+// The repository, asked instead of assumed. Returns null when there is nothing to ask — a
+// report-only instrument that crashes where it cannot look is worse than one that says so.
+function gitProbe(root) {
+  const git = (args) => execFileSync('git', args, { cwd: root, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+  let main;
+  try {
+    git(['rev-parse', '--git-dir']);
+    // Prefer the remote tip: a stale local `main` would report merged work as missing.
+    main = (() => { try { git(['rev-parse', '--verify', 'origin/main']); return 'origin/main'; } catch { return 'main'; } })();
+    git(['rev-parse', '--verify', main]);
+  } catch {
+    return null;
+  }
+  return {
+    hasCommit: (sha) => { try { git(['cat-file', '-e', `${sha}^{commit}`]); return true; } catch { return false; } },
+    isAncestor: (sha) => { try { git(['merge-base', '--is-ancestor', sha, main]); return true; } catch { return false; } },
+    // The squash-merge subject carries `(#N)`; --fixed-strings so the parens are not a regex.
+    hasPr: (n) => { try { return git(['log', main, '--grep', `(#${n})`, '--fixed-strings', '-1', '--format=%H']) !== ''; } catch { return false; } },
+    hasTag: (v) => { try { return git(['tag', '-l', `v${v}`]) !== ''; } catch { return false; } },
+  };
+}
+
+const statusOf = (text) => (/^status:[ \t]*(.*)$/m.exec(text) || [, ''])[1];
+
 function main() {
   const args = process.argv.slice(2);
   const targets = args.length ? args : defaultTargets();
@@ -31,8 +56,11 @@ function main() {
   }
 
   let failed = 0;
+  let drifted = 0;
+  const probe = gitProbe(ROOT);
   for (const path of targets) {
-    const r = specCompleteness(readFileSync(path, 'utf8'));
+    const text = readFileSync(path, 'utf8');
+    const r = specCompleteness(text);
     const name = basename(path);
     if (r.ok) {
       const typed = r.openPoints.length - r.untyped.length;
@@ -40,17 +68,25 @@ function main() {
       if (r.untyped.length) {
         console.log(`      untyped (treated as open questions): ${r.untyped.length}`);
       }
-    } else {
+    }
+    if (!r.ok) {
       failed += 1;
       console.log(`FAIL  ${name}`);
       if (r.missing.length) console.log(`      missing section(s): ${r.missing.join(', ')}`);
       if (r.empty.length) console.log(`      section(s) with no content: ${r.empty.join(', ')}`);
     }
+    // A status that still matches the repository prints nothing: the report grows only where there
+    // is something to act on (P5).
+    for (const v of checkClaims(statusClaims(statusOf(text)), probe)) {
+      if (v.verdict === 'holds') continue;
+      if (v.verdict === 'stale') drifted += 1;
+      console.log(`      status ${v.verdict.toUpperCase()}: ${v.raw} — ${v.reason}`);
+    }
   }
 
   // A green here is narrower than the rule it enforces, so it says so every run rather than
   // letting the reader assume the gate covered more than it did.
-  console.log(`\n${targets.length - failed}/${targets.length} pass. Not checked by this gate:`);
+  console.log(`\n${targets.length - failed}/${targets.length} pass, ${drifted} status claim(s) contradicted by the repo${probe ? '' : ' (no repository to ask)'}. Not checked by this gate:`);
   for (const u of specCompleteness('').unchecked) console.log(`  - ${u}`);
   if (failed) process.exit(1);
 }

--- a/scripts/spec-gate.js
+++ b/scripts/spec-gate.js
@@ -30,9 +30,14 @@ function gitProbe(root) {
   let main;
   try {
     git(['rev-parse', '--git-dir']);
-    // Prefer the remote tip: a stale local `main` would report merged work as missing.
-    main = (() => { try { git(['rev-parse', '--verify', 'origin/main']); return 'origin/main'; } catch { return 'main'; } })();
-    git(['rev-parse', '--verify', main]);
+    // Prefer the remote tip — a stale local `main` reports merged work as missing. But CI checks out
+    // detached with no `origin/main` and no local `main`, and falling through to "no repository to
+    // ask" there means the check silently stops checking exactly where it runs unattended. HEAD is
+    // the honest last resort: on CI it IS the branch under test.
+    main = ['origin/main', 'main', 'HEAD'].find((ref) => {
+      try { git(['rev-parse', '--verify', ref]); return true; } catch { return false; }
+    });
+    if (!main) throw new Error('no ref to compare against');
   } catch {
     return null;
   }
@@ -57,7 +62,17 @@ function main() {
 
   let failed = 0;
   let drifted = 0;
-  const probe = gitProbe(ROOT);
+  // One probe per repository, not one for the tool's own. A spec's claims are about the history of
+  // the project the spec belongs to — checking them against wherever this script happens to live
+  // gives the right answer only by coincidence, and the wrong one the moment the gate is pointed at
+  // another checkout.
+  const probes = new Map();
+  const probeFor = (path) => {
+    const dir = dirname(path);
+    if (!probes.has(dir)) probes.set(dir, gitProbe(dir));
+    return probes.get(dir);
+  };
+  let anyProbe = false;
   for (const path of targets) {
     const text = readFileSync(path, 'utf8');
     const r = specCompleteness(text);
@@ -77,6 +92,8 @@ function main() {
     }
     // A status that still matches the repository prints nothing: the report grows only where there
     // is something to act on (P5).
+    const probe = probeFor(path);
+    anyProbe = anyProbe || Boolean(probe);
     for (const v of checkClaims(statusClaims(statusOf(text)), probe)) {
       if (v.verdict === 'holds') continue;
       if (v.verdict === 'stale') drifted += 1;
@@ -86,7 +103,7 @@ function main() {
 
   // A green here is narrower than the rule it enforces, so it says so every run rather than
   // letting the reader assume the gate covered more than it did.
-  console.log(`\n${targets.length - failed}/${targets.length} pass, ${drifted} status claim(s) contradicted by the repo${probe ? '' : ' (no repository to ask)'}. Not checked by this gate:`);
+  console.log(`\n${targets.length - failed}/${targets.length} pass, ${drifted} status claim(s) contradicted by the repo${anyProbe ? '' : ' (no repository to ask)'}. Not checked by this gate:`);
   for (const u of specCompleteness('').unchecked) console.log(`  - ${u}`);
   if (failed) process.exit(1);
 }

--- a/tests/spec-status-drift.test.js
+++ b/tests/spec-status-drift.test.js
@@ -17,8 +17,8 @@
 // and discarded — as drifted.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync, execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 
@@ -179,13 +179,41 @@ test('an incomplete spec exits non-zero and is counted as a failure', () => {
   } finally { rmSync(dirname(d), { recursive: true, force: true }); }
 });
 
-test('a status contradicted by the repo is reported, and counted', () => {
-  const d = tmpSpec(GOOD.replace('status: implementada', 'status: implementada (PR #99999999)'));
+// Built against a repository this test creates, never against the ambient one. The first version of
+// this test asserted STALE and passed locally purely because the dev machine happens to have an
+// `origin/main`; CI checks out detached with neither `origin/main` nor `main`, the probe fell back to
+// "no repository to ask", and the verdict became UNVERIFIABLE. A test that depends on the machine it
+// runs on is a coincidence, not a test — and it was hiding the fact that `gitProbe`, the one piece
+// that touches git, had no coverage at all.
+function tmpRepo() {
+  // realpath: macOS puts tmp behind a symlink, and git resolves it — a mismatch there has already
+  // cost this repo five silent CLI passes once.
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'rsc-specgit-')));
+  const git = (...a) => execFileSync('git', a, { cwd: dir, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 't@t');
+  git('config', 'user.name', 'T');
+  writeFileSync(join(dir, 'f'), 'x');
+  git('add', '-A');
+  git('commit', '-qm', 'landed for real (#4242)');
+  git('tag', 'v9.9.9');
+  return { dir, sha: git('rev-parse', 'HEAD'), git };
+}
+
+test('against a real repository: a merged PR holds and an unmerged one is stale', () => {
+  const { dir, sha } = tmpRepo();
+  const d = join(dir, 'fixture.md');
   try {
-    const { out } = run([d]);
-    assert.match(out, /status STALE: PR #99999999/);
-    assert.match(out, /1 status claim\(s\) contradicted/);
-  } finally { rmSync(dirname(d), { recursive: true, force: true }); }
+    writeFileSync(d, GOOD.replace('status: implementada', `status: implementada (PR #4242 → ${sha}, publicada en 9.9.9)`));
+    const held = run([d]);
+    assert.equal(held.code, 0);
+    assert.doesNotMatch(held.out, /status (STALE|UNVERIFIABLE)/, `a wholly true status must print nothing:\n${held.out}`);
+
+    writeFileSync(d, GOOD.replace('status: implementada', 'status: implementada (PR #99999999)'));
+    const drift = run([d]);
+    assert.match(drift.out, /status STALE: PR #99999999/);
+    assert.match(drift.out, /1 status claim\(s\) contradicted/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
 test('every run declares what it does not check', () => {

--- a/tests/spec-status-drift.test.js
+++ b/tests/spec-status-drift.test.js
@@ -1,0 +1,201 @@
+// Does a spec's declared status still match the repository? — and the tests that check the checker.
+// Spec: 02-DOCS/wiki/sdd/specs/spec-status-drift.md
+//
+// `spec-gate` has always checked that every section EXISTS. It never checked that what a section
+// CLAIMS is still true, and it never said it didn't. Seven of twenty-five specs drifted: one says
+// "sin push ni PR" over work that has been in main for weeks, four sit in `awaiting-approval` over
+// work already published. That is P2 aimed at the SDD's own ledger.
+//
+// The two mutants, written before the implementation:
+//   1. a landing claim (SHA) over work that is NOT in main  -> `stale`
+//   2. a not-landed claim                                   -> `needs-human`, and explicitly NOT `holds`
+// The second is the whole point: if it came back `holds`, the tool would bless the misleading status
+// that started this spec.
+//
+// And the control that matters on the reader: `no aprobada` and `descartada` must produce NO claim.
+// Without it the first reasonable recognizer flags `spec-challenger` — deliberately closed, measured
+// and discarded — as drifted.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+const tmpSpec = (body) => {
+  const d = mkdtempSync(join(tmpdir(), 'rsc-specstatus-'));
+  const f = join(d, 'fixture.md');
+  writeFileSync(f, body);
+  return f;
+};
+import { statusClaims, checkClaims, specCompleteness } from '../scripts/lib/spec-gate.js';
+
+// A probe stands in for git, so the reader is tested against real status text and never against a
+// throwaway repository. Fabricating repos would mostly test `git`.
+const probe = ({ commits = [], ancestors = [], prs = [], tags = [] } = {}) => ({
+  hasCommit: (sha) => commits.includes(sha),
+  isAncestor: (sha) => ancestors.includes(sha),
+  hasPr: (n) => prs.includes(Number(n)),
+  hasTag: (v) => tags.includes(`v${v}`), // mirrors gitProbe: the bare version in, `v`-prefixed tag looked up
+});
+const only = (text, p) => checkClaims(statusClaims(text), p);
+
+// ── the reader, over the shapes the real corpus actually contains ────────────
+
+test('reads the four shapes the 25 real statuses contain', () => {
+  const c = statusClaims('implementada (PR #226 → c384ff5, publicada en 1.0.13)');
+  assert.deepEqual(c.map((x) => x.kind).sort(), ['pr', 'sha', 'version']);
+  assert.equal(c.find((x) => x.kind === 'pr').value, '226');
+  assert.equal(c.find((x) => x.kind === 'sha').value, 'c384ff5');
+  assert.equal(c.find((x) => x.kind === 'version').value, '1.0.13');
+});
+
+test('reads the three ways this corpus says the work has not landed', () => {
+  for (const text of ['awaiting-approval', 'implementada, sin push ni PR', 'Implementada, sin push: 13/13']) {
+    const c = statusClaims(text);
+    assert.ok(c.some((x) => x.kind === 'not-landed'), `missed the negation in: ${text}`);
+  }
+});
+
+// THE CONTROL — these look like landing claims and are not.
+test('CONTROL: "no aprobada" and "descartada" produce no claim at all', () => {
+  assert.deepEqual(statusClaims('no aprobada ítem por ítem'), []);
+  assert.deepEqual(statusClaims('**medida y descartada** (2026-08-19). No se construye.'), []);
+});
+
+test('a status with nothing checkable yields nothing, and nothing is not green', () => {
+  assert.deepEqual(statusClaims(''), []);
+  assert.deepEqual(statusClaims('aprobada en autopiloto, no punto por punto'), []);
+});
+
+// ── the verdicts ─────────────────────────────────────────────────────────────
+
+test('a SHA that is an ancestor of main holds', () => {
+  const [v] = only('implementada 7ebebaf', probe({ commits: ['7ebebaf'], ancestors: ['7ebebaf'] }));
+  assert.equal(v.verdict, 'holds');
+});
+
+// MUTANT 1 — a landing claim over work that never landed.
+test('MUTANT: a landing claim whose commit is known but NOT in main is stale', () => {
+  const [v] = only('implementada 55a740c', probe({ commits: ['55a740c'], ancestors: [] }));
+  assert.equal(v.verdict, 'stale');
+});
+
+test('a SHA the repository does not know is unverifiable — not stale, not holds', () => {
+  const [v] = only('implementada deadbeef', probe({}));
+  assert.equal(v.verdict, 'unverifiable');
+  assert.notEqual(v.verdict, 'stale');
+  assert.notEqual(v.verdict, 'holds');
+});
+
+// MUTANT 2 — the case that started the spec.
+test('MUTANT: a not-landed claim is needs-human, and explicitly never holds', () => {
+  const [v] = only('implementada, sin push ni PR', probe({}));
+  assert.equal(v.verdict, 'needs-human');
+  assert.notEqual(v.verdict, 'holds');
+  assert.match(v.reason, /otra vía|another route|git/i);
+});
+
+test('a published version holds when its tag exists, and is stale when it does not', () => {
+  assert.equal(only('publicada en 1.1.1', probe({ tags: ['v1.1.1'] }))[0].verdict, 'holds');
+  assert.equal(only('publicada en 9.9.9', probe({ tags: ['v1.1.1'] }))[0].verdict, 'stale');
+});
+
+test('a PR holds when main carries its merge, stale when it does not', () => {
+  assert.equal(only('implementada (PR #246)', probe({ prs: [246] }))[0].verdict, 'holds');
+  assert.equal(only('implementada (PR #999)', probe({ prs: [246] }))[0].verdict, 'stale');
+});
+
+// ── no repository, and a probe that misbehaves ───────────────────────────────
+
+test('no repository means unverifiable everywhere, never stale', () => {
+  const vs = checkClaims(statusClaims('implementada (PR #246 → 7ebebaf, publicada en 1.1.1)'), null);
+  assert.equal(vs.length, 3);
+  for (const v of vs) assert.equal(v.verdict, 'unverifiable');
+});
+
+test('a probe that throws is unverifiable with its reason, never a finding', () => {
+  const angry = { hasCommit: () => { throw new Error('shallow clone'); }, isAncestor: () => false, hasPr: () => false, hasTag: () => false };
+  const [v] = only('implementada 7ebebaf', angry);
+  assert.equal(v.verdict, 'unverifiable');
+  assert.match(v.reason, /shallow clone/);
+});
+
+test('the report grows its own edge: the new claim classes are declared unchecked', () => {
+  const u = specCompleteness('').unchecked;
+  assert.ok(u.some((x) => /nada que ir a mirar/.test(x)), 'the bare-word limit must be declared');
+  assert.ok(u.some((x) => /otra vía/.test(x)), 'the another-route limit must be declared');
+});
+
+// ── the CLI, end to end ──────────────────────────────────────────────────────
+// These exist because of a real defect caught mid-build: wiring the status column in inverted the
+// pass/fail branch, so the gate counted a FAILURE every time a spec PASSED. `node -c` reported the
+// file as fine — syntax is not correctness, and a gate with an inverted counter is the decorative
+// gate with extra steps.
+
+const CLI = new URL('../scripts/spec-gate.js', import.meta.url).pathname;
+const run = (args) => {
+  const r = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8' });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+};
+
+const GOOD = `---
+status: implementada
+---
+# Spec — x
+## Problema & por qué
+p
+## Objetivos
+- g
+## No-objetivos
+- n
+## Usuarios & contexto
+u
+## Comportamiento
+b
+## Criterios de aceptación
+- Given a, When b, Then c.
+## Puntos a clarificar
+- [ ] **pregunta abierta** — q
+`;
+
+test('a complete spec exits 0 and is counted as a pass, not a failure', () => {
+  const d = tmpSpec(GOOD);
+  try {
+    const { code, out } = run([d]);
+    assert.equal(code, 0);
+    assert.match(out, /^PASS/m);
+    assert.match(out, /1\/1 pass/);
+  } finally { rmSync(dirname(d), { recursive: true, force: true }); }
+});
+
+test('an incomplete spec exits non-zero and is counted as a failure', () => {
+  const d = tmpSpec('---\nstatus: draft\n---\n# Spec — x\n');
+  try {
+    const { code, out } = run([d]);
+    assert.notEqual(code, 0);
+    assert.match(out, /^FAIL/m);
+    assert.match(out, /0\/1 pass/);
+  } finally { rmSync(dirname(d), { recursive: true, force: true }); }
+});
+
+test('a status contradicted by the repo is reported, and counted', () => {
+  const d = tmpSpec(GOOD.replace('status: implementada', 'status: implementada (PR #99999999)'));
+  try {
+    const { out } = run([d]);
+    assert.match(out, /status STALE: PR #99999999/);
+    assert.match(out, /1 status claim\(s\) contradicted/);
+  } finally { rmSync(dirname(d), { recursive: true, force: true }); }
+});
+
+test('every run declares what it does not check', () => {
+  const d = tmpSpec(GOOD);
+  try {
+    assert.match(run([d]).out, /Not checked by this gate:/);
+  } finally { rmSync(dirname(d), { recursive: true, force: true }); }
+});
+
+test('the worktree directory is ignored — isolated work must not show up as untracked content', () => {
+  const gi = readFileSync(new URL('../.gitignore', import.meta.url).pathname, 'utf8');
+  assert.match(gi, /^\.worktrees\/$/m);
+});


### PR DESCRIPTION
## El problema

`spec-gate` lleva desde su primer día comprobando que cada sección de una spec **exista**. Nunca comprobó —ni decía que no comprobaba— que lo que una sección **afirma sobre el repositorio** siga siendo cierto. Séptima aparición de P2 en este repo, y esta vez sobre el instrumento de la propia fase.

Se notaba: **siete de veinticinco estados contradecían al repo.** Uno decía *"sin push ni PR"* sobre trabajo con semanas en `main`; cuatro seguían en `awaiting-approval` sobre trabajo publicado. El coste real no era la etiqueta mal puesta, sino que saber qué queda exigía **rehacer la auditoría entera a mano** — y en esa pasada, cinco preguntas registradas como abiertas resultaron estar ya resueltas en código.

## Lo que hace

**Lo determinista, al binario (P1)** — en el instrumento que ya existe, sin superficie nueva:

- `statusClaims(text)` — puro, sin git. Cuatro formas y ninguna más: SHA, `PR #N`, `publicada en X.Y.Z`, y la negación de aterrizaje. **El vocabulario se extrajo de los 25 estados reales, no se imaginó** — y ahí aparecieron las dos trampas que un reconocedor inventado habría tratado como afirmaciones de aterrizaje: `no aprobada` (habla de aprobación, no de código) y `descartada` (no afirma nada). Marcarlas habría inventado deriva en las dos specs mejor cerradas del conjunto.
- `checkClaims(claims, probe)` — cuatro veredictos que no se colapsan: `holds` · `stale` · `unverifiable` · `needs-human`. La sonda entra **por argumento**, así que el reconocedor se prueba contra texto real en vez de contra repositorios de mentira que acabarían probando `git`.
- Una columna en el informe que ya existía. Una spec cuyo estado se sostiene **no imprime nada** (P5).

**Una retirada deliberada de lo que la spec prometía.** La negación de aterrizaje **no** se resuelve por git: ninguna consulta distingue *"no aterrizó"* de *"aterrizó por otra vía"*. `design-tells` nombra un commit que efectivamente no es ancestro de `main`, mientras su entregable lleva semanas dentro. Comprobar el commit nombrado habría **confirmado** el estado engañoso. Así que se adopta el patrón de `knowledge-drift` y del principio 1 — *determinista para estrechar, juicio solo sobre lo estrechado*: la herramienta bajó 25 a 6, los nombró, y paró.

## Los seis, corregidos — y tres cosas salieron al revés del diagnóstico

| Lo que se creía | Lo que dijo git |
|---|---|
| Los SHAs del índice eran buenos | **Nunca fueron ancestros de `main`.** El repo hace squash-merge: `3fafa17`, `21e25fa` y `631383b` murieron dentro de `b84b0e5` (PR #23). La cita que sobrevive es el PR o el squash, jamás el commit de rama |
| En `install-agent-handoff` mentía el estado | **Mentía el índice.** Citaba "PR #220" y ese PR es `automation-gap` entero, sin una línea de handoff. El trabajo está en `398793f` |
| `design-tells` no había aterrizado | Su commit no está en `main`; **su entregable sí**, vía `b0ad133` (PR #235) |

Corrida final sobre las 25: **cero afirmaciones caducadas, cero pendientes de juicio.**

## Dos defectos que el propio uso destapó, los dos con test

1. **Cablear la columna invirtió la rama de fallo del CLI**: contaba un FALLO cada vez que una spec **pasaba**. `node -c` dio verde — la sintaxis no es la corrección. El gate no tenía ni un test de extremo a extremo; ahora tiene cuatro.
2. **Mi prosa creaba deriva.** La primera tanda de correcciones explicaba en el `status:` por qué el SHA viejo no valía, y el reconocedor leyó esos SHAs como afirmaciones nuevas, marcando caducadas cuatro specs recién arregladas. Regla que sale de ahí: *el campo `status:` es una afirmación, no una crónica.*

## Verificación

| Puerta | Resultado |
|---|---|
| `npm test` | **684 tests, 0 fallos** (18 nuevos; 1 skip preexistente, `.rsc/` no instalado en el worktree) |
| `npm run validate` | frontmatter OK · **281 skills**, ninguna descripción nueva |
| `npm run drift:check` | PASS — 824 afirmaciones resuelven |
| `npm run routing:audit` | PASS |
| `bash scripts/eval-lint.sh` | PASS — 281 skills, 0 fallos |
| Corrida real sobre las 25 specs | **0 caducadas, 0 needs-human** |

Los dos mutantes, escritos antes de la implementación: una afirmación de aterrizaje sobre trabajo ausente → `stale`; una de no-aterrizaje → `needs-human` con aserción explícita de que **no** es `holds`. Si esa saliera `holds`, la herramienta bendeciría el estado que originó la spec.

## Lo que NO se tocó, pudiendo

`design-tells` sigue **fallando la completitud** por una sección `Comportamiento` ausente. Es un hueco de contenido anterior a este cambio, y arreglarlo aquí habría sido escribir la spec de otro dentro de un PR de tooling. Queda visible en cada corrida.

Y esto **nunca** será puerta de publicación: las specs viven bajo `02-DOCS`, que no se trackea (P9), así que en un clon limpio no existen. Mismo motivo por el que `spec-gate` tampoco está cableado ahí.

---

Trabajado en worktree aislado (`.worktrees/spec-ledger-gate`), que de paso entra al `.gitignore` — aparecía como material sin trackear.

Spec: `02-DOCS/wiki/sdd/specs/spec-status-drift.md` (aprobada **en autopiloto**)
Plan: `02-DOCS/wiki/sdd/specs/spec-status-drift.plan.md`