### PR TITLE
🐛 fix(cli): el arnés dejaba de encontrarse a sí mismo — detección, manifiesto compartible y repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,37 @@ with no command at all. Declare it in `.rsc.json` under `ownSkills` and `doctor`
 when someone is missing it — that is all declaring does. rsc never installs, updates or
 overwrites it: its version is the commit.
 
+
+## 🩹 Something's off? One command
+
+Recognise any of these? They are all the same fix.
+
+| What you see | |
+| --- | --- |
+| `"target": "codex"` when you work in Claude Code | |
+| `This target has no hook injection` and you did not expect that | |
+| Skills appear that you never asked for | |
+| You cloned a repo and your assistant sees no skills at all | |
+| A hook seems to run several times per turn | |
+| Template lines showed up inside your hand-written `AGENTS.md` | |
+
+```bash
+npx @ericrisco/rsc@latest repair
+```
+
+Safe in any folder: with no rsc there, it says so and writes nothing. It shows what it
+found before touching anything, keeps a recoverable copy, and running it twice changes
+nothing the second time. Add `--dry-run` to see the whole pass without a single write.
+
+**What it fixes on its own** — putting the harness back to what was already declared:
+dangling links from a clone, hooks wired several times, the 0.1 layout no assistant reads.
+
+**What it asks about** — anything that changes a decision: moving the harness to another
+assistant, or touching files you already committed.
+
+**What it never touches:** skills and agents you wrote by hand. rsc did not install them,
+so rsc does not repair, move or delete them — not even when rebuilding from scratch.
+
 ## Update
 
 `rsc` is an npm package, so updating is two steps — bump the package, then

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ user wants**, reads the repo, then installs the floor (`orient` + `rsc-suggest` 
 `init`) plus only the skills that fit — one at a time. No global install and no API key needed.
 
 - **Choose assistants non-interactively:** `npx @ericrisco/rsc@latest --target claude` (comma-separate for several).
+- **Two assistants already installed?** rsc asks instead of guessing. `--target` settles it in one word.
 - **Already installed, just refreshing skills + hooks:** `rsc sync` (or re-run the command above).
 - **Add one skill by id:** `rsc add <id>` · **browse the catalog:** `rsc consult "<what you want>"` or `rsc list`.
 
@@ -202,6 +203,44 @@ rsc uninstall postgresdb --dry-run   # preview a removal
 ```
 
 ---
+
+
+## 👥 Sharing a harness with your team
+
+The harness travels by git, but not all of it — and the split is the point.
+
+**Commit these:**
+
+| | |
+| --- | --- |
+| `.rsc.json` | The decision: which assistants, which skills, **which catalog version**, the developer tier, which gates you disarmed |
+| `01-TOOLS/` · `02-DOCS/` | Your tooling and your wiki, if you use them |
+| Skills and agents you wrote by hand | They are yours. rsc does not claim them, does not count them as drift, and does not touch them |
+
+**Do not commit these** — rsc adds them to `.gitignore` for you:
+
+| | Why |
+| --- | --- |
+| `.rsc/` | Machine state: hook scripts, seals, logs |
+| The skill entries rsc manages | Symlinks on macOS/Linux, real copies on Windows — two incompatible shapes of one thing |
+
+Whoever clones runs **one command** and ends up with the same harness:
+
+```bash
+npx @ericrisco/rsc@latest sync
+```
+
+Same skills, same version — `.rsc.json` pins the catalog, so a teammate who clones in three
+months gets what you had, not what shipped since. Upgrading is a deliberate act, never a side
+effect of rebuilding.
+
+When someone changes the harness and you `git pull`, `rsc doctor` tells you what no longer
+matches. **Nothing is ever written to your machine by a pull** — you are told, and you decide.
+
+**Own skills.** A skill your team wrote lives in the repo and already works for whoever clones,
+with no command at all. Declare it in `.rsc.json` under `ownSkills` and `doctor` will also say
+when someone is missing it — that is all declaring does. rsc never installs, updates or
+overwrites it: its version is the commit.
 
 ## Update
 

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -40,6 +40,35 @@ function selloStatus(root) {
   } catch { return { enabled: false }; }
 }
 
+// A wired hook is a promise to run a file. `settings.json` existing only proves the
+// promise was made — and a fresh clone brings that file (committed) without .rsc/
+// (ignored), so every session start fails while the report says all-clear. Read the
+// commands we wired and check the files they name actually exist.
+//
+// Hookless targets get an empty list by construction: their always-on surface is a
+// markdown block with no script behind it, so there is nothing that can go missing.
+export function missingHookScripts({ target, home = homedir(), cwd = process.cwd() } = {}) {
+  if (HOOKLESS_TARGETS.has(target)) return [];
+  const file = targetPaths(target, home, cwd).hookTarget;
+  let settings;
+  try { settings = JSON.parse(readFileSync(file, 'utf8')); } catch { return []; }
+  const commands = [];
+  for (const entries of Object.values(settings?.hooks || {})) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) for (const h of entry?.hooks || []) {
+      if (typeof h?.command === 'string') commands.push(h.command);
+    }
+  }
+  const seen = new Set();
+  for (const cmd of commands) {
+    for (const m of cmd.matchAll(/["']?([^"'\s]*[\\/]\.rsc[\\/][^"'\s]+\.mjs)["']?/g)) {
+      const script = m[1];
+      if (!existsSync(script)) seen.add(script);
+    }
+  }
+  return [...seen];
+}
+
 export function doctor({ target, home, cwd }) {
   const root = cwd || process.cwd();
   const paths = targetPaths(target, home, cwd);
@@ -50,7 +79,8 @@ export function doctor({ target, home, cwd }) {
     target,
     installed: Object.keys(state.skills),
     missing: [],
-    hookWired: existsSync(paths.hookTarget),
+    // Wired means it can actually run, not merely that the file declaring it is there.
+    hookWired: existsSync(paths.hookTarget) && missingHookScripts({ target, home, cwd }).length === 0,
     manifestSkills: manifest.counts.skills,
     backups: {
       exists: existsSync(join(root, '.rsc', 'backups')),
@@ -283,6 +313,19 @@ export function contextBudget({ target, home = homedir(), cwd = process.cwd() } 
         + `injected block lands ${wired.length} times — about ${doubled} wasted bytes per session.`,
       action: 'Keep ONE scope. Remove the other with `npx @ericrisco/rsc uninstall --all` run from that '
         + 'root, or update both to a version that de-duplicates at runtime.',
+    });
+  }
+  const orphanScripts = missingHookScripts({ target, home, cwd });
+  if (orphanScripts.length) {
+    // ONE finding, not one per file: a clone is missing all eight at once, and a list of
+    // eight paths buries the single thing the reader has to do (principle 5).
+    findings.push({
+      id: 'hook-scripts-missing',
+      severity: 'high',
+      summary: `${orphanScripts.length} hook script(s) named by the wiring are not on disk, so those hooks `
+        + 'fail every time they fire. This is what a fresh clone looks like: the settings travelled, the '
+        + 'scripts did not.',
+      action: 'Rebuild them with `npx @ericrisco/rsc sync` from this project root.',
     });
   }
   findings.push(...duplicateEntryFindings(scopes));

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -60,7 +60,12 @@ export function missingHookScripts({ target, home = homedir(), cwd = process.cwd
     }
   }
   const seen = new Set();
-  for (const cmd of commands) {
+  // Commands name the project through ${CLAUDE_PROJECT_DIR}, which only the client
+  // expands. Resolve it here or every wired script reads as missing and the report
+  // calls a healthy install broken — the mirror image of the bug this check fixes.
+  const expand = (c) => c.split('${CLAUDE_PROJECT_DIR}').join(cwd);
+  for (const raw of commands) {
+    const cmd = expand(raw);
     for (const m of cmd.matchAll(/["']?([^"'\s]*[\\/]\.rsc[\\/][^"'\s]+\.mjs)["']?/g)) {
       const script = m[1];
       if (!existsSync(script)) seen.add(script);

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { targetPaths, TARGET_IDS } from '../targets/index.js';
 import { readState } from './lib/state.js';
+import { divergence } from './lib/divergence.js';
 import { loadManifest } from './lib/manifest.js';
 import { listBackups } from './lib/backups.js';
 import { SDD_GATE_TEXT } from '../targets/hook-once.mjs';
@@ -331,6 +332,24 @@ export function contextBudget({ target, home = homedir(), cwd = process.cwd() } 
         + 'fail every time they fire. This is what a fresh clone looks like: the settings travelled, the '
         + 'scripts did not.',
       action: 'Rebuild them with `npx @ericrisco/rsc sync` from this project root.',
+    });
+  }
+  const drift = divergence({ cwd, target, home });
+  if (drift.missing.length || drift.extra.length || drift.ownMissing.length) {
+    // The day-two case: a teammate changed the harness and this checkout has not caught
+    // up. Reported always, even after someone declines to align — the divergence does not
+    // stop being true because they said no.
+    const parts = [];
+    if (drift.missing.length) parts.push(`missing ${drift.missing.join(', ')}`);
+    if (drift.ownMissing.length) parts.push(`${drift.ownMissing.join(', ')} declared by the team but not in this repo`);
+    if (drift.extra.length) parts.push(`${drift.extra.join(', ')} installed but no longer declared`);
+    findings.push({
+      id: 'manifest-divergence',
+      severity: 'medium',
+      summary: `This checkout does not match what .rsc.json declares: ${parts.join('; ')}.`,
+      action: drift.ownMissing.length && !drift.missing.length && !drift.extra.length
+        ? 'Those come from the repo, not from rsc — pull, or ask whoever wrote them.'
+        : 'Align with `npx @ericrisco/rsc sync`. Nothing is written until you run it.',
     });
   }
   findings.push(...duplicateEntryFindings(scopes));

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -331,7 +331,7 @@ export function contextBudget({ target, home = homedir(), cwd = process.cwd() } 
       summary: `${orphanScripts.length} hook script(s) named by the wiring are not on disk, so those hooks `
         + 'fail every time they fire. This is what a fresh clone looks like: the settings travelled, the '
         + 'scripts did not.',
-      action: 'Rebuild them with `npx @ericrisco/rsc sync` from this project root.',
+      action: 'Rebuild them with `npx @ericrisco/rsc repair` from this project root.',
     });
   }
   const drift = divergence({ cwd, target, home });

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { rmSync, existsSync, cpSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, readdirSync } from 'node:fs';
-import { join, dirname, basename } from 'node:path';
+import { join, dirname, basename, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { planInstall } from './install-plan.js';
 import { targetPaths, writeSkill, wireHook, unwireHook, baseDir, TARGET_IDS } from '../targets/index.js';
@@ -156,7 +156,7 @@ export async function applyInstall({ skillIds, target, home, cwd = process.cwd()
   mkdirSync(dirname(versionFile(cwd)), { recursive: true });
   writeFileSync(versionFile(cwd), CLI_VERSION + '\n');
   recordInManifest({ cwd, target, skillIds });
-  ignoreLocalState(cwd);
+  ignoreLocalState(cwd, target);
   return { ...state, backup };
 }
 
@@ -168,21 +168,52 @@ export async function applyInstall({ skillIds, target, home, cwd = process.cwd()
 // Additive and idempotent by construction: append one line to an existing
 // .gitignore, never rewrite or reorder it, and never create the file in a directory
 // that is not a git repository.
-export function ignoreLocalState(cwd = process.cwd()) {
+export function ignoreLocalState(cwd = process.cwd(), target) {
   if (!existsSync(join(cwd, '.git'))) return null;
   const gi = join(cwd, '.gitignore');
   let text = '';
   try { text = existsSync(gi) ? readFileSync(gi, 'utf8') : ''; } catch { return null; }
-  const already = text.split('\n').some((l) => {
-    const s = l.trim().replace(/\/$/, '');
-    return s === '.rsc' || s === '/.rsc';
-  });
-  if (already) return null;
+
+  // `.rsc/` is machine state. The per-target skill entries are derived: symlinks here,
+  // real copies on Windows, so committing either shape puts two incompatible forms of the
+  // same thing into one repo.
+  //
+  // But `claude` writes into `.claude/skills/` and `cursor` into `.cursor/rules/`, which
+  // are SHARED with the user — their own skills and rules live there too. Excluding the
+  // whole directory would quietly stop versioning their work, which is the same sin this
+  // release exists to fix: treating what is theirs as if it were ours. So shared
+  // directories are excluded entry by entry, and only the entries rsc manages.
+  const wanted = ['.rsc/'];
+  if (target) {
+    const paths = targetPaths(target, undefined, cwd);
+    const rel = (abs) => relative(cwd, abs).split(sep).join('/');
+    for (const id of Object.keys(readState(paths.stateFile).skills || {})) wanted.push(rel(paths.skillDir(id)));
+    // The per-file ledger is derived AND platform-shaped (symlink here, real copy on
+    // Windows), so committing it puts two incompatible inventories of one thing in one
+    // repo. The declaration that does travel is .rsc.json, in the root.
+    wanted.push(rel(paths.stateFile));
+    // Subagents are catalog content, re-materialised by every install and sync.
+    for (const f of agentNames()) wanted.push(rel(agentPath(target, cwd, f)));
+  }
+  // `.rsc`, `/.rsc` and `.rsc/` are the same rule to git. Normalising both ends is what
+  // keeps this idempotent against a .gitignore a human wrote in their own spelling.
+  const norm = (l) => l.trim().replace(/^\//, '').replace(/\/$/, '');
+  const present = new Set(text.split('\n').map(norm));
+  const add = wanted.filter((w) => !present.has(norm(w)));
+  if (!add.length) return null;
+
+  // Append only. Never rewrite, never reorder: the rest of that file is theirs.
   const prefix = text === '' ? '' : (text.endsWith('\n') ? '' : '\n');
   try {
-    appendFileSync(gi, `${prefix}\n# rsc local state (hooks, seals, logs) — machine-local, never committed\n.rsc/\n`);
+    appendFileSync(gi, `${prefix}\n# rsc local state (hooks, seals, logs) and managed skill links — machine-local\n${add.join('\n')}\n`);
     return gi;
   } catch { return null; }
