### PR TITLE
🐛 fix(spec-gate): pregunta al repositorio del que habla la spec

### DIFF
--- a/scripts/spec-gate.js
+++ b/scripts/spec-gate.js
@@ -99,14 +99,14 @@ function resolveSubject(specPath, claims) {
       || (c.kind === 'pr' && p.hasPr(c.value))) ? p : null;
   };
 
-  // The declaration wins WHEN IT CAN ANSWER. Treating it as absolute looked cleaner and was wrong on
-  // the first real corpus: this workspace's config says `root: .`, which is a repository — just not
-  // the one the specs are about — so an authoritative reading would have kept every verdict wrong
-  // while appearing configured. A declaration that does not recognise a single claim in the file is
-  // not evidence about that file.
+  // The declaration is AUTHORITATIVE. Softening it to "wins when it can answer" fixed a wrong config
+  // and opened something worse: with sibling repos, a claim that is false where the spec belongs and
+  // true next door is handed to the neighbour, confirmed, and printed nowhere. A silent false negative
+  // is worse than the noisy false positive it replaced, and choosing the judge by who agrees with the
+  // claim is not a way to find out whether the claim is true. A wrong `project.root` is a wrong datum;
+  // fix the datum.
   const declared = declaredRoot(specPath);
-  const declaredProbe = declared && isRepo(declared) ? answers(declared) : null;
-  if (declaredProbe) return { probe: declaredProbe, from: 'config' };
+  if (declared && isRepo(declared)) return { probe: gitProbe(declared), from: 'config' };
 
   const here = gitProbe(dirname(specPath));
   const home = here && here.root;
@@ -119,6 +119,8 @@ function resolveSubject(specPath, claims) {
       return { probe: null, note: `several repositories here could answer it (${kids.map((k) => basename(k.dir)).join(', ')}) — say which one in project.root` };
     }
     if (kids.length === 1) return { probe: kids[0].probe, from: 'derived' };
+    // Nobody answered. Fall through to the floor rather than guessing: with no declaration and no
+    // recogniser, the spec's own repository is the only honest default.
   }
   // The floor is the old behaviour: a spec that lives beside its own code must keep the detection it
   // already had, or fixing the split layout would downgrade every caught lie to "could not check".
