### PR TITLE
🐛 fix(hooks): run the ESM main block on Windows (memory journal + gitmoji guard were no-ops)

### DIFF
--- a/targets/gitmoji-guard.mjs
+++ b/targets/gitmoji-guard.mjs
@@ -18,6 +18,7 @@
 // read. Anything it cannot read with certainty (editor commit, -F file, --amend
 // --no-edit, an unparseable command) is ALLOWED: a guard that guesses is a guard that
 // gets turned off. Every deny names its recovery. Opt out with .rsc/.no-gitmoji.
+import { pathToFileURL } from 'node:url';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -221,7 +222,7 @@ export function denyMessage(message) {
 
 // ---- hook entrypoint -----------------------------------------------------------
 // Skipped when imported by a test (P2: the mechanism is testable without a subprocess).
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   const root = process.argv[2] || process.cwd();
   const allow = () => process.exit(0);
 

--- a/targets/session-memory-adapter.mjs
+++ b/targets/session-memory-adapter.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { pathToFileURL } from 'node:url';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve, join, dirname } from 'node:path';
 import { capture, resume } from './session-memory-core.mjs';
@@ -125,7 +126,7 @@ function stdinJson() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   const result = handleLifecycle({ target: process.argv[2], event: process.argv[3], native: stdinJson() });
   process.stdout.write(`${JSON.stringify(result.output)}\n`);
 }


### PR DESCRIPTION
## What

`targets/session-memory-adapter.mjs` and `targets/gitmoji-guard.mjs` decide whether to run their main block with:

```js
if (import.meta.url === `file://${process.argv[1]}`) {
```

On Windows `import.meta.url` is `file:///C:/Users/...` and `process.argv[1]` is `C:\Users\...`, so the comparison never holds. Claude Code invokes the hook, the script exits without printing anything, and nothing happens.

## Effect on Windows users

- **Session memory**: all seven wired lifecycle hooks run but never write `.rsc/memory/`. `rsc memory status` still reports `ready`, so there is no visible symptom until you open a new session and get no continuation.
- **gitmoji-guard**: never denies a commit.

Verified on a real Claude Code session (Windows 11, Node 22.13): after an edit and `/exit`, `.rsc/memory/` stayed empty. Calling `handleLifecycle()` directly with the same payload wrote the record, which isolated the guard line as the cause.

## Fix

Compare against `pathToFileURL(process.argv[1]).href`, which normalises the path on every platform. Two files, four lines.

## Evidence

`node --test` on Windows against `upstream/main`:

| | pass | fail |
|---|---|---|
| before | 813 | 87 |
| after | 818 | 82 |

The five newly passing tests are `gitmoji-guard: DENIES a commit with no gitmoji`, `gitmoji-guard: .rsc/.no-gitmoji disarms it completely`, `gitmoji-guard: every deny names the recovery, the fix and the kill switch`, `gitmoji-guard: one bad message in a chain is enough to deny`, and `the command adapter consumes native stdin and emits only target-native JSON`. No test regresses. The remaining 82 failures are pre-existing Windows issues unrelated to this change (mostly symlink and path-separator assumptions); happy to look at those separately if useful.

The other hooks (`session-start`, `worklog-checkpoint`, `danger-guard`, `ship-guard`, `userprompt-gate`) don't use this guard and already work on Windows. `worktree-reaper.mjs` uses `resolve(new URL(import.meta.url).pathname)`, which has a similar Windows problem (leading slash before the drive letter) but is only reached from `session-start` via a direct import, so it isn't affected in practice.

https://claude.ai/code/session_01TorKPy3ypfdvocTruEDnwK