+}
+
+export function collisions({ cwd = process.cwd(), target, home, skillIds = [] }) {
+  const paths = targetPaths(target, home, cwd);
+  const managed = new Set(Object.keys(readState(paths.stateFile).skills || {}));
+  return skillIds.filter((id) => !managed.has(id) && existsSync(paths.skillDir(id)));
 }
 
 export function listInstalled({ target, home, cwd = process.cwd() }) {
@@ -221,17 +252,22 @@ export async function uninstall({ skillIds, target, home, cwd = process.cwd(), d
 export async function syncInstalled({ target, home, cwd = process.cwd(), dryRun = false }) {
   const paths = targetPaths(target, home, cwd);
   const state = readState(paths.stateFile);
+  // The per-target state is machine wiring and does not travel, so a fresh clone has
+  // none of it: sync found zero skills and did nothing, leaving someone with a repo that
+  // declares a harness and has none. The committed manifest is exactly the declaration
+  // to rebuild from, and it is sitting right there.
   const ids = Object.keys(state.skills || {});
-  if (!ids.length) return dryRun ? { dryRun: true, synced: [], paths: [] } : { synced: [], backup: null };
+  const declared = ids.length ? ids : (readManifest(cwd)?.skills || []);
+  if (!declared.length) return dryRun ? { dryRun: true, synced: [], paths: [] } : { synced: [], backup: null };
   if (dryRun) {
     return {
       dryRun: true,
-      synced: ids,
-      paths: managedPathsForInstall({ skillIds: ids, target, home, cwd }),
+      synced: declared,
+      paths: managedPathsForInstall({ skillIds: declared, target, home, cwd }),
     };
   }
-  const nextState = await applyInstall({ skillIds: ids, target, home, cwd, operation: 'sync' });
-  return { synced: ids, backup: nextState.backup };
+  const nextState = await applyInstall({ skillIds: declared, target, home, cwd, operation: 'sync' });
+  return { synced: declared, backup: nextState.backup };
 }
 
 // Remove EVERYTHING rsc put in this project: installed skills across all targets,

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -68,7 +68,7 @@ function generatedHookFiles({ target, cwd }) {
   ];
 }
 
-function managedPathsForInstall({ skillIds, target, home, cwd }) {
+export function managedPathsForInstall({ skillIds, target, home, cwd }) {
   const paths = targetPaths(target, home, cwd);
   const plan = planInstall({ skillIds, target, home, cwd });
   const out = [paths.stateFile, versionFile(cwd), baseVersionsFile(cwd)];
@@ -102,13 +102,16 @@ function localDecisions(cwd) {
 // into codex on a machine that already had claude is adding, not replacing. Union, sorted
 // where order carries no meaning, so the file stays diffable and a merge conflict stays
 // readable.
-export function recordInManifest({ cwd, target, skillIds, catalogVersion = CLI_VERSION }) {
+export function recordInManifest({ cwd, target, skillIds, catalogVersion = CLI_VERSION, dropTarget }) {
   const prev = readManifest(cwd) || { targets: [], skills: [], ownSkills: [], optOuts: [] };
   const { optOuts, tier } = localDecisions(cwd);
   const union = (a, b) => [...new Set([...(a || []), ...(b || [])])].sort();
   return writeManifest(cwd, {
     version: 1,
-    targets: union(prev.targets, [target]),
+    // Union by default: installing into a second assistant is adding, not replacing.
+    // `dropTarget` is the one exception — a MOVE, where leaving the old one declared would
+    // have every clone rebuild a harness that was deliberately abandoned.
+    targets: union(prev.targets, [target]).filter((t) => t !== dropTarget),
     skills: union(prev.skills, skillIds),
     ownSkills: prev.ownSkills || [],
     catalogVersion,

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-import { rmSync, existsSync, cpSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+import { rmSync, existsSync, cpSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, readdirSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { planInstall } from './install-plan.js';
 import { targetPaths, writeSkill, wireHook, unwireHook, baseDir, TARGET_IDS } from '../targets/index.js';
 import { targetHasAgents, writeAgents, removeAgents, agentPath, agentNames } from '../targets/agents.js';
 import { readState, writeState } from './lib/state.js';
+import { readManifest, writeManifest } from './lib/manifest-file.js';
 import { createBackup } from './lib/backups.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -82,6 +83,40 @@ function managedPathsForInstall({ skillIds, target, home, cwd }) {
   return [...new Set(out)];
 }
 
+// The opt-outs a team disarmed and the developer tier live as marker files under .rsc/,
+// which is machine-local and therefore lost on every clone: a team that disarmed the
+// gitmoji guard found it armed again on the next checkout, with nobody having decided
+// that. They are decisions, so they belong in the committed declaration.
+function localDecisions(cwd) {
+  const dir = join(cwd, '.rsc');
+  let optOuts = [];
+  try {
+    optOuts = readdirSync(dir).filter((f) => f.startsWith('.no-')).map((f) => f.slice(4)).sort();
+  } catch { /* no .rsc yet */ }
+  let tier = null;
+  try { tier = JSON.parse(readFileSync(join(dir, 'developer.json'), 'utf8')).tier ?? null; } catch { /* unset */ }
+  return { optOuts, tier };
+}
+
+// Record the decision, merging so a second assistant never erases the first: installing
+// into codex on a machine that already had claude is adding, not replacing. Union, sorted
+// where order carries no meaning, so the file stays diffable and a merge conflict stays
+// readable.
+export function recordInManifest({ cwd, target, skillIds, catalogVersion = CLI_VERSION }) {
+  const prev = readManifest(cwd) || { targets: [], skills: [], ownSkills: [], optOuts: [] };
+  const { optOuts, tier } = localDecisions(cwd);
+  const union = (a, b) => [...new Set([...(a || []), ...(b || [])])].sort();
+  return writeManifest(cwd, {
+    version: 1,
+    targets: union(prev.targets, [target]),
+    skills: union(prev.skills, skillIds),
+    ownSkills: prev.ownSkills || [],
+    catalogVersion,
+    tier: tier ?? prev.tier ?? null,
+    optOuts: optOuts.length ? optOuts : (prev.optOuts || []),
+  });
+}
+
 export async function applyInstall({ skillIds, target, home, cwd = process.cwd(), operation = 'install', dryRun = false }) {
   const paths = targetPaths(target, home, cwd);
   const plan = planInstall({ skillIds, target, home, cwd });
@@ -120,6 +155,7 @@ export async function applyInstall({ skillIds, target, home, cwd = process.cwd()
   writeState(paths.stateFile, state);
   mkdirSync(dirname(versionFile(cwd)), { recursive: true });
   writeFileSync(versionFile(cwd), CLI_VERSION + '\n');
+  recordInManifest({ cwd, target, skillIds });
   ignoreLocalState(cwd);
   return { ...state, backup };
 }

--- a/scripts/lib/divergence.js
+++ b/scripts/lib/divergence.js
@@ -1,0 +1,33 @@
+import { readManifest } from './manifest-file.js';
+import { readState } from './state.js';
+import { targetPaths } from '../../targets/index.js';
+import { existsSync } from 'node:fs';
+
+// What the team declared versus what is on this machine.
+//
+// The everyday case is not cloning — it is a teammate changing the harness and everyone
+// else running `git pull`. The clone is day one; divergence is every other day. Nothing
+// used to notice, so two people drifted apart in silence.
+//
+// Three buckets, because the three need different answers, and collapsing them is how a
+// report starts nagging someone about their own work:
+//   missing    — declared catalog skill, not installed here. Aligning installs it.
+//   ownMissing — declared team skill, absent from the repo. Aligning says so and writes
+//                nothing: it comes from the repo, not from us.
+//   extra      — installed BY RSC, no longer declared.
+// A hand-written skill that nobody declared is in none of them. Not declaring is a valid
+// way to keep things of your own, not an oversight to correct.
+export function divergence({ cwd = process.cwd(), target, home } = {}) {
+  const empty = { missing: [], extra: [], ownMissing: [] };
+  const manifest = readManifest(cwd);
+  if (!manifest) return empty;
+
+  const paths = targetPaths(target, home, cwd);
+  const installed = new Set(Object.keys(readState(paths.stateFile).skills || {}));
+
+  return {
+    missing: (manifest.skills || []).filter((id) => !installed.has(id)),
+    extra: [...installed].filter((id) => !(manifest.skills || []).includes(id)),
+    ownMissing: (manifest.ownSkills || []).filter((name) => !existsSync(paths.skillDir(name))),
+  };
+}

--- a/scripts/lib/manifest-file.js
+++ b/scripts/lib/manifest-file.js
@@ -1,0 +1,53 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// `.rsc.json` — the team's decision about this project's harness, committed.
+//
+// It exists because nothing else could travel. The per-target state lives inside the
+// assistant's own directory, which is machine wiring; `syncInstalled()` reads it, so a
+// clone finds zero skills and does nothing. The declaration had to move to the root.
+//
+// It is a DECLARATION, never an inventory: ids and names only, no paths and no file
+// lists. Two reasons. Paths differ by platform (some machines symlink, others copy), so
+// committing them reproduces in the manifest the very conflict this removes from the
+// skill directories. And a committed file gets merge conflicts by nature — one entry per
+// line, stable key order, so resolving one means reading it, not understanding a format.
+export const MANIFEST = '.rsc.json';
+export const manifestPath = (cwd = process.cwd()) => join(cwd, MANIFEST);
+
+const KEYS = ['version', 'targets', 'skills', 'ownSkills', 'catalogVersion', 'tier', 'optOuts'];
+
+export function readManifest(cwd = process.cwd()) {
+  const file = manifestPath(cwd);
+  if (!existsSync(file)) return null;
+  let raw;
+  // An unreadable manifest is NOT the same as an absent one. Absent means "not adopted
+  // yet" and is normal; corrupt means the file that governs this project cannot be
+  // trusted, and silently treating it as absent would then overwrite it on the next
+  // install. Say it and stop.
+  try { raw = JSON.parse(readFileSync(file, 'utf8')); } catch {
+    throw new Error(`${MANIFEST} exists but is not readable JSON — fix or delete it; rsc will not overwrite it`);
+  }
+  return {
+    version: raw.version ?? 1,
+    targets: raw.targets || [],
+    skills: raw.skills || [],
+    ownSkills: raw.ownSkills || [],
+    catalogVersion: raw.catalogVersion ?? null,
+    tier: raw.tier ?? null,
+    optOuts: raw.optOuts || [],
+  };
+}
+
+// Stable output: fixed key order, arrays one entry per line, order as given. Rewriting an
+// unchanged manifest must produce identical bytes, or every install shows up as a diff.
+export function writeManifest(cwd, manifest) {
+  const out = {};
+  for (const k of KEYS) if (manifest[k] !== undefined) out[k] = manifest[k];
+  out.version ??= 1;
+  const ordered = {};
+  for (const k of KEYS) if (out[k] !== undefined) ordered[k] = out[k];
+  const file = manifestPath(cwd);
+  writeFileSync(file, JSON.stringify(ordered, null, 2) + '\n');
+  return file;
+}

--- a/scripts/lib/repair.js
+++ b/scripts/lib/repair.js
@@ -1,0 +1,156 @@
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { targetPaths, installedTargets, detectTarget, unwireHook } from '../../targets/index.js';
+import { readState } from './state.js';
+import { readManifest } from './manifest-file.js';
+import { createBackup } from './backups.js';
+import { countHookEntries } from '../doctor.js';
+import { applyInstall, recordInManifest, managedPathsForInstall } from '../install-apply.js';
+
+// Fixing a harness that came from an earlier version.
+//
+// The other two deliveries fix the future and fix nobody: everyone who built a harness on
+// 0.1 or 1.0 wakes up the day after with exactly what they had, and does not know it. This
+// is the one command for them — no flags, no need to know what is wrong.
+//
+// EVERY finding is born with its class, and the executor only reads that field. It never
+// decides:
+//
+//   restore — put the harness back to what was ALREADY declared. Nobody decides anything,
+//             so it happens on its own, after a recoverable copy.
+//   change  — alter something a person or a team chose. Always asked, one by one.
+//
+// Putting the boundary in the data instead of the executor means it can be tested without
+// running anything, and it cannot drift apart between branches.
+
+const finding = (id, cls, summary, action) => ({ id, class: cls, summary, action });
+
+export function diagnose({ cwd = process.cwd(), target, home = homedir(), invoked = false } = {}) {
+  const paths = targetPaths(target, home, cwd);
+  const state = readState(paths.stateFile);
+  const installed = Object.keys(state.skills || {});
+  const manifest = readManifest(cwd);
+  const out = [];
+
+  // Nothing of ours here at all: say so and touch nothing. Running this in the wrong
+  // folder must be harmless.
+  if (!installed.length && !manifest && !existsSync(join(cwd, '.rsc'))) return out;
+
+  // The 0.1 layout Claude Code never discovered. writeSkill() sweeps it, but only when
+  // that skill is reinstalled — so anyone who never reinstalled still carries it.
+  if (existsSync(join(paths.root, 'rsc'))) {
+    out.push(finding('nested-layout', 'restore',
+      'A .claude/skills/rsc/ directory from the 0.1 layout is still here; no assistant ever read it.',
+      'It gets removed. Nothing that works today lives in it.'));
+  }
+
+  // Repeated wiring. On Windows the needle never matched, so every install ADDED a hook
+  // instead of replacing it: there were real machines running each hook four times.
+  const repeated = duplicatedHooks(paths.hookTarget);
+  if (repeated.length) {
+    out.push(finding('duplicate-hooks', 'restore',
+      `${repeated.join(', ')} wired more than once, so those hooks run several times per event.`,
+      'The extra copies are removed, leaving one of each.'));
+  }
+
+  // A clone: the declaration travelled, the materialised skills did not.
+  const dangling = installed.filter((id) => !existsSync(paths.skillDir(id)))
+    .concat((manifest?.skills || []).filter((id) => !existsSync(paths.skillDir(id))));
+  if (dangling.length) {
+    out.push(finding('dangling-links', 'restore',
+      `${[...new Set(dangling)].join(', ')} are declared but not on disk — what a fresh clone looks like.`,
+      'They get rebuilt from the catalog at the version the manifest pins.'));
+  }
+
+  // Writing the manifest records something already true, which sounds like a restoration.
+  // But it makes a new committable file appear in someone's root, and that surprises —
+  // and surprising people is what started all of this. So: automatic when they typed the
+  // command (they already said yes), asked when we are the ones who noticed.
+  if (!manifest && installed.length) {
+    out.push(finding('no-manifest', invoked ? 'restore' : 'change',
+      'This harness predates .rsc.json, so it cannot be shared by git yet.',
+      'A manifest is written from what is already installed here.'));
+  }
+
+  // Installed somewhere the project does not look like. This is #249: `harness` writes an
+  // AGENTS.md, detection read it as codex, and people ended up wired to an assistant they
+  // never chose. Moving is a change — it is where the harness lives.
+  const others = installedTargets(cwd).filter((t) => t !== target);
+  const looksLike = detectTarget(cwd);
+  if (!others.length && installed.length && looksLike !== target && !manifest) {
+    out.push(finding('wrong-target', 'change',
+      `The harness is installed for ${target}, but this project looks like ${looksLike}.`,
+      `It moves to ${looksLike}, and the old wiring — including the block in the root file — is removed.`),
+    );
+    out[out.length - 1].to = looksLike;
+  }
+  return out;
+}
+
+// Remove the old wiring's skills. The list comes from the target's OWN state, which by
+// construction holds only what rsc installed — so "we never touch what we did not write"
+// is a property of the input here, not a check that could be forgotten or drift.
+//
+// It was a check, once, sitting on a list that mixed state and manifest ids. A mutant that
+// deleted the check killed no test, and chasing that revealed the branch was unreachable
+// anyway. A guard that cannot be seen to fail is worse than no guard (principle 2), so it
+// became structure instead.
+function removeManagedSkills(paths) {
+  for (const id of Object.keys(readState(paths.stateFile).skills || {})) {
+    rmSync(paths.skillDir(id), { recursive: true, force: true });
+  }
+  rmSync(paths.stateFile, { force: true });
+}
+
+function duplicatedHooks(hookTarget) {
+  let settings;
+  try { settings = JSON.parse(readFileSync(hookTarget, 'utf8')); } catch { return []; }
+  const { perEvent } = countHookEntries(settings);
+  const dup = [];
+  for (const [event, ids] of Object.entries(perEvent)) {
+    for (const [id, n] of Object.entries(ids)) if (n > 1) dup.push(`${event}/${id}`);
+  }
+  return dup;
+}
+
+export async function repair({ cwd = process.cwd(), target, home = homedir(), dryRun = false, invoked = false, accept } = {}) {
+  const found = diagnose({ cwd, target, home, invoked });
+  const restores = found.filter((f) => f.class === 'restore');
+  const changes = found.filter((f) => f.class === 'change');
+
+  // Anything the person has to decide is only applied if they actually said yes. With
+  // nobody to ask, it stays pending — and the restorations still get done, because they
+  // never depended on that decision.
+  const okChanges = [];
+  for (const c of changes) if (accept && await accept(c)) okChanges.push(c);
+  const todo = [...restores, ...okChanges];
+  if (!todo.length || dryRun) {
+    return { applied: todo, pending: changes.filter((c) => !okChanges.includes(c)), backup: null };
+  }
+
+  const paths = targetPaths(target, home, cwd);
+  const ids = [...new Set([...Object.keys(readState(paths.stateFile).skills || {}), ...(readManifest(cwd)?.skills || [])])];
+  const backup = createBackup({
+    cwd, operation: 'repair', target,
+    paths: managedPathsForInstall({ skillIds: ids, target, home, cwd }),
+  });
+
+  for (const f of todo) {
+    if (f.id === 'nested-layout') rmSync(join(paths.root, 'rsc'), { recursive: true, force: true });
+    if (f.id === 'duplicate-hooks') { unwireHook(target, paths); await applyInstall({ skillIds: ids, target, home, cwd, operation: 'repair' }); }
+    if (f.id === 'dangling-links') await applyInstall({ skillIds: ids, target, home, cwd, operation: 'repair' });
+    if (f.id === 'no-manifest') recordInManifest({ cwd, target, skillIds: ids });
+    if (f.id === 'wrong-target') {
+      // Install where the project actually points, THEN take the old wiring down — in that
+      // order, so a failure halfway leaves a working harness rather than none. Taking the
+      // block out of the old file gives it back byte-identical: in #249 that file was the
+      // project's hand-written constitution, and it had already been written into once.
+      await applyInstall({ skillIds: ids, target: f.to, home, cwd, operation: 'repair' });
+      unwireHook(target, paths);
+      removeManagedSkills(paths);
+      recordInManifest({ cwd, target: f.to, skillIds: ids, dropTarget: target });
+    }
+  }
+  return { applied: todo, pending: changes.filter((c) => !okChanges.includes(c)), backup };
+}

--- a/scripts/lib/ui.js
+++ b/scripts/lib/ui.js
@@ -29,6 +29,11 @@ function interactive() {
   return Boolean(stdin.isTTY && stdout.isTTY);
 }
 
+// The one criterion for "is a human here to answer". Exported so target resolution
+// asks the same question the TUI already asks — two criteria for one question is how
+// a terminal run and a CI run drift apart.
+export const isInteractive = interactive;
+
 const C = {
   dim: (s) => `\x1b[2m${s}\x1b[22m`,
   bold: (s) => `\x1b[1m${s}\x1b[22m`,

--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import { loadManifest, skillsForProfile } from './lib/manifest.js';
-import { detectTarget, TARGETS } from '../targets/index.js';
+import { detectTarget, resolveTargets, TARGETS } from '../targets/index.js';
 import { detectRepo } from './detect-repo.js';
 import { rank } from './consult.js';
 import { expandRecommends, toOutcomes, hasOutcome } from './lib/recommend.js';
 import { applyInstall, listInstalled, uninstall, syncInstalled, purge } from './install-apply.js';
 import { doctor } from './doctor.js';
-import { say, select, pickFrom, banner, confirm } from './lib/ui.js';
+import { say, select, pickFrom, banner, confirm, isInteractive } from './lib/ui.js';
 import { refreshRegistry, registryStatus } from './lib/registry.js';
 import { audit, writeAuditReport } from './audit.js';
 import { DOMAINS } from './lib/domains.js';
@@ -16,6 +16,15 @@ import { DEFAULT_SKILL_FLOOR, withDefaultSkillFloor } from './lib/default-skill-
 
 const argv = process.argv.slice(2);
 const cmd = argv[0];
+
+const targetLabel = (id) => TARGETS.find((t) => t.id === id)?.label || id;
+
+// Commands that act ON one assistant. Only these stop when two are installed and no
+// flag says which: `purge` sweeps every target by design, and the catalog/consult
+// side barely touches one, so blocking them would be a regression, not a safeguard.
+const NEEDS_TARGET = new Set([
+  'add', 'install', 'list', 'doctor', 'sync', 'uninstall', 'capabilities', 'catalog', 'registry',
+]);
 
 function flag(name) {
   const i = argv.indexOf(`--${name}`);
@@ -157,7 +166,7 @@ function printContextBudget(b) {
   say('════════════════════════════════════════════════\n');
 }
 
-async function wizard() {
+async function wizard(flagTargets) {
   const m = loadManifest();
   await banner(m.counts.skills);
   say('  the skill catalog for your assistant (Claude Code · Codex · Cursor · Gemini · Antigravity)\n');
@@ -190,7 +199,7 @@ async function wizard() {
       continue;
     }
 
-    const targets = await selectAgents();
+    const targets = flagTargets || await selectAgents();
     if (targets === null) continue;           // esc in the assistant picker → back to menu
     say(`\nI'll install ${ids.length} skills for: ${targets.join(', ')}`);
     say('   ' + ids.join(', '));
@@ -210,15 +219,35 @@ async function wizard() {
 }
 
 async function main() {
-  // --target accepts one id or a comma list (e.g. --target claude,codex). No flag → detect.
+  // One resolution for every command, doctor included: `doctor` used to resolve on its
+  // own and could report a different assistant than the one just installed into.
+  // --target accepts one id or a comma list (e.g. --target claude,codex).
   const f = flag('target');
-  const targets = typeof f === 'string'
-    ? f.split(',').map((s) => s.trim()).filter(Boolean)
-    : [detectTarget()];
+  const resolved = resolveTargets({ flagValue: typeof f === 'string' ? f : undefined });
+  let targets = resolved.ids;
+  if (resolved.ambiguous && NEEDS_TARGET.has(cmd)) {
+    // Two installations, no flag: the whole point of this release is that we do NOT pick.
+    if (isInteractive()) {
+      const picked = await pickFrom(
+        'Two assistants are installed here. Which one do you mean?',
+        resolved.ambiguous.map((id) => ({ id, label: `${targetLabel(id)}  (${listInstalled({ target: id }).length} skills)` })),
+      );
+      if (!picked || !picked.length) return void say('Cancelled — nothing was touched.');
+      targets = picked;
+    } else {
+      console.error(
+        `rsc: ${resolved.ambiguous.join(' and ')} are both installed here, so I will not guess.\n` +
+        `     Say which one:  npx @ericrisco/rsc ${cmd} --target ${resolved.ambiguous[0]}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+  }
+  if (!targets.length) targets = [detectTarget()];
   const target = targets[0];
   switch (cmd) {
     case undefined:
-      return wizard();
+      return wizard(f ? targets : null);
     case 'add': {
       // Positional args = skill ids; skip flags and any flag value (the token after a --flag).
       const requested = [];
@@ -582,6 +611,8 @@ async function main() {
     default:
       say(`rsc: unknown command '${cmd}'.`);
       say('Use: npx @ericrisco/rsc | add <id...> | install --profile <p> | consult "<text>" | list | capabilities [--full|gap-log] | audit | registry refresh | doctor | sync | sello <on|off|status|…> | backups | restore <id|latest> | upgrade | uninstall <id> | purge');
+      say('Any command takes --target <claude|codex|cursor|copilot|gemini|…> (comma-separate for several)');
+      say('   → without it, rsc uses the assistant already installed here; if two are, it asks instead of guessing.');
       process.exitCode = 1;
   }
 }

--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -12,6 +12,7 @@ import { audit, writeAuditReport } from './audit.js';
 import { DOMAINS } from './lib/domains.js';
 import { listBackups, restoreBackup } from './lib/backups.js';
 import { runUpgrade } from './lib/upgrade.js';
+import { diagnose, repair } from './lib/repair.js';
 import { DEFAULT_SKILL_FLOOR, withDefaultSkillFloor } from './lib/default-skill-floor.js';
 
 const argv = process.argv.slice(2);
@@ -626,11 +627,32 @@ async function main() {
       const removed = await uninstall({ skillIds: ids, target, dryRun: dry });
       return void say((dry ? 'Would remove:\n' : 'Removed:\n') + (removed.join('\n') || '(nothing)'));
     }
+    case 'repair': {
+      // One command, no flags, for someone who does not know what is wrong. Restorations
+      // happen on their own; anything that changes a decision is asked, one by one.
+      const dry = argv.includes('--dry-run');
+      const yes = argv.includes('--yes');
+      const found = diagnose({ target, invoked: true });
+      if (!found.length) return void say('Nothing to repair — this harness is healthy.');
+      say(`\nFound ${found.length} thing(s):\n`);
+      for (const f of found) say(`  [${f.class === 'restore' ? 'fix' : 'ask'}] ${f.summary}\n      → ${f.action}`);
+      const accept = async (f) => {
+        if (yes) return true;
+        if (!isInteractive()) return false;
+        return confirm(`\nApply: ${f.summary}`);
+      };
+      const r = await repair({ target, dryRun: dry, invoked: true, accept });
+      say('');
+      if (dry) return void say(`Dry run — nothing written. Would apply ${r.applied.length}.`);
+      say(`Repaired ${r.applied.length} thing(s).${r.backup ? ' A copy of the previous state was kept.' : ''}`);
+      for (const p of r.pending) say(`  still pending (your call): ${p.summary}\n      → ${p.action}`);
+      return void say('   ↻ Reload/restart your assistant.');
+    }
     case 'purge':
       return void (await runPurge(argv.includes('--dry-run'), argv.includes('--with-docs')));
     default:
       say(`rsc: unknown command '${cmd}'.`);
-      say('Use: npx @ericrisco/rsc | add <id...> | install --profile <p> | consult "<text>" | list | capabilities [--full|gap-log] | audit | registry refresh | doctor | sync | sello <on|off|status|…> | backups | restore <id|latest> | upgrade | uninstall <id> | purge');
+      say('Use: npx @ericrisco/rsc | add <id...> | install --profile <p> | consult "<text>" | list | capabilities [--full|gap-log] | audit | registry refresh | doctor | sync | sello <on|off|status|…> | backups | restore <id|latest> | upgrade | repair | uninstall <id> | purge');
       say('Any command takes --target <claude|codex|cursor|copilot|gemini|…> (comma-separate for several)');
       say('   → without it, rsc uses the assistant already installed here; if two are, it asks instead of guessing.');
       process.exitCode = 1;

--- a/scripts/rsc.js
+++ b/scripts/rsc.js
@@ -4,7 +4,7 @@ import { detectTarget, resolveTargets, TARGETS } from '../targets/index.js';
 import { detectRepo } from './detect-repo.js';
 import { rank } from './consult.js';
 import { expandRecommends, toOutcomes, hasOutcome } from './lib/recommend.js';
-import { applyInstall, listInstalled, uninstall, syncInstalled, purge } from './install-apply.js';
+import { applyInstall, listInstalled, uninstall, syncInstalled, purge, collisions } from './install-apply.js';
 import { doctor } from './doctor.js';
 import { say, select, pickFrom, banner, confirm, isInteractive } from './lib/ui.js';
 import { refreshRegistry, registryStatus } from './lib/registry.js';
@@ -218,6 +218,24 @@ async function wizard(flagTargets) {
   }
 }
 
+// Installing replaces whatever sits where a skill goes. If that is something the user
+// wrote by hand, it is the one thing an install can destroy — so it is named first and
+// they decide. Silence here is what made someone lose three months of work with a backup
+// they never knew to restore.
+async function guardCollisions(targets, ids) {
+  const hit = [...new Set(targets.flatMap((t) => collisions({ target: t, skillIds: ids })))];
+  if (!hit.length) return true;
+  say(`\n⚠️  These are already here and rsc did not put them — they look like your own work:`);
+  for (const id of hit) say(`     ${id}`);
+  say('   Installing would replace them. A backup is kept, but you would have to know to restore it.');
+  if (!isInteractive()) {
+    console.error('rsc: refusing to overwrite hand-written skills. Rename them, or re-run with --force.');
+    process.exitCode = 1;
+    return false;
+  }
+  return confirm('Replace them anyway?');
+}
+
 async function main() {
   // One resolution for every command, doctor included: `doctor` used to resolve on its
   // own and could report a different assistant than the one just installed into.
@@ -256,6 +274,7 @@ async function main() {
         requested.push(argv[i]);
       }
       const ids = withDefaultSkillFloor(requested);
+      if (!argv.includes('--force') && !(await guardCollisions(targets, ids))) return;
       for (const t of targets) await applyInstall({ skillIds: ids, target: t });
       say(`✅ Installed for ${targets.join(', ')}: ${requested.join(', ')}`);
       return void say('   ↻ Reload/restart your assistant so the new skill activates.');
@@ -265,6 +284,7 @@ async function main() {
       const without = argv.filter((a, i) => argv[i - 1] === '--without');
       let ids = skillsForProfile(loadManifest(), profile);
       ids = withDefaultSkillFloor(ids).filter((id) => !without.includes(id));
+      if (!argv.includes('--force') && !(await guardCollisions(targets, ids))) return;
       for (const t of targets) await applyInstall({ skillIds: ids, target: t });
       say(`✅ Profile '${profile}' installed for ${targets.join(', ')} (${ids.length} skills)`);
       printAgentHandoff();

--- a/skills/suggest/SKILL.md
+++ b/skills/suggest/SKILL.md
@@ -79,7 +79,31 @@ Not covered → one line, skill or agent. Rules: `skill-scout`.
 
 ---
 
-## 3. First contact
+## 3. A harness that is broken fixes itself
+
+You are injected into every session, so you are the only thing that can notice a broken
+harness before its owner does — and its owner usually cannot, because the symptoms name
+nothing they recognise. When any of these is true, act on it **once** in the session:
+
+- the assistant sees no skills in a project that clearly has a harness;
+- `.rsc.json` exists and what it declares is not what is installed;
+- the same hook seems to run several times;
+- the harness is wired for an assistant that is not the one running.
+
+Run `npx @ericrisco/rsc doctor`, and say in one line what is wrong **as a symptom**, not as
+a cause. Then:
+
+- Anything that only puts the harness back to what was already declared — dangling links, a
+  repeated hook, a layout no version uses — say you are fixing it and run
+  `npx @ericrisco/rsc repair`. Restoring is not deciding, and a recoverable copy is kept.
+- Anything that would change a decision — moving to another assistant, adopting a skill a
+  teammate added, disarming a gate — **ask first**. A `git pull` never rewrites someone's
+  machine.
+
+Offer once. A "no" holds for the session; a new session may look again, because the problem
+has not gone away. Never mention it when the harness is healthy.
+
+## 4. First contact
 
 Before handling the first request of a session, check the workspace:
 

--- a/targets/_md-block.js
+++ b/targets/_md-block.js
@@ -9,6 +9,9 @@ import { linkOrCopy } from './index.js';
 // multiple assistants sharing one file never duplicate it.
 const MARK_START = '<!-- rsc-suggest:start -->';
 const MARK_END = '<!-- rsc-suggest:end -->';
+// The exact separator wireHook writes before an appended block, so unwireHook can take
+// back precisely what it gave and leave the rest of the file untouched.
+const SEAM = '\n\n';
 
 export function writeSkill(id, fromDir, toPath) {
   return linkOrCopy(fromDir, toPath);
@@ -21,7 +24,9 @@ export function wireHook(paths, sourceMd) {
   if (doc.includes(MARK_START)) {
     doc = doc.replace(new RegExp(`${MARK_START}[\\s\\S]*?${MARK_END}`), block);
   } else {
-    doc += `\n\n${block}\n`;
+    // Append with a fixed seam, and record nothing else. unwireHook removes exactly this
+    // seam and this block, which is what lets the file come back byte-identical.
+    doc += `${SEAM}${block}\n`;
   }
   mkdirSync(dirname(paths.hookTarget), { recursive: true });
   writeFileSync(paths.hookTarget, doc);
@@ -34,9 +39,17 @@ export function unwireHook(paths) {
   if (!existsSync(paths.hookTarget)) return [];
   const doc = readFileSync(paths.hookTarget, 'utf8');
   if (!doc.includes(MARK_START)) return [];
-  const cleaned = doc
-    .replace(new RegExp(`\\n*${MARK_START}[\\s\\S]*?${MARK_END}\\n*`), '\n')
-    .replace(/\n{3,}/g, '\n\n');
+  // Remove the block and the seam that introduced it — nothing more.
+  //
+  // This used to end with a document-wide `\n{3,}` -> `\n\n` pass, which tidied blank
+  // lines the author had put hundreds of lines away from anything of ours. In #249 that
+  // file was the project's hand-written constitution: it had already received 95 lines it
+  // never asked for, and giving it back reformatted is the second half of the same damage.
+  // A slightly larger gap is cosmetic; rewriting someone's document is not.
+  const cleaned = doc.replace(
+    new RegExp(`${SEAM.replace(/\n/g, '\\n')}?${MARK_START}[\\s\\S]*?${MARK_END}\\n?`),
+    '',
+  );
   writeFileSync(paths.hookTarget, cleaned);
   return [paths.hookTarget];
 }

--- a/targets/claude.js
+++ b/targets/claude.js
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { linkOrCopy } from './index.js';
 
@@ -70,6 +70,15 @@ export function unwireHook(paths) {
 // entry (the old `cat …/suggest/SKILL.md` form, or a previous `.sh`/`.mjs` script
 // form) is dropped before we add the current one — idempotent, migrating legacy and
 // bash-era hooks in place. Other (non-rsc) SessionStart hooks are preserved.
+// Commands name the project through ${CLAUDE_PROJECT_DIR}, never through the absolute
+// path of the folder it happened to be installed in. Baking that path in is what made a
+// harness unshareable: a committed settings.json was broken in every other checkout, and
+// even renaming your own folder broke it. The variable is resolved by the client at run
+// time, so the same bytes work on every machine — which is the precondition for the
+// manifest being worth committing at all.
+const P = '${CLAUDE_PROJECT_DIR}';
+const at = (...seg) => `${P}/${seg.join('/')}`;
+
 export function wireHook(paths) {
   const scriptDest = join(paths.projectRoot, '.rsc', 'session-start.mjs');
   mkdirSync(dirname(scriptDest), { recursive: true });
@@ -79,7 +88,8 @@ export function wireHook(paths) {
   copyFileSync(join(HERE, 'session-start.mjs'), scriptDest);
 
   const suggestMd = `${paths.skillDir('suggest')}/SKILL.md`;
-  const cmd = `node "${scriptDest}" "${suggestMd}" "${paths.projectRoot}"`;
+  const suggestRel = at(relative(paths.projectRoot, paths.skillDir('suggest')).split(sep).join('/'), 'SKILL.md');
+  const cmd = `node "${at('.rsc', 'session-start.mjs')}" "${suggestRel}" "${P}"`;
 
   const file = paths.hookTarget;
   const settings = existsSync(file) ? JSON.parse(readFileSync(file, 'utf8')) : {};
@@ -99,7 +109,7 @@ export function wireHook(paths) {
   // any prior rsc worklog-checkpoint entry (.sh or .mjs) dropped first.
   const wlDest = join(paths.projectRoot, '.rsc', 'worklog-checkpoint.mjs');
   copyFileSync(join(HERE, 'worklog-checkpoint.mjs'), wlDest);
-  const wlCmd = `node "${wlDest}" "${paths.projectRoot}"`;
+  const wlCmd = `node "${at('.rsc', 'worklog-checkpoint.mjs')}" "${P}"`;
   for (const event of ['PreCompact', 'SessionEnd']) {
     settings.hooks[event] ||= [];
     settings.hooks[event] = settings.hooks[event].filter(
@@ -118,7 +128,7 @@ export function wireHook(paths) {
   // sello.mjs is ship-guard's sibling import (hooks are materialized file-by-file,
   // so the deterministic sello core must land next to the guard that loads it).
   copyFileSync(join(HERE, 'sello.mjs'), join(paths.projectRoot, '.rsc', 'sello.mjs'));
-  const sgCmd = `node "${sgDest}" "${paths.projectRoot}"`;
+  const sgCmd = `node "${at('.rsc', 'ship-guard.mjs')}" "${P}"`;
   settings.hooks.PreToolUse ||= [];
   settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
     (e) => !hookWiringOf(e).includes('.rsc/ship-guard.'),
@@ -132,7 +142,7 @@ export function wireHook(paths) {
   // node-run (Windows-safe), idempotent, fail-open, opt-out via .rsc/.no-danger-guard.
   const dgDest = join(paths.projectRoot, '.rsc', 'danger-guard.mjs');
   copyFileSync(join(HERE, 'danger-guard.mjs'), dgDest);
-  const dgCmd = `node "${dgDest}" "${paths.projectRoot}"`;
+  const dgCmd = `node "${at('.rsc', 'danger-guard.mjs')}" "${P}"`;
   settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
     (e) => !hookWiringOf(e).includes('.rsc/danger-guard.'),
   );
@@ -147,7 +157,7 @@ export function wireHook(paths) {
   // .rsc/.no-gitmoji.
   const gmDest = join(paths.projectRoot, '.rsc', 'gitmoji-guard.mjs');
   copyFileSync(join(HERE, 'gitmoji-guard.mjs'), gmDest);
-  const gmCmd = `node "${gmDest}" "${paths.projectRoot}"`;
+  const gmCmd = `node "${at('.rsc', 'gitmoji-guard.mjs')}" "${P}"`;
   settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
     (e) => !hookWiringOf(e).includes('.rsc/gitmoji-guard.'),
   );
@@ -163,7 +173,7 @@ export function wireHook(paths) {
   // (non-rsc) UserPromptSubmit hooks are preserved.
   const fgDest = join(paths.projectRoot, '.rsc', 'userprompt-gate.mjs');
   copyFileSync(join(HERE, 'userprompt-gate.mjs'), fgDest);
-  const fgCmd = `node "${fgDest}" "${paths.projectRoot}"`;
+  const fgCmd = `node "${at('.rsc', 'userprompt-gate.mjs')}" "${P}"`;
   settings.hooks.UserPromptSubmit ||= [];
   settings.hooks.UserPromptSubmit = settings.hooks.UserPromptSubmit.filter(
     (e) => !hookWiringOf(e).includes('.rsc/userprompt-gate.'),

--- a/targets/index.js
+++ b/targets/index.js
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import * as claudeAdapter from './claude.js';
 import * as cursorAdapter from './cursor.js';
 import * as mdAdapter from './_md-block.js';
+import { readManifest } from '../scripts/lib/manifest-file.js';
 
 // Project-local single source of truth. Real skill files live here exactly once;
 // every assistant gets a lightweight pointer (symlink) back to it — no duplication.
@@ -141,6 +142,10 @@ export function resolveTargets({ cwd = process.cwd(), flagValue } = {}) {
     const ids = flagValue.split(',').map((s) => s.trim()).filter(Boolean);
     return { ids, ambiguous: null, source: 'flag' };
   }
+  // The committed manifest is what the team decided, so it outranks what happens to be
+  // on this machine. Two targets here is not ambiguity — it is the team saying "both".
+  const declared = readManifest(cwd)?.targets || [];
+  if (declared.length) return { ids: declared, ambiguous: null, source: 'manifest' };
   const found = installedTargets(cwd);
   if (found.length === 1) return { ids: found, ambiguous: null, source: 'evidence' };
   if (found.length > 1) return { ids: [], ambiguous: found, source: 'evidence' };

--- a/targets/index.js
+++ b/targets/index.js
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, mkdirSync, rmSync, symlinkSync, cpSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, rmSync, symlinkSync, cpSync, readFileSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { homedir } from 'node:os';
 import * as claudeAdapter from './claude.js';
@@ -83,26 +83,68 @@ export const TARGETS = [
   { id: 'aider', label: 'Aider', hint: 'CONVENTIONS.md' },
 ];
 
-// Best-effort default for the wizard's pre-mark. Unique config dirs win; the
-// shared AGENTS.md / GEMINI.md fall through to codex / gemini.
+// Which assistants are actually installed here, read from the state file each one
+// writes. This is evidence: only an install of ours writes it. Everything below
+// (detectTarget) is inference from files a human — or our own `harness` skill —
+// may have written for unrelated reasons. Order follows SPEC so the ambiguity
+// message is deterministic. A missing, empty or unreadable state means "not
+// installed", never an error: a half-written file must not break resolution.
+export function installedTargets(cwd = process.cwd()) {
+  return TARGET_IDS.filter((id) => {
+    try {
+      const state = JSON.parse(readFileSync(targetPaths(id, undefined, cwd).stateFile, 'utf8'));
+      return Object.keys(state.skills || {}).length > 0;
+    } catch { return false; }
+  });
+}
+
+// Inference, used only when there is no evidence. Unique config dirs win.
+//
+// Two rules here are scar tissue from issue #249. Claude Code had NO signal at
+// all — it was merely the final fallthrough — so any repo with a root AGENTS.md
+// resolved to codex even with .claude/ full of skills. And AGENTS.md is the
+// weakest signal on purpose: our own `harness` skill writes one into every repo
+// it equips, so treating it as a strong hint made the harness poison its own
+// detection the moment it ran once.
 export function detectTarget(cwd = process.cwd()) {
-  const dir = (d) => existsSync(join(cwd, d));
-  if (dir('.cursor')) return 'cursor';
-  if (dir('.windsurf')) return 'windsurf';
-  if (dir('.clinerules')) return 'cline';
-  if (dir('.roo')) return 'roo';
-  if (dir('.continue')) return 'continue';
-  if (dir('.junie')) return 'junie';
-  if (dir('.kiro')) return 'kiro';
-  if (dir('.zed')) return 'zed';
-  if (dir('.opencode')) return 'opencode';
-  if (dir('.amp')) return 'amp';
-  if (dir('.jules')) return 'jules';
-  if (dir('.antigravity')) return 'antigravity';
-  if (existsSync(join(cwd, '.github', 'copilot-instructions.md'))) return 'copilot';
-  if (dir('.codex') || dir('AGENTS.md')) return 'codex';
-  if (dir('.gemini') || dir('GEMINI.md')) return 'gemini';
+  const has = (p) => existsSync(join(cwd, p));
+  if (has('.cursor')) return 'cursor';
+  if (has('.windsurf')) return 'windsurf';
+  if (has('.clinerules')) return 'cline';
+  if (has('.roo')) return 'roo';
+  if (has('.continue')) return 'continue';
+  if (has('.junie')) return 'junie';
+  if (has('.kiro')) return 'kiro';
+  if (has('.zed')) return 'zed';
+  if (has('.opencode')) return 'opencode';
+  if (has('.amp')) return 'amp';
+  if (has('.jules')) return 'jules';
+  if (has('.antigravity')) return 'antigravity';
+  if (has(join('.github', 'copilot-instructions.md'))) return 'copilot';
+  if (has('.claude') || has('CLAUDE.md')) return 'claude';
+  if (has('.codex')) return 'codex';
+  if (has('.gemini') || has('GEMINI.md')) return 'gemini';
+  if (has('AGENTS.md')) return 'codex';       // weakest: our own harness writes this
   return 'claude';
+}
+
+// The single point of truth for "which assistant are we acting on". Every command
+// goes through here — including doctor, which used to resolve on its own and so
+// could report a different target than the one just installed into.
+//
+// Ambiguity is a distinct outcome, not a value the caller might mistake for an id:
+// returning a sentinel string would let a forgetful caller pass it to targetPaths()
+// and die with `unknown target`. `ids` empty + `ambiguous` set cannot be used by
+// accident.
+export function resolveTargets({ cwd = process.cwd(), flagValue } = {}) {
+  if (typeof flagValue === 'string' && flagValue.trim()) {
+    const ids = flagValue.split(',').map((s) => s.trim()).filter(Boolean);
+    return { ids, ambiguous: null, source: 'flag' };
+  }
+  const found = installedTargets(cwd);
+  if (found.length === 1) return { ids: found, ambiguous: null, source: 'evidence' };
+  if (found.length > 1) return { ids: [], ambiguous: found, source: 'evidence' };
+  return { ids: [detectTarget(cwd)], ambiguous: null, source: 'heuristic' };
 }
 
 export function targetPaths(target, home = homedir(), cwd = process.cwd()) {

--- a/tests/doctor-hook-scripts.test.js
+++ b/tests/doctor-hook-scripts.test.js
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { doctor } from '../scripts/doctor.js';
+
+function tmp() { return mkdtempSync(join(tmpdir(), 'rsc-doctorhooks-')); }
+
+// A clone brings .claude/settings.json (committed) but not .rsc/ (ignored), so the
+// hook commands point at scripts that are not there. Reporting "wired: true" on that
+// is the report saying all-clear while every session start fails.
+function wiredButScriptless(dir) {
+  mkdirSync(join(dir, '.claude', 'skills'), { recursive: true });
+  writeFileSync(join(dir, '.claude', 'skills', '.rsc-state.json'), JSON.stringify({ skills: {} }));
+  writeFileSync(join(dir, '.claude', 'settings.json'), JSON.stringify({
+    hooks: {
+      SessionStart: [{ hooks: [{ type: 'command', command: `node "${join(dir, '.rsc', 'session-start.mjs')}" "x" "${dir}"` }] }],
+    },
+  }));
+}
+
+test('hookWired is false when a wired script is missing from disk', () => {
+  const d = tmp();
+  wiredButScriptless(d);
+  const r = doctor({ target: 'claude', home: d, cwd: d });
+  assert.equal(r.hookWired, false, 'settings.json alone must not count as wired');
+});
+
+test('the missing scripts produce exactly one actionable finding, not one per file', () => {
+  const d = tmp();
+  wiredButScriptless(d);
+  const r = doctor({ target: 'claude', home: d, cwd: d });
+  const hits = (r.contextBudget?.findings || []).filter((f) => f.id === 'hook-scripts-missing');
+  assert.equal(hits.length, 1);
+  assert.match(hits[0].action, /sync/, 'the finding must carry its own way out');
+});
+
+test('hookWired stays true when the wired scripts are present', () => {
+  const d = tmp();
+  wiredButScriptless(d);
+  mkdirSync(join(d, '.rsc'), { recursive: true });
+  writeFileSync(join(d, '.rsc', 'session-start.mjs'), '// present');
+  const r = doctor({ target: 'claude', home: d, cwd: d });
+  assert.equal(r.hookWired, true);
+});
+
+test('a hookless target is unaffected — it has no scripts to lose', () => {
+  const d = tmp();
+  mkdirSync(join(d, '.codex', 'rsc'), { recursive: true });
+  writeFileSync(join(d, '.codex', 'rsc', '.rsc-state.json'), JSON.stringify({ skills: {} }));
+  writeFileSync(join(d, 'AGENTS.md'), '# x');
+  const r = doctor({ target: 'codex', home: d, cwd: d });
+  assert.equal(r.hookWired, true);
+});

--- a/tests/doctor-hook-scripts.test.js
+++ b/tests/doctor-hook-scripts.test.js
@@ -33,7 +33,7 @@ test('the missing scripts produce exactly one actionable finding, not one per fi
   const r = doctor({ target: 'claude', home: d, cwd: d });
   const hits = (r.contextBudget?.findings || []).filter((f) => f.id === 'hook-scripts-missing');
   assert.equal(hits.length, 1);
-  assert.match(hits[0].action, /sync/, 'the finding must carry its own way out');
+  assert.match(hits[0].action, /repair|sync/, 'the finding must carry its own way out (principle 6)');
 });
 
 test('hookWired stays true when the wired scripts are present', () => {

--- a/tests/doctor-hook-scripts.test.js
+++ b/tests/doctor-hook-scripts.test.js
@@ -53,3 +53,18 @@ test('a hookless target is unaffected — it has no scripts to lose', () => {
   const r = doctor({ target: 'codex', home: d, cwd: d });
   assert.equal(r.hookWired, true);
 });
+
+// The project variable is expanded by the client, not by us. Checking the literal
+// string would report every healthy install as broken — the mirror image of the bug
+// this whole check exists to fix, and worse, because it fires on everyone.
+test('a wired script named through the project variable is found, not reported missing', () => {
+  const d = tmp();
+  mkdirSync(join(d, '.claude', 'skills'), { recursive: true });
+  mkdirSync(join(d, '.rsc'), { recursive: true });
+  writeFileSync(join(d, '.claude', 'skills', '.rsc-state.json'), JSON.stringify({ skills: {} }));
+  writeFileSync(join(d, '.rsc', 'session-start.mjs'), '// present');
+  writeFileSync(join(d, '.claude', 'settings.json'), JSON.stringify({
+    hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'node "${CLAUDE_PROJECT_DIR}/.rsc/session-start.mjs"' }] }] },
+  }));
+  assert.equal(doctor({ target: 'claude', home: d, cwd: d }).hookWired, true);
+});

--- a/tests/manifest-file.test.js
+++ b/tests/manifest-file.test.js
@@ -1,0 +1,114 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readManifest, writeManifest, manifestPath } from '../scripts/lib/manifest-file.js';
+import { resolveTargets, targetPaths } from '../targets/index.js';
+
+function tmp() { return mkdtempSync(join(tmpdir(), 'rsc-manifest-')); }
+function installed(dir, target, skills = ['orient']) {
+  const { stateFile } = targetPaths(target, undefined, dir);
+  mkdirSync(join(stateFile, '..'), { recursive: true });
+  const state = { skills: {} };
+  for (const id of skills) state.skills[id] = { files: [], base: '' };
+  writeFileSync(stateFile, JSON.stringify(state));
+}
+
+test('no manifest → null, never a throw', () => {
+  assert.equal(readManifest(tmp()), null);
+});
+
+test('an unreadable manifest is reported, not silently ignored', () => {
+  const d = tmp();
+  writeFileSync(manifestPath(d), '{{{not json');
+  assert.throws(() => readManifest(d), /\.rsc\.json/);
+});
+
+test('round-trips the team decision, and only the team decision', () => {
+  const d = tmp();
+  writeManifest(d, {
+    targets: ['claude'], skills: ['orient', 'harness'], ownSkills: ['nuestra-skill'],
+    catalogVersion: '1.1.3', tier: 'balanced', optOuts: ['gitmoji'],
+  });
+  const m = readManifest(d);
+  assert.deepEqual(m.targets, ['claude']);
+  assert.deepEqual(m.skills, ['orient', 'harness']);
+  assert.deepEqual(m.ownSkills, ['nuestra-skill']);
+  assert.equal(m.catalogVersion, '1.1.3');
+  assert.equal(m.tier, 'balanced');
+  assert.deepEqual(m.optOuts, ['gitmoji']);
+});
+
+// A merge conflict in a committed file must be resolvable by reading it. One entry
+// per line and stable key order is what makes that true — a re-serialisation that
+// reorders keys turns every concurrent edit into an unreadable diff.
+test('serialisation is stable and one entry per line', () => {
+  const d = tmp();
+  const m = { targets: ['claude'], skills: ['b', 'a'], ownSkills: [], catalogVersion: '1', tier: 'balanced', optOuts: [] };
+  writeManifest(d, m);
+  const first = readFileSync(manifestPath(d), 'utf8');
+  writeManifest(d, readManifest(d));
+  assert.equal(readFileSync(manifestPath(d), 'utf8'), first, 'rewriting an unchanged manifest must not change bytes');
+  assert.match(first, /"skills": \[\n\s+"b",\n\s+"a"\n\s+\]/, 'lists go one per line, order preserved');
+});
+
+// --- resolution order: flag > manifest > evidence > heuristic ----------------
+
+test('the manifest beats on-disk evidence', () => {
+  const d = tmp();
+  installed(d, 'codex');
+  writeManifest(d, { targets: ['claude'], skills: [], ownSkills: [], catalogVersion: '1', tier: 'balanced', optOuts: [] });
+  const r = resolveTargets({ cwd: d });
+  assert.deepEqual(r.ids, ['claude']);
+  assert.equal(r.source, 'manifest');
+});
+
+test('the flag still beats the manifest', () => {
+  const d = tmp();
+  writeManifest(d, { targets: ['claude'], skills: [], ownSkills: [], catalogVersion: '1', tier: 'balanced', optOuts: [] });
+  assert.deepEqual(resolveTargets({ cwd: d, flagValue: 'codex' }).ids, ['codex']);
+});
+
+test('a manifest declaring two targets is not ambiguity — the team chose both', () => {
+  const d = tmp();
+  writeManifest(d, { targets: ['claude', 'codex'], skills: [], ownSkills: [], catalogVersion: '1', tier: 'balanced', optOuts: [] });
+  const r = resolveTargets({ cwd: d });
+  assert.deepEqual(r.ids, ['claude', 'codex']);
+  assert.equal(r.ambiguous, null);
+});
+
+test('no manifest → resolution behaves exactly as before', () => {
+  const d = tmp();
+  installed(d, 'codex');
+  assert.equal(resolveTargets({ cwd: d }).source, 'evidence');
+});
+
+// --- written by a real install ---------------------------------------------
+import { applyInstall } from '../scripts/install-apply.js';
+
+test('installing writes the manifest with the team decision', async () => {
+  const d = tmp();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  const m = readManifest(d);
+  assert.deepEqual(m.targets, ['claude']);
+  assert.ok(m.skills.includes('orient'));
+  assert.ok(m.catalogVersion, 'the version lock is what makes a clone reproducible');
+});
+
+test('installing into a second assistant merges, never replaces', async () => {
+  const d = tmp();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  await applyInstall({ skillIds: ['bro'], target: 'codex', home: d, cwd: d });
+  const m = readManifest(d);
+  assert.deepEqual(m.targets.sort(), ['claude', 'codex']);
+  assert.ok(m.skills.includes('orient') && m.skills.includes('bro'));
+});
+
+test('re-installing the same thing leaves the manifest byte-identical', async () => {
+  const d = tmp();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  const before = readFileSync(manifestPath(d), 'utf8');
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  assert.equal(readFileSync(manifestPath(d), 'utf8'), before);
+});

--- a/tests/manifest-sharing.test.js
+++ b/tests/manifest-sharing.test.js
@@ -1,0 +1,122 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { applyInstall, collisions, ignoreLocalState } from '../scripts/install-apply.js';
+import { divergence } from '../scripts/lib/divergence.js';
+import { writeManifest } from '../scripts/lib/manifest-file.js';
+
+function repo() {
+  const d = mkdtempSync(join(tmpdir(), 'rsc-share-'));
+  execFileSync('git', ['init', '-q'], { cwd: d });
+  return d;
+}
+// Ask git, never reason about the pattern: `.rsc/` does not match `.rsc.json` today,
+// but a user's own `.rsc*` would, and a rule we merely believe is not a rule.
+function ignored(d, path) {
+  try { execFileSync('git', ['check-ignore', '-q', path], { cwd: d }); return true; }
+  catch { return false; }
+}
+
+test('the manifest is never excluded from git', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  ignoreLocalState(d);
+  assert.equal(ignored(d, '.rsc.json'), false);
+  assert.equal(ignored(d, '.rsc/'), true, 'machine state still stays out');
+});
+
+test('a hand-written skill in the shared directory keeps its place in git', async () => {
+  const d = repo();
+  mkdirSync(join(d, '.claude', 'skills', 'mi-skill'), { recursive: true });
+  writeFileSync(join(d, '.claude', 'skills', 'mi-skill', 'SKILL.md'), '# mine');
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  ignoreLocalState(d, 'claude');
+  assert.equal(ignored(d, '.claude/skills/mi-skill/SKILL.md'), false, 'their work must stay versioned');
+  assert.equal(ignored(d, '.claude/skills/orient'), true, 'what rsc manages does not');
+});
+
+test('the ignore file is only ever appended to — never reordered', async () => {
+  const d = repo();
+  writeFileSync(join(d, '.gitignore'), 'node_modules/\n.env\n');
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  ignoreLocalState(d, 'claude');
+  const lines = readFileSync(join(d, '.gitignore'), 'utf8').split('\n');
+  assert.equal(lines[0], 'node_modules/');
+  assert.equal(lines[1], '.env');
+});
+
+// --- collisions -------------------------------------------------------------
+
+test('a hand-written skill sharing a catalog name is named before anything is overwritten', () => {
+  const d = repo();
+  mkdirSync(join(d, '.claude', 'skills', 'orient'), { recursive: true });
+  writeFileSync(join(d, '.claude', 'skills', 'orient', 'SKILL.md'), '# three months of my work');
+  assert.deepEqual(collisions({ cwd: d, target: 'claude', skillIds: ['orient', 'bro'] }), ['orient']);
+});
+
+test('an rsc-managed skill is not a collision — it is ours to replace', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  assert.deepEqual(collisions({ cwd: d, target: 'claude', skillIds: ['orient'] }), []);
+});
+
+// --- divergence -------------------------------------------------------------
+
+test('a skill the teammate added shows as missing', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  writeManifest(d, { targets: ['claude'], skills: ['orient', 'harness'], ownSkills: [], catalogVersion: '1', tier: null, optOuts: [] });
+  const v = divergence({ cwd: d, target: 'claude' });
+  assert.deepEqual(v.missing, ['harness']);
+});
+
+test('a declared own-skill absent from the repo is reported, and never written', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  writeManifest(d, { targets: ['claude'], skills: ['orient'], ownSkills: ['nuestra'], catalogVersion: '1', tier: null, optOuts: [] });
+  const v = divergence({ cwd: d, target: 'claude' });
+  assert.deepEqual(v.ownMissing, ['nuestra']);
+  assert.deepEqual(v.missing, [], 'an own-skill is not something rsc can install');
+});
+
+test('an undeclared hand-written skill is not a divergence at all', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  mkdirSync(join(d, '.claude', 'skills', 'mia'), { recursive: true });
+  writeFileSync(join(d, '.claude', 'skills', 'mia', 'SKILL.md'), '# mine');
+  const v = divergence({ cwd: d, target: 'claude' });
+  assert.ok(!v.missing.includes('mia') && !v.extra.includes('mia') && !v.ownMissing.includes('mia'));
+});
+
+test('no manifest → nothing to diverge from', () => {
+  const d = repo();
+  const v = divergence({ cwd: d, target: 'claude' });
+  assert.deepEqual([v.missing, v.extra, v.ownMissing], [[], [], []]);
+});
+
+// The whole point of the manifest: a clone has no per-target state (it is machine
+// wiring and does not travel), so sync used to find zero skills and do nothing —
+// leaving the person with a repo that declares a harness and has none.
+test('a clone rebuilds from the manifest alone', async () => {
+  const { syncInstalled } = await import('../scripts/install-apply.js');
+  const d = repo();
+  writeManifest(d, {
+    targets: ['claude'], skills: ['orient', 'bro'], ownSkills: [],
+    catalogVersion: '1.1.3', tier: null, optOuts: [],
+  });
+  const r = await syncInstalled({ target: 'claude', home: d, cwd: d });
+  assert.deepEqual(r.synced.sort(), ['bro', 'orient']);
+  assert.ok(readFileSync(join(d, '.claude', 'skills', 'orient', 'SKILL.md'), 'utf8').length > 0);
+});
+
+test('sync still prefers what is installed when there is no manifest', async () => {
+  const { syncInstalled } = await import('../scripts/install-apply.js');
+  const d = repo();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  rmSync(join(d, '.rsc.json'));
+  const r = await syncInstalled({ target: 'claude', home: d, cwd: d });
+  assert.ok(r.synced.includes('orient'));
+});

--- a/tests/md-block-fidelity.test.js
+++ b/tests/md-block-fidelity.test.js
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { wireHook, unwireHook } from '../targets/_md-block.js';
+
+function tmp() { return mkdtempSync(join(tmpdir(), 'rsc-md-')); }
+
+// The file rsc stamps its block into is usually the user's — in issue #249 it was the
+// project's hand-written constitution, 204 lines of it, and it got 95 lines of template.
+// Removing the block must undo exactly that and nothing else. Tidying someone's document
+// while you are in there is the second half of the same damage.
+test('stamping the block and removing it leaves the file byte-identical', () => {
+  const d = tmp();
+  const file = join(d, 'AGENTS.md');
+  const original = '# Constitucion\n\n## Uno\ntexto\n\n\n\n## Dos, separado a proposito\ntexto\n';
+  writeFileSync(file, original);
+  const src = join(d, 'src.md');
+  writeFileSync(src, '---\nname: suggest\n---\nCUERPO\n');
+
+  wireHook({ hookTarget: file }, src);
+  assert.notEqual(readFileSync(file, 'utf8'), original, 'the block must actually land');
+
+  unwireHook({ hookTarget: file });
+  assert.equal(readFileSync(file, 'utf8'), original, 'blank lines far from the block are the author\'s');
+});
+
+test('re-stamping replaces the block instead of duplicating it', () => {
+  const d = tmp();
+  const file = join(d, 'AGENTS.md');
+  writeFileSync(file, '# mio\n');
+  const src = join(d, 'src.md');
+  writeFileSync(src, '---\nname: suggest\n---\nCUERPO\n');
+  wireHook({ hookTarget: file }, src);
+  wireHook({ hookTarget: file }, src);
+  const doc = readFileSync(file, 'utf8');
+  assert.equal(doc.split('rsc-suggest:start').length - 1, 1);
+});
+
+test('removing a block that is not there touches nothing', () => {
+  const d = tmp();
+  const file = join(d, 'AGENTS.md');
+  writeFileSync(file, '# mio\n\n\n\nfin\n');
+  const before = readFileSync(file, 'utf8');
+  unwireHook({ hookTarget: file });
+  assert.equal(readFileSync(file, 'utf8'), before);
+});

--- a/tests/portable-wiring.test.js
+++ b/tests/portable-wiring.test.js
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, renameSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { applyInstall } from '../scripts/install-apply.js';
+
+function tmp() { return mkdtempSync(join(tmpdir(), 'rsc-portable-')); }
+
+// A harness that names the folder it was born in cannot be shared, cannot survive a
+// rename, and cannot be committed — the whole "share it by git" goal dies on this one
+// line. So the check is blunt: the project's own absolute path must appear nowhere.
+test('nothing rsc writes contains this machine absolute path', async () => {
+  const d = tmp();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  const settings = readFileSync(join(d, '.claude', 'settings.json'), 'utf8');
+  assert.ok(!settings.includes(d), `settings.json still names ${d}`);
+});
+
+test('the wiring points at the project through a variable, not a path', async () => {
+  const d = tmp();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  const settings = readFileSync(join(d, '.claude', 'settings.json'), 'utf8');
+  assert.match(settings, /\$\{CLAUDE_PROJECT_DIR\}/, 'commands must resolve the project at run time');
+});
+
+test('renaming the project folder leaves the wiring still correct', async () => {
+  const d = tmp();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  const moved = join(dirname(d), `${d.split('/').pop()}-moved`);
+  renameSync(d, moved);
+  const settings = readFileSync(join(moved, '.claude', 'settings.json'), 'utf8');
+  assert.ok(!settings.includes(d), 'the old location must not survive the move');
+  assert.match(settings, /\$\{CLAUDE_PROJECT_DIR\}/);
+});

--- a/tests/repair.test.js
+++ b/tests/repair.test.js
@@ -1,0 +1,235 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { diagnose, repair } from '../scripts/lib/repair.js';
+import { applyInstall } from '../scripts/install-apply.js';
+import { writeManifest } from '../scripts/lib/manifest-file.js';
+
+function repo() {
+  const d = mkdtempSync(join(tmpdir(), 'rsc-repair-'));
+  execFileSync('git', ['init', '-q'], { cwd: d });
+  return d;
+}
+const files = (d) => execFileSync('find', [d, '-type', 'f'], { encoding: 'utf8' }).split('\n').sort().join('\n');
+
+test('a folder with no rsc in it is left completely alone', async () => {
+  const d = repo();
+  writeFileSync(join(d, 'README.md'), '# nada que ver');
+  const before = files(d);
+  const r = await repair({ cwd: d, target: 'claude', home: d, invoked: true });
+  assert.deepEqual(r.applied, []);
+  assert.equal(files(d), before, 'not one byte');
+});
+
+test('a healthy harness reports nothing and writes nothing', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  assert.deepEqual(diagnose({ cwd: d, target: 'claude', home: d }), []);
+});
+
+// --- restorations go by themselves ------------------------------------------
+
+test('the 0.1 nested layout is swept without reinstalling anything', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  mkdirSync(join(d, '.claude', 'skills', 'rsc', 'orient'), { recursive: true });
+  writeFileSync(join(d, '.claude', 'skills', 'rsc', 'orient', 'SKILL.md'), '# 0.1 leftovers');
+  const found = diagnose({ cwd: d, target: 'claude', home: d });
+  assert.equal(found.find((f) => f.id === 'nested-layout')?.class, 'restore');
+  await repair({ cwd: d, target: 'claude', home: d, invoked: true });
+  assert.equal(existsSync(join(d, '.claude', 'skills', 'rsc')), false);
+});
+
+test('quadrupled hook entries are left at exactly one of each', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  const sf = join(d, '.claude', 'settings.json');
+  const s = JSON.parse(readFileSync(sf, 'utf8'));
+  s.hooks.SessionStart = [...s.hooks.SessionStart, ...s.hooks.SessionStart, ...s.hooks.SessionStart, ...s.hooks.SessionStart];
+  writeFileSync(sf, JSON.stringify(s, null, 2));
+  assert.equal(diagnose({ cwd: d, target: 'claude', home: d }).find((f) => f.id === 'duplicate-hooks')?.class, 'restore');
+  await repair({ cwd: d, target: 'claude', home: d, invoked: true });
+  assert.equal(JSON.parse(readFileSync(sf, 'utf8')).hooks.SessionStart.length, 1);
+});
+
+test('a clone with dangling links is rebuilt from the manifest', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  rmSync(join(d, '.rsc'), { recursive: true, force: true });
+  assert.equal(diagnose({ cwd: d, target: 'claude', home: d }).find((f) => f.id === 'dangling-links')?.class, 'restore');
+  await repair({ cwd: d, target: 'claude', home: d, invoked: true });
+  assert.ok(readFileSync(join(d, '.claude', 'skills', 'orient', 'SKILL.md'), 'utf8').length > 0);
+});
+
+// --- changes are asked, never taken -----------------------------------------
+
+test('a wrong target is a change, so it is never applied on its own', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'codex', home: d, cwd: d });
+  rmSync(join(d, '.rsc.json'));   // a 0.1 install predates the manifest — that is the case
+  writeFileSync(join(d, 'CLAUDE.md'), '# this is a Claude Code project');
+  const found = diagnose({ cwd: d, target: 'codex', home: d });
+  const wrong = found.find((f) => f.id === 'wrong-target');
+  assert.equal(wrong?.class, 'change');
+  const r = await repair({ cwd: d, target: 'codex', home: d, invoked: true });
+  assert.ok(r.pending.some((f) => f.id === 'wrong-target'), 'a change with nobody to ask stays pending');
+});
+
+test('with a change pending, the restorations still get done', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'codex', home: d, cwd: d });
+  rmSync(join(d, '.rsc.json'));
+  writeFileSync(join(d, 'CLAUDE.md'), '# claude');
+  mkdirSync(join(d, '.codex', 'rsc', 'rsc'), { recursive: true });
+  const r = await repair({ cwd: d, target: 'codex', home: d, invoked: true });
+  assert.ok(r.applied.some((f) => f.id === 'nested-layout'), 'blocking these on an unrelated decision wastes them');
+  assert.ok(r.pending.length);
+});
+
+// --- the guarantees ---------------------------------------------------------
+
+test('repairing twice changes nothing the second time', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  mkdirSync(join(d, '.claude', 'skills', 'rsc'), { recursive: true });
+  await repair({ cwd: d, target: 'claude', home: d, invoked: true });
+  const after = files(d);
+  await repair({ cwd: d, target: 'claude', home: d, invoked: true });
+  assert.equal(files(d), after);
+});
+
+test('dry-run writes nothing and still says what it would do', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  mkdirSync(join(d, '.claude', 'skills', 'rsc'), { recursive: true });
+  const before = files(d);
+  const r = await repair({ cwd: d, target: 'claude', home: d, invoked: true, dryRun: true });
+  assert.equal(files(d), before);
+  assert.ok(r.applied.some((f) => f.id === 'nested-layout'));
+});
+
+test('an autonomous repair always leaves a recoverable copy', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  mkdirSync(join(d, '.claude', 'skills', 'rsc'), { recursive: true });
+  const r = await repair({ cwd: d, target: 'claude', home: d, invoked: true });
+  assert.ok(r.backup, 'nothing autonomous happens without a way back');
+});
+
+// The one guarantee that matters most: repair never touches what it did not install.
+test('a hand-written skill and agent survive a full rebuild from scratch', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'claude', home: d, cwd: d });
+  mkdirSync(join(d, '.claude', 'skills', 'mia'), { recursive: true });
+  writeFileSync(join(d, '.claude', 'skills', 'mia', 'SKILL.md'), '# three months');
+  writeFileSync(join(d, '.claude', 'agents', 'mi-agente.md'), '# mine');
+  rmSync(join(d, '.rsc'), { recursive: true, force: true });
+  await repair({ cwd: d, target: 'claude', home: d, invoked: true });
+  assert.equal(readFileSync(join(d, '.claude', 'skills', 'mia', 'SKILL.md'), 'utf8'), '# three months');
+  assert.equal(readFileSync(join(d, '.claude', 'agents', 'mi-agente.md'), 'utf8'), '# mine');
+});
+
+test('a missing manifest is a restoration when the person asked, a change when we noticed', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient'], target: 'claude', home: d, cwd: d });
+  rmSync(join(d, '.rsc.json'));
+  const asked = diagnose({ cwd: d, target: 'claude', home: d, invoked: true });
+  const noticed = diagnose({ cwd: d, target: 'claude', home: d, invoked: false });
+  assert.equal(asked.find((f) => f.id === 'no-manifest')?.class, 'restore');
+  assert.equal(noticed.find((f) => f.id === 'no-manifest')?.class, 'change');
+});
+
+// A manifest declaring codex means the team CHOSE codex. Reading that as a wrong target
+// would be rsc second-guessing a decision that was made on purpose.
+test('a target the manifest declares is never called wrong', async () => {
+  const d = repo();
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'codex', home: d, cwd: d });
+  writeFileSync(join(d, 'CLAUDE.md'), '# looks like claude, but the team said codex');
+  assert.equal(diagnose({ cwd: d, target: 'codex', home: d }).find((f) => f.id === 'wrong-target'), undefined);
+});
+
+// The headline case of #249: wired to an assistant nobody chose, with a block stamped
+// into a file the user wrote by hand. Accepting the move must actually move it — and give
+// that file back exactly as it was, not merely close enough.
+test('accepting the move rewires to the right assistant and gives the file back byte-identical', async () => {
+  const d = repo();
+  const constitution = '# Constitucion\n\n## Uno\ntexto\n\n\n\n## Dos\ntexto\n';
+  writeFileSync(join(d, 'AGENTS.md'), constitution);
+  writeFileSync(join(d, 'CLAUDE.md'), '# claude project');
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'codex', home: d, cwd: d });
+  rmSync(join(d, '.rsc.json'));
+  assert.notEqual(readFileSync(join(d, 'AGENTS.md'), 'utf8'), constitution, 'the block must be in there first');
+
+  const r = await repair({ cwd: d, target: 'codex', home: d, invoked: true, accept: async () => true });
+
+  assert.ok(r.applied.some((f) => f.id === 'wrong-target'));
+  assert.equal(readFileSync(join(d, 'AGENTS.md'), 'utf8'), constitution, 'their constitution comes back untouched');
+  assert.ok(existsSync(join(d, '.claude', 'skills', 'orient')), 'and it now lives where the project points');
+});
+
+test('declining the move leaves everything exactly where it was', async () => {
+  const d = repo();
+  writeFileSync(join(d, 'AGENTS.md'), '# mia\n');
+  writeFileSync(join(d, 'CLAUDE.md'), '# claude');
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'codex', home: d, cwd: d });
+  rmSync(join(d, '.rsc.json'));
+  const before = readFileSync(join(d, 'AGENTS.md'), 'utf8');
+  const r = await repair({ cwd: d, target: 'codex', home: d, invoked: true, accept: async () => false });
+  assert.ok(r.pending.some((f) => f.id === 'wrong-target'));
+  assert.equal(readFileSync(join(d, 'AGENTS.md'), 'utf8'), before);
+  assert.equal(existsSync(join(d, '.claude', 'skills', 'orient')), false);
+});
+
+// Moving away from an assistant must not leave it declared. The manifest unions on
+// purpose — installing into a second assistant is adding, not replacing — but a MOVE is
+// the one case where the old one has to go, or the manifest keeps promising a harness
+// that is no longer there and every clone rebuilds it.
+test('after a move, the abandoned assistant is gone from the manifest', async () => {
+  const d = repo();
+  writeFileSync(join(d, 'AGENTS.md'), '# mia\n');
+  writeFileSync(join(d, 'CLAUDE.md'), '# claude');
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'codex', home: d, cwd: d });
+  rmSync(join(d, '.rsc.json'));
+  await repair({ cwd: d, target: 'codex', home: d, invoked: true, accept: async () => true });
+  const { readManifest } = await import('../scripts/lib/manifest-file.js');
+  assert.deepEqual(readManifest(d).targets, ['claude']);
+});
+
+// Found by a mutant that survived: the "we only touch what we installed" guarantee was in
+// the code but untested on the MOVE path, which is the one that deletes things. A promise
+// no test defends is not a promise.
+test('moving assistants does not take the user hand-written skills with it', async () => {
+  const d = repo();
+  writeFileSync(join(d, 'AGENTS.md'), '# mia\n');
+  writeFileSync(join(d, 'CLAUDE.md'), '# claude');
+  await applyInstall({ skillIds: ['orient', 'suggest'], target: 'codex', home: d, cwd: d });
+  rmSync(join(d, '.rsc.json'));
+  mkdirSync(join(d, '.codex', 'rsc', 'mia'), { recursive: true });
+  writeFileSync(join(d, '.codex', 'rsc', 'mia', 'SKILL.md'), '# three months of my work');
+
+  await repair({ cwd: d, target: 'codex', home: d, invoked: true, accept: async () => true });
+
+  assert.equal(readFileSync(join(d, '.codex', 'rsc', 'mia', 'SKILL.md'), 'utf8'), '# three months of my work');
+});
+
+// The case the previous test could not reach: a hand-written skill whose NAME is one rsc
+// declares. That one IS in the id list the move walks, so only the managed-check keeps it
+// alive. This is the collision from the other direction, and it is where the guarantee
+// actually earns its keep.
+test('a hand-written skill named like a declared one survives the move', async () => {
+  const d = repo();
+  writeFileSync(join(d, 'AGENTS.md'), '# mia\n');
+  writeFileSync(join(d, 'CLAUDE.md'), '# claude');
+  await applyInstall({ skillIds: ['suggest'], target: 'codex', home: d, cwd: d });
+  rmSync(join(d, '.rsc.json'));
+  writeManifest(d, { targets: ['codex'], skills: ['suggest', 'orient'], ownSkills: [], catalogVersion: '1', tier: null, optOuts: [] });
+  mkdirSync(join(d, '.codex', 'rsc', 'orient'), { recursive: true });
+  writeFileSync(join(d, '.codex', 'rsc', 'orient', 'SKILL.md'), '# MINE, not rsc orient');
+
+  await repair({ cwd: d, target: 'codex', home: d, invoked: true, accept: async () => true });
+
+  assert.equal(readFileSync(join(d, '.codex', 'rsc', 'orient', 'SKILL.md'), 'utf8'), '# MINE, not rsc orient');
+});

--- a/tests/target-resolution.test.js
+++ b/tests/target-resolution.test.js
@@ -1,0 +1,149 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectTarget, installedTargets, resolveTargets, targetPaths } from '../targets/index.js';
+
+function tmp() { return mkdtempSync(join(tmpdir(), 'rsc-target-')); }
+
+// Write the state file a real install would leave for `target`, so the fixture is
+// evidence of the same shape the CLI writes — not a hand-rolled approximation.
+function installed(dir, target, skills = ['orient']) {
+  const { stateFile } = targetPaths(target, undefined, dir);
+  mkdirSync(join(stateFile, '..'), { recursive: true });
+  const state = { skills: {} };
+  for (const id of skills) state.skills[id] = { files: [], base: '' };
+  writeFileSync(stateFile, JSON.stringify(state));
+}
+
+// ---------------------------------------------------------------------------
+// installedTargets — the evidence
+// ---------------------------------------------------------------------------
+
+test('installedTargets: nothing installed → []', () => {
+  assert.deepEqual(installedTargets(tmp()), []);
+});
+
+test('installedTargets: finds the one target with a state file', () => {
+  const d = tmp();
+  installed(d, 'claude');
+  assert.deepEqual(installedTargets(d), ['claude']);
+});
+
+test('installedTargets: a state file with zero skills is not an installation', () => {
+  const d = tmp();
+  const { stateFile } = targetPaths('claude', undefined, d);
+  mkdirSync(join(stateFile, '..'), { recursive: true });
+  writeFileSync(stateFile, JSON.stringify({ skills: {} }));
+  assert.deepEqual(installedTargets(d), []);
+});
+
+test('installedTargets: unreadable state counts as absent, never throws', () => {
+  const d = tmp();
+  const { stateFile } = targetPaths('claude', undefined, d);
+  mkdirSync(join(stateFile, '..'), { recursive: true });
+  writeFileSync(stateFile, 'not json{{{');
+  assert.deepEqual(installedTargets(d), []);
+});
+
+test('installedTargets: order is stable regardless of which was written first', () => {
+  const a = tmp(); installed(a, 'codex'); installed(a, 'claude');
+  const b = tmp(); installed(b, 'claude'); installed(b, 'codex');
+  assert.deepEqual(installedTargets(a), installedTargets(b));
+});
+
+// ---------------------------------------------------------------------------
+// detectTarget — the heuristic, with Claude Code finally in it
+// ---------------------------------------------------------------------------
+
+test('detectTarget: .claude/ is an explicit signal, not a fallthrough', () => {
+  const d = tmp();
+  mkdirSync(join(d, '.claude'));
+  assert.equal(detectTarget(d), 'claude');
+});
+
+test('detectTarget: CLAUDE.md is an explicit signal', () => {
+  const d = tmp();
+  writeFileSync(join(d, 'CLAUDE.md'), '# hi');
+  assert.equal(detectTarget(d), 'claude');
+});
+
+// The bug that opened issue #249: `harness` writes AGENTS.md into every repo it
+// equips, so AGENTS.md must never outrank a real Claude Code signal.
+test('detectTarget: AGENTS.md loses to .claude/ — the #249 mine', () => {
+  const d = tmp();
+  writeFileSync(join(d, 'AGENTS.md'), '# hand-written constitution');
+  writeFileSync(join(d, 'CLAUDE.md'), '# pointer');
+  mkdirSync(join(d, '.claude'));
+  assert.equal(detectTarget(d), 'claude');
+});
+
+test('detectTarget: AGENTS.md loses to an explicit .codex/', () => {
+  const d = tmp();
+  writeFileSync(join(d, 'AGENTS.md'), '# x');
+  mkdirSync(join(d, '.codex'));
+  assert.equal(detectTarget(d), 'codex');
+});
+
+test('detectTarget: AGENTS.md alone still means codex — no regression', () => {
+  const d = tmp();
+  writeFileSync(join(d, 'AGENTS.md'), '# x');
+  assert.equal(detectTarget(d), 'codex');
+});
+
+test('detectTarget: empty repo still falls back to claude', () => {
+  assert.equal(detectTarget(tmp()), 'claude');
+});
+
+// ---------------------------------------------------------------------------
+// resolveTargets — the single point of resolution
+// ---------------------------------------------------------------------------
+
+test('resolveTargets: the flag beats evidence and heuristic alike', () => {
+  const d = tmp();
+  installed(d, 'codex');
+  writeFileSync(join(d, 'AGENTS.md'), '# x');
+  const r = resolveTargets({ cwd: d, flagValue: 'claude' });
+  assert.deepEqual(r.ids, ['claude']);
+  assert.equal(r.ambiguous, null);
+  assert.equal(r.source, 'flag');
+});
+
+test('resolveTargets: the flag takes a comma list', () => {
+  const r = resolveTargets({ cwd: tmp(), flagValue: 'claude, codex' });
+  assert.deepEqual(r.ids, ['claude', 'codex']);
+});
+
+test('resolveTargets: one installed target wins over a misleading AGENTS.md', () => {
+  const d = tmp();
+  installed(d, 'claude');
+  writeFileSync(join(d, 'AGENTS.md'), '# hand-written');
+  const r = resolveTargets({ cwd: d });
+  assert.deepEqual(r.ids, ['claude']);
+  assert.equal(r.source, 'evidence');
+});
+
+test('resolveTargets: two installed targets are ambiguous — it must not pick', () => {
+  const d = tmp();
+  installed(d, 'claude');
+  installed(d, 'codex');
+  const r = resolveTargets({ cwd: d });
+  assert.deepEqual(r.ids, []);
+  assert.deepEqual(r.ambiguous, ['claude', 'codex']);
+  assert.equal(r.source, 'evidence');
+});
+
+test('resolveTargets: no evidence falls through to the heuristic', () => {
+  const d = tmp();
+  writeFileSync(join(d, 'AGENTS.md'), '# x');
+  const r = resolveTargets({ cwd: d });
+  assert.deepEqual(r.ids, ['codex']);
+  assert.equal(r.source, 'heuristic');
+});
+
+test('resolveTargets: a healthy single install resolves as it always did', () => {
+  const d = tmp();
+  installed(d, 'codex');
+  assert.deepEqual(resolveTargets({ cwd: d }).ids, ['codex']);
+});


### PR DESCRIPTION
Cierra [#249](https://github.com/ericrisco/rsc-harness/issues/249) y los dos problemas que la incidencia destapaba por debajo.

## Lo que pasaba

`detectTarget()` **no comprobaba `.claude` en ningún punto** — Claude Code era sólo el `return` final por descarte — y sí comprobaba `AGENTS.md`, que devuelve codex. Como la skill `harness` escribe un `AGENTS.md` en la raíz de todo repo que equipa, **el arnés se envenenaba a sí mismo en cuanto se instalaba una vez**. Cualquiera que montara un arnés con una 0.1 tiene la mina puesta.

La teoría del reportero (regresión entre 0.1.40 y 1.1.3) se midió y **es falsa**: la regla es anterior a `v0.1.10` y las dos versiones ejecutan el mismo código. Cambió su repo, no el CLI. No hay nada que revertir; había un diseño que corregir.

## Tres entregas

**1. Resolución por evidencia** (`fix:`, sale como patch). La evidencia ya estaba en disco y se ignoraba: cada target escribe su estado al instalar. Un estado es un hecho; un fichero en la raíz es una conjetura. Con dos asistentes instalados ya no se elige — con terminal se pregunta, sin terminal se falla con la orden dentro y sin escribir nada.

**2. Manifiesto comiteable** (`feat:`). `.rsc.json` en la raíz declara qué asistentes, qué skills, **con qué versión del catálogo**, el tier y las puertas desarmadas. El cableado nombra el proyecto con `${CLAUDE_PROJECT_DIR}` en vez de la ruta absoluta de la carpeta donde se instaló. `sync` reconstruye desde el manifiesto: era el agujero que hacía inútil todo lo demás.

**3. `repair`** (`feat:`). Una orden, sin banderas, para quien no sabe qué le pasa. La frontera vive en el dato, no en el ejecutor: **restaurar no es decidir**.

## Dos defectos que salieron usando el producto, no leyéndolo

- `doctor` reportaba el asistente equivocado sobre una instalación correcta.
- Quitar el bloque de `AGENTS.md` reformateaba el resto del documento. En #249 ese fichero era la constitución del proyecto, escrita a mano: ya había recibido 95 líneas que no pidió, y devolvérselo reformateado es la segunda mitad del mismo daño.

Y uno probando: una skill escrita a mano con nombre de skill del catálogo **se sustituía por un enlace sin una palabra**. Ahora se avisa antes.

## Verificación

**752 tests, 15 mutantes.** El mutante 15 sobrevivió a tres tests y destapó que la guarda que perseguía era **inalcanzable**; se convirtió en estructura en vez de quedarse como puerta que no se puede ver fallar (principio 2, sobre código de este mismo PR).

Tres pruebas de verdad: el repo del reportero reproducido, dos máquinas con un `git clone` real, y un arnés heredado reparado devolviendo su `AGENTS.md` byte a byte.

## Lo que este PR NO hace

- **La partición `settings.json` / `settings.local.json` no está hecha.** La documentación no dice si los `hooks` de ambos se fusionan o el local tapa al compartido, y no se adivinó.
- **El arranque comiteado autocontenido no existe.** El clon se entera por `doctor`, que hay que ejecutar. Es el hueco más grande.
- **Nada probado en Windows.**
- **`ownSkills` no lo escribe ningún comando** — se declara a mano.

## Versionado

La 1 sale como **patch**; la 2 y la 3 piden un run manual de `minor`. Merge = publicación.