@@ -179,11 +181,14 @@ function main() {
   // gives the right answer only by coincidence, and the wrong one the moment the gate is pointed at
   // another checkout.
   const subjects = new Map();
+  const announced = new Set();
   const subjectFor = (path, claims) => {
     const dir = dirname(path);
-    // Cached per directory: every spec in a corpus shares a subject, and asking git once per spec
-    // instead of once per corpus is the kind of cost nobody notices until the corpus is big.
-    const key = `${dir}::${claims.map((c) => `${c.kind}:${c.value}`).join('|')}`;
+    // Keyed by directory alone. It used to include the claims, which meant a fresh resolution per
+    // spec — the opposite of what its own comment claimed, and measured at 0.8s → 10.3s over a
+    // 36-spec corpus, because every miss re-walks the children and re-runs git. A corpus shares a
+    // subject; that is the whole premise.
+    const key = dir;
     if (!subjects.has(key)) subjects.set(key, resolveSubject(path, claims));
     return subjects.get(key);
   };
@@ -209,6 +214,12 @@ function main() {
     // is something to act on (P5).
     const claims = statusClaims(statusOf(text));
     const subject = claims.length ? subjectFor(path, claims) : { probe: null };
+    // A subject nobody declared was inferred from the claims themselves, which is a guess. Say it
+    // once per run: silent inference is how a coincidence passes for a verdict.
+    if (subject.from === 'derived' && subject.probe && !announced.has(subject.probe.root)) {
+      announced.add(subject.probe.root);
+      console.log(`      note: subject derived (not declared) — asking ${subject.probe.root}; set project.root to settle it`);
+    }
     const probe = subject.probe;
     anyProbe = anyProbe || Boolean(probe);
     for (const v of checkClaims(claims, probe)) {

--- a/scripts/spec-gate.js
+++ b/scripts/spec-gate.js
@@ -4,8 +4,8 @@
 // Not wired into `prepublishOnly`, and that is deliberate: specs live under 02-DOCS, which is never
 // tracked (principle 9), so a publish gate depending on them would fail in any clean clone. This is
 // the phase's own instrument, and the author's.
-import { readFileSync, readdirSync } from 'node:fs';
-import { join, dirname, basename } from 'node:path';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, dirname, basename, resolve, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { specCompleteness, statusClaims, checkClaims } from './lib/spec-gate.js';
@@ -25,11 +25,19 @@ function defaultTargets() {
 
 // The repository, asked instead of assumed. Returns null when there is nothing to ask — a
 // report-only instrument that crashes where it cannot look is worse than one that says so.
+function spawnSyncGit(cwd, args) {
+  try { return execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim(); } catch { return ''; }
+}
+
 function gitProbe(root) {
   const git = (args) => execFileSync('git', args, { cwd: root, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
   let main;
+  let top;
   try {
     git(['rev-parse', '--git-dir']);
+    // The repository, not the directory we happened to be handed: `children()` looks for sibling
+    // repos under this one, and asking a specs/ subdirectory for its children finds nothing.
+    top = git(['rev-parse', '--show-toplevel']) || root;
     // Prefer the remote tip — a stale local `main` reports merged work as missing. But CI checks out
     // detached with no `origin/main` and no local `main`, and falling through to "no repository to
     // ask" there means the check silently stops checking exactly where it runs unattended. HEAD is
@@ -44,10 +52,114 @@ function gitProbe(root) {
   return {
     hasCommit: (sha) => { try { git(['cat-file', '-e', `${sha}^{commit}`]); return true; } catch { return false; } },
     isAncestor: (sha) => { try { git(['merge-base', '--is-ancestor', sha, main]); return true; } catch { return false; } },
-    // The squash-merge subject carries `(#N)`; --fixed-strings so the parens are not a regex.
-    hasPr: (n) => { try { return git(['log', main, '--grep', `(#${n})`, '--fixed-strings', '-1', '--format=%H']) !== ''; } catch { return false; } },
+    // Two ways a pull request lands, and only one of them was recognised. The squash subject carries
+    // `(#N)`; a plain merge writes `Merge pull request #N from …` and matched nothing, so half the
+    // ways of landing were invisible even when the right repository was being asked.
+    // Two literal searches rather than one regex: `--fixed-strings` is what keeps the parens from
+    // being read as a group, and swapping it for an alternation would put that back.
+    hasPr: (n) => {
+      for (const needle of [`(#${n})`, `Merge pull request #${n} `]) {
+        try {
+          if (git(['log', main, '--grep', needle, '--fixed-strings', '-1', '--format=%H']) !== '') return true;
+        } catch { /* try the other form */ }
+      }
+      return false;
+    },
     hasTag: (v) => { try { return git(['tag', '-l', `v${v}`]) !== ''; } catch { return false; } },
+    root: top,
   };
+}
+
+const commonDir = (dir) => {
+  const r = spawnSyncGit(dir, ['rev-parse', '--path-format=absolute', '--git-common-dir']);
+  return r || dir;
+};
+const sameRepo = (a, b) => commonDir(a) === commonDir(b);
+
+const isRepo = (dir) => { try { return statSync(join(dir, '.git')).isDirectory() || statSync(join(dir, '.git')).isFile(); } catch { return false; } };
+
+/**
+ * Which repository is this spec's `status:` talking about?
+ *
+ * It used to be "the one holding the file", which is right only when docs and code live together.
+ * Where they deliberately do not — this workspace's own CLAUDE.md requires the children's working
+ * docs to live in the container — every true claim came back false, and a gate that flags everything
+ * distinguishes nothing.
+ *
+ * The subject is pinned ONCE per spec and every claim is then judged against it. Letting each claim
+ * find whichever repository happens to confirm it would read better and destroy the function: an
+ * unconfirmed claim would simply find no confirmer, and nothing would ever be reported stale again.
+ */
+function resolveSubject(specPath, claims) {
+  const answers = (root) => {
+    const p = gitProbe(root);
+    if (!p) return null;
+    return claims.some((c) => (c.kind === 'sha' && p.hasCommit(c.value))
+      || (c.kind === 'version' && p.hasTag(c.value))
+      || (c.kind === 'pr' && p.hasPr(c.value))) ? p : null;
+  };
+
+  // The declaration wins WHEN IT CAN ANSWER. Treating it as absolute looked cleaner and was wrong on
+  // the first real corpus: this workspace's config says `root: .`, which is a repository — just not
+  // the one the specs are about — so an authoritative reading would have kept every verdict wrong
+  // while appearing configured. A declaration that does not recognise a single claim in the file is
+  // not evidence about that file.
+  const declared = declaredRoot(specPath);
+  const declaredProbe = declared && isRepo(declared) ? answers(declared) : null;
+  if (declaredProbe) return { probe: declaredProbe, from: 'config' };
+
+  const here = gitProbe(dirname(specPath));
+  const home = here && here.root;
+
+  if (home) {
+    const kids = children(home).map((dir) => ({ dir, probe: answers(dir) })).filter((k) => k.probe);
+    // Two histories cannot both be the subject. Saying so is an answer; picking the first one that
+    // sorted alphabetically is a coin toss wearing a verdict's clothes.
+    if (kids.length > 1) {
+      return { probe: null, note: `several repositories here could answer it (${kids.map((k) => basename(k.dir)).join(', ')}) — say which one in project.root` };
+    }
+    if (kids.length === 1) return { probe: kids[0].probe, from: 'derived' };
+  }
+  // The floor is the old behaviour: a spec that lives beside its own code must keep the detection it
+  // already had, or fixing the split layout would downgrade every caught lie to "could not check".
+  const floor = declared && isRepo(declared) ? gitProbe(declared) : here;
+  return { probe: floor, from: declared ? 'config' : 'spec repo' };
+}
+
+/** `project.root` from the nearest SDD config, resolved against the directory that holds 02-DOCS. */
+function declaredRoot(specPath) {
+  let dir = resolve(dirname(specPath));
+  for (let i = 0; i < 24; i += 1) {
+    const cfg = join(dir, '02-DOCS', 'wiki', 'sdd', 'config.yaml');
+    if (existsSync(cfg)) {
+      try {
+        const block = /^project:[ \t]*\r?\n((?:[ \t]+.*\r?\n?)*)/m.exec(readFileSync(cfg, 'utf8'));
+        const m = block && /^[ \t]+root:[ \t]*(.+?)[ \t]*$/m.exec(block[1]);
+        // Relative to the directory that owns 02-DOCS, not to the config file and not to the cwd:
+        // the only reading where `.` keeps meaning what it means today and the answer does not change
+        // with where the gate was invoked from.
+        if (m) return resolve(dir, m[1].replace(/^['"]|['"]$/g, ''));
+      } catch { /* unreadable config → derive instead */ }
+      return null;
+    }
+    const up = dirname(dir);
+    if (up === dir) break;
+    dir = up;
+  }
+  return null;
+}
+
+/** Git repositories directly inside `root` — far enough to find a child, near enough to still be this project. */
+function children(root) {
+  try {
+    return readdirSync(root, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && !e.name.startsWith('.') && e.name !== 'node_modules')
+      .map((e) => join(root, e.name))
+      .filter(isRepo)
+      // A linked worktree has a `.git` file and the same history, so without this a repo and its own
+      // worktree look like two candidates that both answer — an ambiguity invented out of one repo.
+      .filter((dir, i, all) => all.findIndex((d) => sameRepo(d, dir)) === i);
+  } catch { return []; }
 }
 
 const statusOf = (text) => (/^status:[ \t]*(.*)$/m.exec(text) || [, ''])[1];
@@ -66,11 +178,14 @@ function main() {
   // the project the spec belongs to — checking them against wherever this script happens to live
   // gives the right answer only by coincidence, and the wrong one the moment the gate is pointed at
   // another checkout.
-  const probes = new Map();
-  const probeFor = (path) => {
+  const subjects = new Map();
+  const subjectFor = (path, claims) => {
     const dir = dirname(path);
-    if (!probes.has(dir)) probes.set(dir, gitProbe(dir));
-    return probes.get(dir);
+    // Cached per directory: every spec in a corpus shares a subject, and asking git once per spec
+    // instead of once per corpus is the kind of cost nobody notices until the corpus is big.
+    const key = `${dir}::${claims.map((c) => `${c.kind}:${c.value}`).join('|')}`;
+    if (!subjects.has(key)) subjects.set(key, resolveSubject(path, claims));
+    return subjects.get(key);
   };
   let anyProbe = false;
   for (const path of targets) {
@@ -92,12 +207,18 @@ function main() {
     }
     // A status that still matches the repository prints nothing: the report grows only where there
     // is something to act on (P5).
-    const probe = probeFor(path);
+    const claims = statusClaims(statusOf(text));
+    const subject = claims.length ? subjectFor(path, claims) : { probe: null };
+    const probe = subject.probe;
     anyProbe = anyProbe || Boolean(probe);
-    for (const v of checkClaims(statusClaims(statusOf(text)), probe)) {
+    for (const v of checkClaims(claims, probe)) {
       if (v.verdict === 'holds') continue;
       if (v.verdict === 'stale') drifted += 1;
-      console.log(`      status ${v.verdict.toUpperCase()}: ${v.raw} — ${v.reason}`);
+      // Every non-green line names where it looked, so the reader can go and check by hand (P6).
+      const rel = probe ? relative(process.cwd(), probe.root) : '';
+      const where = probe ? ` [asked ${!rel || rel.startsWith('..') ? probe.root : rel}]` : '';
+      const reason = !probe && subject.note ? subject.note : v.reason;
+      console.log(`      status ${v.verdict.toUpperCase()}: ${v.raw} — ${reason}${where}`);
     }
   }
 

--- a/targets/session-memory-adapter.mjs
+++ b/targets/session-memory-adapter.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { resolve, join, dirname } from 'node:path';
 import { capture, resume } from './session-memory-core.mjs';
 
 const LOCAL_TARGETS = new Set(['claude', 'codex', 'cursor', 'gemini', 'opencode']);
@@ -12,6 +12,20 @@ function projectSettings(cwd) {
     return manifest.memory && typeof manifest.memory === 'object' ? manifest.memory : {};
   } catch {
     return {};
+  }
+}
+
+// The project is the nearest ancestor holding `.rsc.json` — the file that IS the harness's decision.
+// The hook payload's `cwd` is only where the tool call happened to run; inside a container of child
+// repos that is routinely a subdirectory with no harness of its own, and anchoring there scatters
+// one session's journal across children. With no harness anywhere above, the cwd stays the project.
+function nearestHarness(dir) {
+  let current = dir;
+  for (;;) {
+    if (existsSync(join(current, '.rsc.json'))) return current;
+    const parent = dirname(current);
+    if (parent === current) return dir;
+    current = parent;
   }
 }
 
@@ -63,7 +77,7 @@ export function handleLifecycle({ target, event, native = {}, cwd, settings } = 
   try {
     if (!LOCAL_TARGETS.has(target)) throw new Error(`unsupported memory target: ${target}`);
     if (isRemote(target, native)) return { output: {}, capture: null, remote: true, degraded: false };
-    const project = resolve(cwd || native.cwd || process.env.RSC_PROJECT_CWD || process.cwd());
+    const project = nearestHarness(resolve(cwd || native.cwd || process.env.RSC_PROJECT_CWD || process.cwd()));
     if (!existsSync(project)) throw new Error('project directory unavailable');
     const config = settings || projectSettings(project);
     if (config.enabled === false) return { output: {}, capture: null, remote: false, degraded: false };

--- a/tests/memory-adapters.test.js
+++ b/tests/memory-adapters.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -92,4 +92,46 @@ test('the command adapter consumes native stdin and emits only target-native JSO
     const output = JSON.parse(stdout);
     assert.ok(adapters.contextFromNativeOutput(target, output).includes('exact continuation'), target);
   }
+});
+
+// A container harness (the directory holding `.rsc.json`) governs child repos that have no harness of
+// their own. The hook payload's `cwd` is wherever the tool call happened to run — inside a child, often —
+// and that is not the project's identity. Anchoring the journal there scatters memory across children.
+function containerWithChild({ childHarness = false } = {}) {
+  const container = repo();
+  writeFileSync(join(container, '.rsc.json'), JSON.stringify({ version: 1, targets: ['claude'], skills: [] }));
+  const child = join(container, 'child');
+  execFileSync('git', ['init', '-q', child]);
+  git(child, ['config', 'user.name', 'Test']);
+  git(child, ['config', 'user.email', 'test@example.test']);
+  writeFileSync(join(child, 'file.txt'), 'child\n');
+  git(child, ['add', 'file.txt']);
+  git(child, ['commit', '-qm', 'child initial']);
+  if (childHarness) writeFileSync(join(child, '.rsc.json'), JSON.stringify({ version: 1, targets: ['claude'], skills: [] }));
+  return { container, child };
+}
+const anchorAt = (root, id) => join(root, '.rsc', 'memory', 'anchors', `claude--${id}.json`);
+
+test('a tool call inside a child repo anchors memory in the nearest harness, not in the child', () => {
+  const { container, child } = containerWithChild();
+  const id = 'container-governs-child';
+  const result = adapters.handleLifecycle({ target: 'claude', event: 'start', native: { session_id: id, cwd: child } });
+  assert.equal(result.degraded, false, result.error);
+  assert.ok(existsSync(anchorAt(container, id)), 'anchor belongs to the harness that owns the session');
+  assert.ok(!existsSync(join(child, '.rsc')), 'nothing is written into a child that has no harness');
+});
+
+test('a child with its own .rsc.json is its own project — the nearest harness wins', () => {
+  const { container, child } = containerWithChild({ childHarness: true });
+  const id = 'child-has-own-harness';
+  adapters.handleLifecycle({ target: 'claude', event: 'start', native: { session_id: id, cwd: child } });
+  assert.ok(existsSync(anchorAt(child, id)), 'the child harness is the project');
+  assert.ok(!existsSync(anchorAt(container, id)), 'the container is not consulted past a nearer harness');
+});
+
+test('with no .rsc.json anywhere above, the payload cwd is still the project (unchanged behaviour)', () => {
+  const cwd = repo();
+  const id = 'no-harness-anywhere';
+  adapters.handleLifecycle({ target: 'claude', event: 'start', native: { session_id: id, cwd } });
+  assert.ok(existsSync(anchorAt(cwd, id)));
 });

--- a/tests/spec-gate-subject.test.js
+++ b/tests/spec-gate-subject.test.js
@@ -1,0 +1,256 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The status half of `spec-gate` is the only mechanism in the harness that ties a claim about what
+// shipped to something checkable. It asked the repository that HOLDS the spec instead of the one the
+// spec is ABOUT — and in the layout this workspace's own CLAUDE.md mandates (docs in the container,
+// code in the child) that is always the wrong repository. Measured on a freshly published spec: three
+// true claims, three false verdicts.
+//
+// A detector that flags everything put in front of it distinguishes nothing, so these tests are built
+// around one asymmetry: "I could not look" must never come back as "this is a lie", and a lie must
+// still come back as a lie. Real git repositories throughout; a stubbed git would agree with whatever
+// the code believes.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, '..', 'scripts', 'spec-gate.js');
+
+const TMP = [];
+function git(cwd, ...args) {
+  const r = spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8' });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} → ${r.stderr || r.stdout}`);
+  return r.stdout.trim();
+}
+function put(root, rel, body) {
+  mkdirSync(dirname(join(root, rel)), { recursive: true });
+  writeFileSync(join(root, rel), body);
+}
+
+function newRepo(dir) {
+  mkdirSync(dir, { recursive: true });
+  git(dir, 'init', '-b', 'main', '-q');
+  git(dir, 'config', 'user.email', 'eric@example.com');
+  git(dir, 'config', 'user.name', 'Eric');
+  return dir;
+}
+
+// The layout that breaks it: a container repo holding the docs, a child repo holding the code.
+function workspace({ config = null, children = ['child'] } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'rsc-gate-'));
+  TMP.push(root);
+  newRepo(root);
+  put(root, 'README.md', '# container\n');
+  git(root, 'add', '-A');
+  git(root, 'commit', '-qm', 'container');
+
+  const made = {};
+  for (const name of children) {
+    const child = newRepo(join(root, name));
+    put(child, 'code.js', '// code\n');
+    git(child, 'add', '-A');
+    git(child, 'commit', '-qm', 'work');
+    // Landed the way a plain merge lands: the subject says "Merge pull request #7 from …".
+    git(child, 'checkout', '-qb', 'feat/thing');
+    put(child, 'more.js', '// more\n');
+    git(child, 'add', '-A');
+    git(child, 'commit', '-qm', 'feat: thing');
+    git(child, 'checkout', '-q', 'main');
+    git(child, 'merge', '--no-ff', '-q', 'feat/thing', '-m', 'Merge pull request #7 from eric/feat/thing');
+    git(child, 'tag', 'v9.9.9');
+    made[name] = { path: child, head: git(child, 'rev-parse', '--short', 'HEAD') };
+  }
+
+  if (config !== null) {
+    put(root, '02-DOCS/wiki/sdd/config.yaml', `version: 1\nproject:\n  root: ${config}\n`);
+  }
+  return { root, children: made };
+}
+
+function spec(root, { slug = 'thing', status }) {
+  const body = `---
+type: spec
+slug: ${slug}
+status: ${status}
+---
+# Spec — ${slug}
+
+## Problema & por qué
+Duele.
+
+## Coste de no construirlo
+Sigue doliendo.
+
+## La alternativa más barata
+Aguantarse.
+
+## Objetivos
+- Que deje de doler.
+
+## No-objetivos / fuera de alcance
+- Lo de al lado.
+
+## Usuarios & contexto
+El autor.
+
+## Comportamiento
+- Main: pasa algo.
+
+## Criterios de aceptación
+- Given X, When Y, Then Z.
+
+## Puntos a clarificar
+- **pregunta abierta** — ¿cuál es el umbral?
+`;
+  const path = join(root, '02-DOCS', 'wiki', 'sdd', 'specs', `${slug}.md`);
+  put(root, `02-DOCS/wiki/sdd/specs/${slug}.md`, body);
+  return path;
+}
+
+function runGate(path, cwd) {
+  const r = spawnSync('node', [GATE, path], { cwd: cwd || dirname(path), encoding: 'utf8' });
+  return { out: r.stdout + r.stderr, code: r.status };
+}
+
+test.after(() => {
+  for (const d of TMP) { try { rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } }
+});
+
+// ── 1-2. the claim is true, and the gate must say so ────────────────────────────────────────
+
+test('1 · config names the subject: three true claims verify, in the split layout', () => {
+  const ws = workspace({ config: 'child' });
+  const p = spec(ws.root, { status: `publicada en 9.9.9 (PR #7 → \`${ws.children.child.head}\`)` });
+
+  const { out } = runGate(p);
+  assert.match(out, /^PASS/m);
+  assert.doesNotMatch(out, /STALE|UNVERIFIABLE/,
+    `true claims came back as findings:\n${out}`);
+});
+
+test('2 · with no config at all, derivation still finds the child', () => {
+  const ws = workspace({ config: null });
+  const p = spec(ws.root, { status: `publicada en 9.9.9 (PR #7 → \`${ws.children.child.head}\`)` });
+
+  const { out } = runGate(p);
+  assert.doesNotMatch(out, /STALE|UNVERIFIABLE/,
+    `whoever never ran sdd-init must still get an answer:\n${out}`);
+});
+
+// ── 3-4. and a lie must still come back as a lie ────────────────────────────────────────────
+
+test('3 · a claim the subject contradicts is STALE, not "could not check"', () => {
+  const ws = workspace({ config: 'child' });
+  const p = spec(ws.root, { status: 'publicada en 1.1.1 (PR #4242)' });
+
+  const { out } = runGate(p);
+  assert.match(out, /STALE/, `the whole point is catching this:\n${out}`);
+});
+
+test('4 · a spec living beside its own code keeps the detection it already had', () => {
+  const ws = workspace({ config: null, children: [] });
+  const p = spec(ws.root, { status: 'publicada en 3.3.3 (PR #99)' });
+
+  const { out } = runGate(p);
+  assert.match(out, /STALE/,
+    `locating the subject must not downgrade a detected lie to "unverifiable":\n${out}`);
+});
+
+// ── 5-7. what happens when the subject cannot be pinned down ────────────────────────────────
+
+test('5 · nobody can answer → UNVERIFIABLE, and the message says where it looked', () => {
+  const bare = mkdtempSync(join(tmpdir(), 'rsc-gate-nogit-'));
+  TMP.push(bare);
+  const p = spec(bare, { status: 'publicada en 9.9.9 (PR #7)' });
+
+  const { out } = runGate(p);
+  assert.match(out, /UNVERIFIABLE/, `a failure of ours must not be reported as a lie:\n${out}`);
+  assert.doesNotMatch(out, /STALE/);
+});
+
+test('6 · two children could answer → the ambiguity is reported, never guessed', () => {
+  const ws = workspace({ config: null, children: ['one', 'two'] });
+  // Both children carry an identical history, so both can answer #7 and v9.9.9.
+  const p = spec(ws.root, { status: 'publicada en 9.9.9 (PR #7)' });
+
+  const { out } = runGate(p);
+  assert.match(out, /UNVERIFIABLE|AMBIG/i, `two histories cannot both be the subject:\n${out}`);
+  assert.match(out, /one|two/, 'and the candidates must be named so a human can settle it');
+});
+
+test('7 · config pointing at something that is not a repository falls through to derivation', () => {
+  const ws = workspace({ config: 'not-a-repo' });
+  mkdirSync(join(ws.root, 'not-a-repo'), { recursive: true });
+  const p = spec(ws.root, { status: `publicada en 9.9.9 (PR #7 → \`${ws.children.child.head}\`)` });
+
+  const { out } = runGate(p);
+  assert.doesNotMatch(out, /STALE/, `a misconfigured root must not turn true claims false:\n${out}`);
+});
+
+// ── 8-9. both ways a pull request lands ─────────────────────────────────────────────────────
+
+test('8 · a PR landed with a merge commit is recognised', () => {
+  const ws = workspace({ config: 'child' });
+  const p = spec(ws.root, { status: 'publicada en 9.9.9 (PR #7)' });
+
+  const { out } = runGate(p);
+  assert.doesNotMatch(out, /PR #7/, `"Merge pull request #7 from …" is how a plain merge lands:\n${out}`);
+});
+
+test('9 · and one landed with a squash still is', () => {
+  const ws = workspace({ config: 'child' });
+  const child = ws.children.child.path;
+  git(child, 'checkout', '-qb', 'feat/squashed');
+  put(child, 'sq.js', '// sq\n');
+  git(child, 'add', '-A');
+  git(child, 'commit', '-qm', 'feat: sq');
+  git(child, 'checkout', '-q', 'main');
+  git(child, 'merge', '--squash', '-q', 'feat/squashed');
+  git(child, 'commit', '-qm', 'feat: squashed thing (#8)');
+
+  const p = spec(ws.root, { slug: 'squashed', status: 'publicada en 9.9.9 (PR #8)' });
+  const { out } = runGate(p);
+  assert.doesNotMatch(out, /PR #8/, `the squash convention must keep working:\n${out}`);
+});
+
+// ── 10. it reports; it does not block ───────────────────────────────────────────────────────
+
+test('10 · a stale claim does not change the exit code', () => {
+  const clean = workspace({ config: 'child' });
+  const okSpec = spec(clean.root, { slug: 'ok', status: 'draft' });
+  const stale = workspace({ config: 'child' });
+  const badSpec = spec(stale.root, { slug: 'bad', status: 'publicada en 1.1.1 (PR #4242)' });
+
+  const a = runGate(okSpec);
+  const b = runGate(badSpec);
+  assert.match(b.out, /STALE/);
+  assert.equal(b.code, a.code, 'the status check informs; turning it into a blocker is how it gets switched off');
+});
+
+// ── 11-12. the branch the first real corpus taught us about ─────────────────────────────────
+
+test('11 · a config naming a real repo that knows nothing about the claims falls through', () => {
+  // This workspace's own config says `root: .` — a repository, just not the one its specs describe.
+  // Read as authoritative, that keeps every verdict wrong while looking configured.
+  const ws = workspace({ config: '.' });
+  const p = spec(ws.root, { status: `publicada en 9.9.9 (PR #7 → \`${ws.children.child.head}\`)` });
+
+  const { out } = runGate(p);
+  assert.doesNotMatch(out, /STALE|UNVERIFIABLE/,
+    `a declaration that recognises nothing in the file is not evidence about the file:\n${out}`);
+});
+
+test('12 · a repository and its own worktree are one candidate, not an ambiguity', () => {
+  const ws = workspace({ config: null });
+  const child = ws.children.child.path;
+  git(child, 'worktree', 'add', '-q', '-b', 'feat/side', join(ws.root, 'child-side'));
+  const p = spec(ws.root, { status: 'publicada en 9.9.9 (PR #7)' });
+
+  const { out } = runGate(p);
+  assert.doesNotMatch(out, /several repositories/,
+    `a worktree shares the history; counting it twice invents an ambiguity out of one repo:\n${out}`);
+  assert.doesNotMatch(out, /STALE/, out);
+});

--- a/tests/spec-gate-subject.test.js
+++ b/tests/spec-gate-subject.test.js
@@ -115,6 +115,14 @@ function runGate(path, cwd) {
   return { out: r.stdout + r.stderr, code: r.status };
 }
 
+// Most assertions here are of the form "no STALE line appeared", and empty output satisfies every one
+// of them: with the gate throwing before it prints, six of these tests passed. A negative assertion
+// needs an anchor proving the thing ran at all, or it is a test that cannot fail for its own reason.
+function ran(out) {
+  assert.match(out, /\d+\/\d+ pass, \d+ status claim\(s\)/,
+    `the gate did not get as far as reporting:\n${out}`);
+}
+
 test.after(() => {
   for (const d of TMP) { try { rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } }
 });
@@ -136,6 +144,7 @@ test('2 · with no config at all, derivation still finds the child', () => {
   const p = spec(ws.root, { status: `publicada en 9.9.9 (PR #7 → \`${ws.children.child.head}\`)` });
 
   const { out } = runGate(p);
+  ran(out);
   assert.doesNotMatch(out, /STALE|UNVERIFIABLE/,
     `whoever never ran sdd-init must still get an answer:\n${out}`);
 });
@@ -187,6 +196,7 @@ test('7 · config pointing at something that is not a repository falls through t
   const p = spec(ws.root, { status: `publicada en 9.9.9 (PR #7 → \`${ws.children.child.head}\`)` });
 
   const { out } = runGate(p);
+  ran(out);
   assert.doesNotMatch(out, /STALE/, `a misconfigured root must not turn true claims false:\n${out}`);
 });
 
@@ -197,6 +207,7 @@ test('8 · a PR landed with a merge commit is recognised', () => {
   const p = spec(ws.root, { status: 'publicada en 9.9.9 (PR #7)' });
 
   const { out } = runGate(p);
+  ran(out);
   assert.doesNotMatch(out, /PR #7/, `"Merge pull request #7 from …" is how a plain merge lands:\n${out}`);
 });
 
@@ -213,6 +224,7 @@ test('9 · and one landed with a squash still is', () => {
 
   const p = spec(ws.root, { slug: 'squashed', status: 'publicada en 9.9.9 (PR #8)' });
   const { out } = runGate(p);
+  ran(out);
   assert.doesNotMatch(out, /PR #8/, `the squash convention must keep working:\n${out}`);
 });
 
@@ -232,16 +244,11 @@ test('10 · a stale claim does not change the exit code', () => {
 
 // ── 11-12. the branch the first real corpus taught us about ─────────────────────────────────
 
-test('11 · a config naming a real repo that knows nothing about the claims falls through', () => {
-  // This workspace's own config says `root: .` — a repository, just not the one its specs describe.
-  // Read as authoritative, that keeps every verdict wrong while looking configured.
-  const ws = workspace({ config: '.' });
-  const p = spec(ws.root, { status: `publicada en 9.9.9 (PR #7 → \`${ws.children.child.head}\`)` });
-
-  const { out } = runGate(p);
-  assert.doesNotMatch(out, /STALE|UNVERIFIABLE/,
-    `a declaration that recognises nothing in the file is not evidence about the file:\n${out}`);
-});
+// Test 11 used to assert that a config naming a repo which cannot answer falls through to derivation.
+// That reading was written during implementation and is now retired: the adversarial pass showed it
+// lets a sibling repo that coincidentally answers a FALSE claim become the judge, and confirm it in
+// silence. The declaration is authoritative; a wrong `project.root` is a wrong datum, not a case for
+// the mechanism to route around. Tests 13 and 14 hold the replacement.
 
 test('12 · a repository and its own worktree are one candidate, not an ambiguity', () => {
   const ws = workspace({ config: null });
@@ -250,7 +257,112 @@ test('12 · a repository and its own worktree are one candidate, not an ambiguit
   const p = spec(ws.root, { status: 'publicada en 9.9.9 (PR #7)' });
 
   const { out } = runGate(p);
+  ran(out);
   assert.doesNotMatch(out, /several repositories/,
     `a worktree shares the history; counting it twice invents an ambiguity out of one repo:\n${out}`);
   assert.doesNotMatch(out, /STALE/, out);
+});
+
+// ── 13-17. what the adversarial pass found: a coincidence must never pass for a verdict ─────
+
+test('13 · a lie is not laundered by a sibling repo that happens to answer it', () => {
+  // The claim is about `two`, which never landed #7. `one` did. Selecting the subject by "who can
+  // answer" hands the judgement to the repo that confirms it — so the lie came back silent, which is
+  // strictly worse than the false positive it replaced.
+  const ws = workspace({ config: 'two', children: ['one', 'two'] });
+  const two = ws.children.two.path;
+  git(two, 'reset', '-q', '--hard', 'HEAD~1');   // `two` never merged #7
+  git(two, 'tag', '-d', 'v9.9.9');
+
+  const p = spec(ws.root, { status: 'implementada en two (PR #7)' });
+  const { out } = runGate(p);
+  assert.match(out, /STALE/, `the configured subject says no; a sibling saying yes is a coincidence:\n${out}`);
+  assert.match(out, /two/, 'and the verdict must name the repository it actually asked');
+});
+
+test('14 · the declared subject is authoritative even when it cannot answer', () => {
+  const ws = workspace({ config: 'two', children: ['one', 'two'] });
+  const two = ws.children.two.path;
+  git(two, 'reset', '-q', '--hard', 'HEAD~1');
+  git(two, 'tag', '-d', 'v9.9.9');
+
+  const p = spec(ws.root, { status: 'publicada en 9.9.9 (PR #7)' });
+  const { out } = runGate(p);
+  assert.doesNotMatch(out, /several repositories/, `a declaration settles it; there is no ambiguity to report:\n${out}`);
+  assert.match(out, /STALE/);
+});
+
+test('15 · when the subject is derived rather than declared, the run says so', () => {
+  const ws = workspace({ config: null });
+  const p = spec(ws.root, { status: `publicada en 9.9.9 (PR #7 → \`${ws.children.child.head}\`)` });
+
+  const { out } = runGate(p);
+  ran(out);
+  assert.match(out, /derived|derivad/i,
+    `a subject nobody declared is a guess, and a guess has to be visible to be checkable:\n${out}`);
+  assert.match(out, /child/);
+});
+
+test('16 · a status that claims nothing checkable prints no status line at all', () => {
+  const ws = workspace({ config: 'child' });
+  const p = spec(ws.root, { status: 'draft' });
+
+  const { out } = runGate(p);
+  assert.match(out, /^PASS/m, 'the gate must have actually run');
+  assert.doesNotMatch(out, /^\s+status /m, `nothing to act on, nothing to print (P5):\n${out}`);
+});
+
+test('17 · a commit that exists but never reached the trunk is STALE, end to end', () => {
+  const ws = workspace({ config: 'child' });
+  const child = ws.children.child.path;
+  git(child, 'checkout', '-qb', 'feat/side');
+  put(child, 'side.js', '// side\n');
+  git(child, 'add', '-A');
+  git(child, 'commit', '-qm', 'feat: side');
+  const side = git(child, 'rev-parse', '--short', 'HEAD');
+  git(child, 'checkout', '-q', 'main');
+
+  const p = spec(ws.root, { slug: 'side', status: `implementada (\`${side}\`)` });
+  const { out } = runGate(p);
+  assert.match(out, /STALE/, `"committed but never merged" is the drift this exists to catch:\n${out}`);
+  assert.match(out, new RegExp(side));
+});
+
+test('18 · a child that is itself a linked worktree still counts as a candidate', () => {
+  const outside = newRepo(mkdtempSync(join(tmpdir(), 'rsc-gate-out-')));
+  TMP.push(outside);
+  put(outside, 'a.js', '// a\n');
+  git(outside, 'add', '-A');
+  git(outside, 'commit', '-qm', 'work');
+  git(outside, 'checkout', '-qb', 'feat/x');
+  put(outside, 'b.js', '// b\n');
+  git(outside, 'add', '-A');
+  git(outside, 'commit', '-qm', 'feat: x');
+  git(outside, 'checkout', '-q', 'main');
+  git(outside, 'merge', '--no-ff', '-q', 'feat/x', '-m', 'Merge pull request #7 from eric/feat/x');
+
+  const ws = workspace({ config: null, children: [] });
+  git(outside, 'worktree', 'add', '-q', '-b', 'linked-side', join(ws.root, 'linked'), 'main');
+
+  const p = spec(ws.root, { status: 'publicada (PR #7)' });
+  const { out } = runGate(p);
+  ran(out);
+  assert.doesNotMatch(out, /STALE/, `a worktree has a .git FILE; missing that makes real repos invisible:\n${out}`);
+});
+
+test('19 · PR numbers do not match by prefix, and only the trunk counts', () => {
+  const ws = workspace({ config: 'child' });
+  const child = ws.children.child.path;
+  // #7 exists on main. #1 does not — and must not match "…#7…" by being a prefix of it.
+  const p = spec(ws.root, { slug: 'prefix', status: 'publicada (PR #1)' });
+  assert.match(runGate(p).out, /STALE/, 'PR #1 must not be satisfied by a merge of PR #7');
+
+  git(child, 'checkout', '-qb', 'release');
+  put(child, 'r.js', '// r\n');
+  git(child, 'add', '-A');
+  git(child, 'commit', '-qm', 'Merge pull request #55 from eric/thing');
+  git(child, 'checkout', '-q', 'main');
+
+  const q = spec(ws.root, { slug: 'offtrunk', status: 'publicada (PR #55)' });
+  assert.match(runGate(q).out, /STALE/, 'landed on some branch is not landed on the trunk');
 });


### PR DESCRIPTION
## What

La comprobación de `status:` de `spec-gate` interrogaba al repositorio que **contiene** la spec en vez de al que la spec **describe**. Ahora localiza el sujeto (config `project.root` → derivación entre repos hijos → repo de la spec) y juzga todas las afirmaciones contra él. Además reconoce el commit de merge, no solo la convención del squash.

## Why

Implementa `02-DOCS/wiki/sdd/specs/spec-gate-subject-repo.md`.

El comentario del propio código ya decía la intención correcta —*"las afirmaciones de una spec son sobre la historia del proyecto al que pertenece"*— pero la aproximación solo la cumple cuando documentación y código viven juntos. En la disposición que el workspace de desarrollo manda (docs en el contenedor, código en el hijo) eso es siempre el repo equivocado: **53 líneas de estado sobre el corpus real, las 53 falsas**. Un detector de mentiras que marca como mentira todo lo que se le pone delante no distingue nada, y se acaba ignorando — la cicatriz que este repo ya se hizo con `eval-integrity`.

## How

- **El sujeto se localiza una vez por spec** y después todas sus afirmaciones se juzgan contra él. Dejar que cada afirmación busque quien la confirme lee mejor y mata la función: una afirmación falsa no encontraría confirmador y nada volvería a salir nunca como rancio.
- **La declaración es autoritativa.** Ablandarla a "manda cuando sabe responder" fue mi primera corrección y era peor: con repos hermanos, una afirmación falsa donde la spec pertenece y cierta al lado se le entrega al vecino, se confirma y no se imprime nada. Un `project.root` equivocado es un dato equivocado — y el de este workspace queda corregido.
- **Cuando el sujeto se deriva, se dice.** Una inferencia silenciosa es cómo una coincidencia acaba pasando por veredicto.
- `hasPr` reconoce `(#N)` y `Merge pull request #N ` — dos búsquedas literales, no una expresión regular, para no reintroducir lo que `--fixed-strings` evitaba.
- Sigue siendo **solo informe**: una afirmación rancia se imprime y no cambia el código de salida.

## Verification

`02-DOCS/wiki/sdd/verifications/spec-gate-subject-repo-2026-09-06.md`

- 905 tests / 0 fallos; `validate`, `drift:check` y `originality:check` en verde. La mitad de completitud da 36/64, **idéntico a `main`**: no se tocó.
- **Corpus real: 53 líneas falsas → 1 cierta** (el commit de esta propia rama, que aún no está en main). Y una copia con un PR y una versión inventados vuelve a salir STALE contra `rsc-harness`.
- **Panel adversarial: 32 mutantes.** El hallazgo grave no fue de cobertura — mi propio arreglo había introducido un falso negativo silencioso, invisible por construcción. Corregido y cubierto.
- **Seis de doce tests pasaban con el gate petando antes de imprimir**: todas las aserciones eran "no apareció STALE", y una salida vacía las cumple. Con anclas, ese mutante mata los 18.
- Coste sobre el corpus: 10,3 s → 1,3 s (el cache estaba cacheando por afirmación, no por corpus, al contrario de lo que su propio comentario decía).

Lo que el verde no prueba está enumerado en el registro, incluido el caso de un contenedor con varios proyectos.
